### PR TITLE
Fix for native full screen on secondary monitor.

### DIFF
--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1535,7 +1535,12 @@
     // NOTE: Do not use [NSScreen visibleFrame] when determining the screen
     // size since it compensates for menu and dock.
     int maxRows, maxColumns;
-    NSSize size = [[NSScreen mainScreen] frame].size;
+    NSScreen *screen = [decoratedWindow screen];
+    if (!screen) {
+        ASLogNotice(@"Window not on screen, using main screen");
+        screen = [NSScreen mainScreen];
+    }
+    NSSize size = [screen frame].size;
     [vimView constrainRows:&maxRows columns:&maxColumns toSize:size];
 
     ASLogDebug(@"Window dimensions max: %dx%d  current: %dx%d",


### PR DESCRIPTION
I've long suffered from this MacVim bug when using native full-screen mode on a laptop with a large secondary monitor. The symptom is that when MacVim activates or deactivates, it will frequently shrink to a smaller size, leaving blank space around it. Activating the window and flipping to Mission Control and back is the easiest way to force it to return to the correct size.

The culprit is the use of `[NSScreen mainScreen]` instead of `[decoratedWindow screen]` in `-[MMWindowController maximizeWindow:]`. I don't know if the fallback to the main screen is necessary, but I copied it from `-[MMWindowController zoom:]` to be prudent.