### PR TITLE
Fix additional deprecation warnings.

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -2076,7 +2076,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
     if (fsEventStream)
         return;
-    if (NULL == FSEventStreamStart)
+    if (NULL == &FSEventStreamStart)
         return; // FSEvent functions are weakly linked
 
     NSString *path = [@"~/.vim" stringByExpandingTildeInPath];
@@ -2098,7 +2098,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 - (void)stopWatchingVimDir
 {
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
-    if (NULL == FSEventStreamStop)
+    if (NULL == &FSEventStreamStop)
         return; // FSEvent functions are weakly linked
 
     if (fsEventStream) {
@@ -2489,7 +2489,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 {
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
     // The TIS symbols are weakly linked.
-    if (NULL != TISCopyCurrentKeyboardInputSource) {
+    if (NULL != &TISCopyCurrentKeyboardInputSource) {
         // We get here when compiled on >=10.5 and running on >=10.5.
 
         id nc = [NSDistributedNotificationCenter defaultCenter];
@@ -2507,7 +2507,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 {
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
     // The TIS symbols are weakly linked.
-    if (NULL != TISCopyCurrentKeyboardInputSource) {
+    if (NULL != &TISCopyCurrentKeyboardInputSource) {
         // We get here when compiled on >=10.5 and running on >=10.5.
 
         id nc = [NSDistributedNotificationCenter defaultCenter];

--- a/src/MacVim/MMTextViewHelper.m
+++ b/src/MacVim/MMTextViewHelper.m
@@ -130,7 +130,7 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
     ASLogDebug(@"%@", event);
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
-    if (NULL == TISCopyCurrentKeyboardInputSource) {
+    if (NULL == &TISCopyCurrentKeyboardInputSource) {
 #endif
 
         // NOTE: Check IM state _before_ key has been interpreted or we'll pick
@@ -787,7 +787,7 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
     // The TIS symbols are weakly linked.
-    if (NULL != TISCopyCurrentKeyboardInputSource) {
+    if (NULL != &TISCopyCurrentKeyboardInputSource) {
         // We get here when compiled on >=10.5 and running on >=10.5.
 
         if (asciiImSource) {
@@ -824,7 +824,7 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
     // The TIS symbols are weakly linked.
-    if (NULL != TISCopyCurrentKeyboardInputSource) {
+    if (NULL != &TISCopyCurrentKeyboardInputSource) {
         // We get here when compiled on >=10.5 and running on >=10.5.
 
         // Enable IM: switch back to input source used when IM was last on
@@ -862,7 +862,7 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
 - (void)checkImState
 {
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
-    if (imControl && NULL != TISCopyCurrentKeyboardInputSource) {
+    if (imControl && NULL != &TISCopyCurrentKeyboardInputSource) {
         // We get here when compiled on >=10.5 and running on >=10.5.
         TISInputSourceRef cur = TISCopyCurrentKeyboardInputSource();
         BOOL state = !KeyboardInputSourcesEqual(asciiImSource, cur);

--- a/src/MacVim/MMVimView.m
+++ b/src/MacVim/MMVimView.m
@@ -199,7 +199,7 @@ enum {
             || !([[self window] styleMask] & NSTexturedBackgroundWindowMask))
         return;
 
-    int sw = [NSScroller scrollerWidth];
+    int sw = [NSScroller scrollerWidthForControlSize:NSRegularControlSize scrollerStyle:NSScrollerStyleLegacy];
 
     // add .5 to the pixel locations to put the lines on a pixel boundary.
     // the top and right edges of the rect will be outside of the bounds rect
@@ -699,11 +699,16 @@ enum {
             continue;
 
         NSRect rect;
+#if (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_7)
+        CGFloat scrollerWidth = [NSScroller scrollerWidthForControlSize:NSRegularControlSize scrollerStyle:NSScrollerStyleLegacy];
+#else
+        CGFloat scrollerWidth = [NSScroller scrollerWidth];
+#endif
         if ([scroller type] == MMScrollerTypeBottom) {
             rect = [textView rectForColumnsInRange:[scroller range]];
-            rect.size.height = [NSScroller scrollerWidth];
+            rect.size.height = scrollerWidth;
             if (leftSbVisible)
-                rect.origin.x += [NSScroller scrollerWidth];
+                rect.origin.x += scrollerWidth;
 
             // HACK!  Make sure the horizontal scrollbar covers the text view
             // all the way to the right, otherwise it looks ugly when the user
@@ -722,7 +727,7 @@ enum {
             if (NSMaxX(rect) > NSMaxX(textViewFrame))
                 rect.size.width -= NSMaxX(rect) - NSMaxX(textViewFrame);
             if (!rightSbVisible)
-                rect.size.width -= [NSScroller scrollerWidth];
+                rect.size.width -= scrollerWidth;
             if (rect.size.width < 0)
                 rect.size.width = 0;
         } else {
@@ -730,7 +735,7 @@ enum {
             // Adjust for the fact that text layout is flipped.
             rect.origin.y = NSMaxY(textViewFrame) - rect.origin.y
                     - rect.size.height;
-            rect.size.width = [NSScroller scrollerWidth];
+            rect.size.width = scrollerWidth;
             if ([scroller type] == MMScrollerTypeRight)
                 rect.origin.x = NSMaxX(textViewFrame);
 
@@ -752,9 +757,9 @@ enum {
             // Vertical scrollers must not cover the resize box in the
             // bottom-right corner of the window.
             if ([[self window] showsResizeIndicator]  // XXX: make this a flag
-                && rect.origin.y < [NSScroller scrollerWidth]) {
-                rect.size.height -= [NSScroller scrollerWidth] - rect.origin.y;
-                rect.origin.y = [NSScroller scrollerWidth];
+                && rect.origin.y < scrollerWidth) {
+                rect.size.height -= scrollerWidth - rect.origin.y;
+                rect.origin.y = scrollerWidth;
             }
 
             // Make sure scrollbar rect is bounded by the text view frame.
@@ -808,16 +813,21 @@ enum {
 - (NSSize)vimViewSizeForTextViewSize:(NSSize)textViewSize
 {
     NSSize size = textViewSize;
+#if (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_7)
+    CGFloat scrollerWidth = [NSScroller scrollerWidthForControlSize:NSRegularControlSize scrollerStyle:NSScrollerStyleLegacy];
+#else
+    CGFloat scrollerWidth = [NSScroller scrollerWidth];
+#endif
 
     if (![[self tabBarControl] isHidden])
         size.height += [[self tabBarControl] frame].size.height;
 
     if ([self bottomScrollbarVisible])
-        size.height += [NSScroller scrollerWidth];
+        size.height += scrollerWidth;
     if ([self leftScrollbarVisible])
-        size.width += [NSScroller scrollerWidth];
+        size.width += scrollerWidth;
     if ([self rightScrollbarVisible])
-        size.width += [NSScroller scrollerWidth];
+        size.width += scrollerWidth;
 
     return size;
 }
@@ -825,20 +835,25 @@ enum {
 - (NSRect)textViewRectForVimViewSize:(NSSize)contentSize
 {
     NSRect rect = { {0, 0}, {contentSize.width, contentSize.height} };
+#if (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_7)
+    CGFloat scrollerWidth = [NSScroller scrollerWidthForControlSize:NSRegularControlSize scrollerStyle:NSScrollerStyleLegacy];
+#else
+    CGFloat scrollerWidth = [NSScroller scrollerWidth];
+#endif
 
     if (![[self tabBarControl] isHidden])
         rect.size.height -= [[self tabBarControl] frame].size.height;
 
     if ([self bottomScrollbarVisible]) {
-        rect.size.height -= [NSScroller scrollerWidth];
-        rect.origin.y += [NSScroller scrollerWidth];
+        rect.size.height -= scrollerWidth;
+        rect.origin.y += scrollerWidth;
     }
     if ([self leftScrollbarVisible]) {
-        rect.size.width -= [NSScroller scrollerWidth];
-        rect.origin.x += [NSScroller scrollerWidth];
+        rect.size.width -= scrollerWidth;
+        rect.origin.x += scrollerWidth;
     }
     if ([self rightScrollbarVisible])
-        rect.size.width -= [NSScroller scrollerWidth];
+        rect.size.width -= scrollerWidth;
 
     return rect;
 }

--- a/src/MacVim/MMVimView.m
+++ b/src/MacVim/MMVimView.m
@@ -199,7 +199,11 @@ enum {
             || !([[self window] styleMask] & NSTexturedBackgroundWindowMask))
         return;
 
+#if (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_7)
     int sw = [NSScroller scrollerWidthForControlSize:NSRegularControlSize scrollerStyle:NSScrollerStyleLegacy];
+#else
+    int sw = [NSScroller scrollerWidth];
+#endif
 
     // add .5 to the pixel locations to put the lines on a pixel boundary.
     // the top and right edges of the rect will be outside of the bounds rect

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -25,6 +25,21 @@
 #ifndef MAC_OS_X_VERSION_10_7
 # define MAC_OS_X_VERSION_10_7 1070
 #endif
+#ifndef MAC_OS_X_VERSION_10_8
+# define MAC_OS_X_VERSION_10_8 1080
+#endif
+#ifndef MAC_OS_X_VERSION_10_9
+# define MAC_OS_X_VERSION_10_9 1090
+#endif
+#ifndef MAC_OS_X_VERSION_10_10
+# define MAC_OS_X_VERSION_10_10 101000
+#endif
+#ifndef MAC_OS_X_VERSION_10_10_2
+# define MAC_OS_X_VERSION_10_10_2 101002
+#endif
+#ifndef MAC_OS_X_VERSION_10_10_3
+# define MAC_OS_X_VERSION_10_10_3 101003
+#endif
 
 
 //


### PR DESCRIPTION
This change address two more classes of warnings found in the Xcode project:

- checks for the weak symbols that may not exist when running on earlier than 10.5 explicitly use the address of the symbol in question
- `[NSScroller scrollerWidth]` was deprecated in 10.7; the modern equivalent is `[NSScroller scrollerWidthForControlSize]`; the method is only invoked once per function now, as well, as a way to handle the availability macro guards more cleanly.