### PR TITLE
Regression of "Early-out of resize handling if the window has not been presented yet…"

### DIFF
--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1013,7 +1013,7 @@
         return;
     }
 
-    if (!setupDone || fullScreenEnabled) return;
+    if (!setupDone || fullScreenEnabled || !windowPresented) return;
 
     // NOTE: Since we have no control over when the window may resize (Cocoa
     // may resize automatically) we simply set the view to fill the entire


### PR DESCRIPTION
Fix regression of the bug addressed in commit 40090e.