### PR TITLE
Early-out of resize handling if the window has not been presented yet.

### DIFF
--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -993,7 +993,7 @@
 
 - (void)windowDidResize:(id)sender
 {
-    if (!setupDone || fullScreenEnabled) return;
+    if (!setupDone || fullScreenEnabled || !windowPresented) return;
 
     // NOTE: Since we have no control over when the window may resize (Cocoa
     // may resize automatically) we simply set the view to fill the entire


### PR DESCRIPTION
This change address an issue I noticed on OS 10.10.3 when MacVim starts up and tries to restore a saved window position to a location on a secondary monitor.

When that happens, MacVim's attempt to set the window's position before it actually becomes visible will trigger a resize event (because the window moved from one NSScreen to another), even though the actual size of the window frame doesn't change. This resize event occurs too early, before the window's size constraints based on the initial rows/columns setting from Vim have been corrected set up. This causes the window to appear at the proper size briefly and then immediate shrink to a size based on the window's default, small frame.

By ensuring that the window controller does not propagate logic from the resize event until the window has been fully presented, the issue is avoided.

I am fairly certain this is a safe, clean way to accomplish this. Moving around where `setupDone` is set to `YES` was another approach, but given the number of checks against `setupDone` in the controller I thought it might be too risky. It is, however, the first change I've attempted to make in MacVim's source so I could be missing a critical piece of logic.

My testing hasn't revealed any issues so far. I've run MacVim with my current set of RC files, as well as via `mvim -u NONE` and `mvim -u NONE -c 'set columns=X'` and so on (in both cases, with and without nuking the autosaved window size user defaults). Everything appears normal.