### PR TITLE
Fix deprecation warning regarding NSOKButton on 10.10+.

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -1095,7 +1095,12 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 #else
     NSInteger result = [panel runModalForDirectory:dir file:nil types:nil];
 #endif
+
+#if (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_10)
+    if (NSModalResponseOK == result) {
+#else
     if (NSOKButton == result) {
+#endif
         // NOTE: -[NSOpenPanel filenames] is deprecated on 10.7 so use
         // -[NSOpenPanel URLs] instead.  The downside is that we have to check
         // that each URL is really a path first.

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -888,7 +888,11 @@ static BOOL isUnsafeMessage(int msgid);
                 context:(void *)context
 {
     NSString *path = nil;
+#if (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_10)
+    if (code == NSModalResponseOK) {
+#else
     if (code == NSOKButton) {
+#endif
         NSURL *url = [panel URL];
         if ([url isFileURL])
             path = [url path];


### PR DESCRIPTION
I've been fixing some of the deprecation (and other) warnings and static analysis issues in my local fork. Before I continued doing so I wanted to send a PR for one of the simpler ones to make sure I'm handling things the right way.

This commit addresses two warnings regarding the use of NSOKButton, which was deprecated in 10.10 in favor of NSModalResponseOK. The change itself is very simple; I'd like guidance on handling the versioning, however.

In general I've guarded deprecation changes by testing against the OS version the deprecation was introduced in (10.10 in this case) to avoid changing the behavior for an "older" build. This will let somebody build a binary against older deployment targets if desired, but they'll still need the latest SDK (to see the appropriate availability macros).

Is this sufficient or should I also take steps to make sure I check the SDK version somehow before doing the availability check? I don't really see this being done elsewhere, but MacVim.h does have a redefinition of the OS version macros up to 10.7; should I add the ones through 10.10 if I'm going to be using them?
