### PR TITLE
Fix 'flicker' during window presentation caused by early-out criteria.

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -769,6 +769,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         if (!screen)
             screen = [win screen];
 
+        BOOL willSwitchScreens = screen != [win screen];
         if (cascadeFrom) {
             // Do manual cascading instead of using
             // -[MMWindow cascadeTopLeftFromPoint:] since it is rather
@@ -795,7 +796,14 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
             ASLogNotice(@"Window not on screen, don't constrain position");
         }
 
-        [win setFrameTopLeftPoint:topLeft];
+        // setFrameTopLeftPoint will trigger a resize event if the window is
+        // moved across monitors; at this point such a resize would incorrectly
+        // constrain the window to the default vim dimensions, so a specialized
+        // method is used that will avoid that behavior.
+        if (willSwitchScreens)
+            [windowController moveWindowAcrossScreens:topLeft];
+        else
+            [win setFrameTopLeftPoint:topLeft];
     }
 
     if (1 == [vimControllers count]) {

--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -45,6 +45,7 @@
     NSPoint             userTopLeft;
     NSPoint             defaultTopLeft;
     NSToolbar           *toolbar;
+    BOOL                resizingDueToMove;
 }
 
 - (id)initWithVimController:(MMVimController *)controller;
@@ -55,6 +56,7 @@
 - (void)cleanup;
 - (void)openWindow;
 - (BOOL)presentWindow:(id)unused;
+- (void)moveWindowAcrossScreens:(NSPoint)origin;
 - (void)updateTabsWithData:(NSData *)data;
 - (void)selectTabWithIndex:(int)idx;
 - (void)setTextDimensionsWithRows:(int)rows columns:(int)cols isLive:(BOOL)live


### PR DESCRIPTION
Related discussion can be found on PR #5, which caused this bug as a result of trying to fix a different bug.

The intent here is to avoid the too-early resize event generated from having setFrameTopLeft move a window between screens, but to keep subsequent events that correctly resize the MacVim frame by the time the window animates.