### PR TITLE
Fix the fullscreen display rect for multiple monitors on Yosemite

### DIFF
--- a/src/MacVim/MMFullScreenWindow.m
+++ b/src/MacVim/MMFullScreenWindow.m
@@ -65,7 +65,7 @@ enum {
     // you can't change the style of an existing window in cocoa. create a new
     // window and move the MMTextView into it.
     // (another way would be to make the existing window large enough that the
-    // title bar is off screen. but that doesn't work with multiple screens).  
+    // title bar is off screen. but that doesn't work with multiple screens).
     self = [super initWithContentRect:[screen frame]
                             styleMask:NSBorderlessWindowMask
                               backing:NSBackingStoreBuffered
@@ -371,6 +371,15 @@ enum {
     [self resizeVimView];
 }
 
+- (CGFloat) viewOffset {
+    CGFloat menuBarHeight = 0;
+    if([self screen] != [[NSScreen screens] objectAtIndex:0]) {
+        // Screens other than the primary screen will not hide their menu bar, adjust the visible view down by the menu height
+        menuBarHeight = [[[NSApplication sharedApplication] mainMenu] menuBarHeight]-1;
+    }
+    return menuBarHeight;
+}
+
 - (void)centerView
 {
     NSRect outer = [self frame], inner = [view frame];
@@ -379,7 +388,7 @@ enum {
     // rendering issues may arise (screen looks blurry, each redraw clears the
     // entire window, etc.).
     NSPoint origin = { floor((outer.size.width - inner.size.width)/2),
-                       floor((outer.size.height - inner.size.height)/2) };
+                       floor((outer.size.height - inner.size.height)/2 - [self viewOffset]/2) };
 
     [view setFrameOrigin:origin];
 }
@@ -478,6 +487,8 @@ enum {
     // size since it compensates for menu and dock.
     int maxRows, maxColumns;
     NSSize size = [[self screen] frame].size;
+    size.height -= [self viewOffset];
+    
     [view constrainRows:&maxRows columns:&maxColumns toSize:size];
 
     // Compute current fu size


### PR DESCRIPTION
When using a second display on Yosemite, the menu bar is not animated out as it is on the primary display, which causes the Mac OS menu bar to cover up the first line or so of MacVim in fullscreen. This fix defines a viewOffset method and adjusts the vim view rect based on whether or not the primary display is being used.