### PR TITLE
Improve mvim script's finding of MacVim.app

### DIFF
--- a/src/MacVim/mvim
+++ b/src/MacVim/mvim
@@ -17,7 +17,7 @@ if [ -z "$VIM_APP_DIR" ]
 then
 	myDir="`dirname "$0"`"
 	myAppDir="$myDir/../Applications"
-    suspects=(
+	suspects=(
 		/Applications
 		~/Applications
 		/Applications/vim

--- a/src/MacVim/mvim
+++ b/src/MacVim/mvim
@@ -17,7 +17,19 @@ if [ -z "$VIM_APP_DIR" ]
 then
 	myDir="`dirname "$0"`"
 	myAppDir="$myDir/../Applications"
-	for i in /Applications ~/Applications /Applications/vim ~/Applications/vim $myDir $myDir/vim $myAppDir $myAppDir/vim /Applications/Utilities /Applications/Utilities/vim; do
+    suspects=(
+		/Applications
+		~/Applications
+		/Applications/vim
+		~/Applications/vim
+		$myDir
+		$myDir/vim
+		$myAppDir
+		$myAppDir/vim
+		/Applications/Utilities
+		/Applications/Utilities/vim
+	)
+	for i in ${suspects[@]}; do
 		if [ -x "$i/MacVim.app" ]; then
 			VIM_APP_DIR="$i"
 			break

--- a/src/MacVim/mvim
+++ b/src/MacVim/mvim
@@ -17,7 +17,7 @@ if [ -z "$VIM_APP_DIR" ]
 then
 	myDir="`dirname "$0"`"
 	myAppDir="$myDir/../Applications"
-	for i in ~/Applications ~/Applications/vim $myDir $myDir/vim $myAppDir $myAppDir/vim /Applications /Applications/vim /Applications/Utilities /Applications/Utilities/vim; do
+	for i in /Applications ~/Applications /Applications/vim ~/Applications/vim $myDir $myDir/vim $myAppDir $myAppDir/vim /Applications/Utilities /Applications/Utilities/vim; do
 		if [ -x "$i/MacVim.app" ]; then
 			VIM_APP_DIR="$i"
 			break


### PR DESCRIPTION
For some reason, the mvim script had "/Applications" as the *seventh* item in the list of places to look for MacVim.app.  Given that the overwhelming majority of all users are bound to have MacVim.app in /Applications, put it first in the list.

Also, eliminate a needlessly long line by making an array out of the places to check.