### PR TITLE
Fix the fullscreen problem in Yosemite

### DIFF
--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1150,6 +1150,8 @@
     // Fade out window, remove title bar and maximize, then fade back in.
     // (There is a small delay before window is maximized but usually this is
     // not noticeable on a relatively modern Mac.)
+
+    // Fade out
     [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
         [context setDuration:0.5*duration];
         [[window animator] setAlphaValue:0];
@@ -1157,13 +1159,21 @@
         [window setStyleMask:([window styleMask] | NSFullScreenWindowMask)];
         [[vimView tabBarControl] setStyleNamed:@"Unified"];
         [self updateTablineSeparator];
-        [self maximizeWindow:fullScreenOptions];
 
+        // Stay dark for some time to wait for things to sync, then do the full screen operation
         [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
             [context setDuration:0.5*duration];
-            [[window animator] setAlphaValue:1];
+            [[window animator] setAlphaValue:0];
         } completionHandler:^{
-            // Do nothing
+            [self maximizeWindow:fullScreenOptions];
+            
+            // Fade in
+            [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
+                [context setDuration:0.5*duration];
+                [[window animator] setAlphaValue:1];
+            } completionHandler:^{
+                // Do nothing
+            }];
         }];
     }];
 }


### PR DESCRIPTION
For the current version of MacVim, after entering native fullscreen mode in Yosemite, the window will look strange, here is what it looks like:

![screen shot 2015-05-01 at 1 15 36 pm](https://cloud.githubusercontent.com/assets/320252/7433931/33072822-f004-11e4-8844-bfadb03b9f43.png)

We can see the first line (as well as the cursor) is hidden by a black bar, also there's a grey bar on the right.

I think this is because `[self maximizeWindow:fullScreenOptions]` doesn't get the correct dimension, maybe it needs some time to sync.

So I tried to fix this problem by keeping the screen dark for a short time before fading in, in order to make things sync, then do `[self maximizeWindow:fullScreenOptions]`.

This fixes the problem on my Macbook Pro Retina 13 Late 2013.