### PR TITLE
Restrict transparency blur to >= Leopard

### DIFF
--- a/src/MacVim/MMBackend.h
+++ b/src/MacVim/MMBackend.h
@@ -137,7 +137,7 @@ extern NSTimeInterval MMBalloonEvalInternalDelay;
 
 - (void)setAntialias:(BOOL)antialias;
 
-#ifdef FEAT_TRANSPARENCY
+#ifdef BLUR_TRANSPARENCY
 - (void)setBlurRadius:(int)radius;
 #endif
 

--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -1180,7 +1180,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
     [self queueMessage:msgid data:nil];
 }
 
-#ifdef FEAT_TRANSPARENCY
+#ifdef BLUR_TRANSPARENCY
 
 - (void)setBlurRadius:(int)radius
 {

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -876,10 +876,12 @@ static BOOL isUnsafeMessage(int msgid);
         if (filenames)
             [[NSDocumentController sharedDocumentController]
                                             noteNewRecentFilePaths:filenames];
+#ifdef BLUR_TRANSPARENCY
     } else if (SetBlurRadiusMsgID == msgid) {
         const void *bytes = [data bytes];
         int radius = *((int*)bytes);
         [windowController setBlurRadius:radius];
+#endif
 
     // IMPORTANT: When adding a new message, make sure to update
     // isUnsafeMessage() if necessary!

--- a/src/MacVim/MMWindow.h
+++ b/src/MacVim/MMWindow.h
@@ -28,7 +28,9 @@
 - (void)setContentMinSize:(NSSize)size;
 - (void)setContentMaxSize:(NSSize)size;
 - (void)setContentSize:(NSSize)size;
+#ifdef BLUR_TRANSPARENCY
 - (void)setBlurRadius:(int)radius;
+#endif
 
 - (IBAction)toggleFullScreen:(id)sender;
 - (IBAction)realToggleFullScreen:(id)sender;

--- a/src/MacVim/MMWindow.m
+++ b/src/MacVim/MMWindow.m
@@ -28,9 +28,11 @@
 
 #import "MMWindow.h"
 #import "Miscellaneous.h"
+
+
+#ifdef BLUR_TRANSPARENCY
+
 #import "CGSInternal/CGSWindow.h"
-
-
 
 typedef CGError CGSSetWindowBackgroundBlurRadiusFunction(CGSConnectionID cid, CGSWindowID wid, NSUInteger blur);
 
@@ -59,6 +61,8 @@ static CGSSetWindowBackgroundBlurRadiusFunction* GetCGSSetWindowBackgroundBlurRa
     }
     return function;
 }
+
+#endif // BLUR_TRANSPARENCY
 
 
 
@@ -155,6 +159,8 @@ static CGSSetWindowBackgroundBlurRadiusFunction* GetCGSSetWindowBackgroundBlurRa
     [super setContentSize:size];
 }
 
+#ifdef BLUR_TRANSPARENCY
+
 - (void)setBlurRadius:(int)radius
 {
     if (radius >= 0) {
@@ -168,6 +174,8 @@ static CGSSetWindowBackgroundBlurRadiusFunction* GetCGSSetWindowBackgroundBlurRa
         }
     }
 }
+
+#endif // BLUR_TRANSPARENCY
 
 - (void)performClose:(id)sender
 {

--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -46,7 +46,9 @@
     NSPoint             defaultTopLeft;
     NSToolbar           *toolbar;
     BOOL                resizingDueToMove;
+#ifdef BLUR_TRANSPARENCY
     int                 blurRadius;
+#endif
 }
 
 - (id)initWithVimController:(MMVimController *)controller;
@@ -82,7 +84,10 @@
 - (void)adjustLinespace:(int)linespace;
 - (void)liveResizeWillStart;
 - (void)liveResizeDidEnd;
+
+#ifdef BLUR_TRANSPARENCY
 - (void)setBlurRadius:(int)radius;
+#endif
 
 - (void)enterFullScreen:(int)fuoptions backgroundColor:(NSColor *)back;
 - (void)leaveFullScreen;

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -330,7 +330,9 @@
     if (fullScreenEnabled && !fullScreenWindow)
         [decoratedWindow setAlphaValue:0];
 
+#ifdef BLUR_TRANSPARENCY
     [decoratedWindow setBlurRadius:blurRadius];
+#endif
 
     // Flag that the window is now placed on screen.  From now on it is OK for
     // code to depend on the screen state.  (Such as constraining views etc.)
@@ -721,6 +723,7 @@
     }
 }
 
+#ifdef BLUR_TRANSPARENCY
 - (void)setBlurRadius:(int)radius
 {
     blurRadius = radius;
@@ -728,6 +731,7 @@
         [decoratedWindow setBlurRadius:radius];
     }
 }
+#endif
 
 - (void)enterFullScreen:(int)fuoptions backgroundColor:(NSColor *)back
 {

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -2360,7 +2360,7 @@ gui_mch_post_balloon(beval, mesg)
 
 #endif // FEAT_BEVAL
 
-#ifdef FEAT_TRANSPARENCY
+#ifdef BLUR_TRANSPARENCY
 
     void
 gui_macvim_set_blur(int radius)
@@ -2368,4 +2368,4 @@ gui_macvim_set_blur(int radius)
     [[MMBackend sharedInstance] setBlurRadius:radius];
 }
 
-#endif // FEAT_TRANSPARENCY
+#endif // BLUR_TRANSPARENCY

--- a/src/option.c
+++ b/src/option.c
@@ -647,7 +647,7 @@ static struct vimoption
 #endif
 			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
     {"blurradius",  "blur", P_NUM|P_VIM,
-#ifdef FEAT_TRANSPARENCY
+#ifdef BLUR_TRANSPARENCY
 			    (char_u *)&p_blur, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
@@ -8713,7 +8713,9 @@ set_num_option(opt_idx, varp, value, errbuf, errbuflen, opt_flags)
         else if (gui.in_use)
             gui_mch_new_colors();
     }
+#endif
 
+#ifdef BLUR_TRANSPARENCY
     else if (pp == &p_blur)
     {
         if (p_blur < 0)

--- a/src/option.h
+++ b/src/option.h
@@ -811,6 +811,8 @@ EXTERN char_u	*p_tsr;		/* 'thesaurus' */
 #endif
 #ifdef FEAT_TRANSPARENCY
 EXTERN long     p_transp;       /* 'transparency' */
+#endif
+#ifdef BLUR_TRANSPARENCY
 EXTERN long     p_blur;         /* 'blurradius' */
 #endif
 EXTERN int	p_ttimeout;	/* 'ttimeout' */

--- a/src/proto/gui_macvim.pro
+++ b/src/proto/gui_macvim.pro
@@ -208,7 +208,7 @@ void gui_macvim_update_modified_flag();
 void gui_macvim_add_to_find_pboard(char_u *pat);
 void gui_macvim_set_antialias(int antialias);
 
-#ifdef FEAT_TRANSPARENCY
+#ifdef BLUR_TRANSPARENCY
 void gui_macvim_set_blur(int blur);
 #endif
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -1751,7 +1751,7 @@ typedef int proftime_T;	    /* dummy for function prototypes */
 #endif
 
 /* Needs to be before option.h, which uses BLUR_TRANSPARENCY */
-#if defined(FEAT_TRANSPARENCY) && (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_5)
+#if defined(FEAT_TRANSPARENCY) && defined(MAC_OS_X_VERSION_10_5) && (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_5)
 # define BLUR_TRANSPARENCY
 #endif
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -1750,6 +1750,11 @@ typedef struct timeval proftime_T;
 typedef int proftime_T;	    /* dummy for function prototypes */
 #endif
 
+/* Needs to be before option.h, which uses BLUR_TRANSPARENCY */
+#if defined(FEAT_TRANSPARENCY) && (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_5)
+# define BLUR_TRANSPARENCY
+#endif
+
 /* Include option.h before structs.h, because the number of window-local and
  * buffer-local options is used there. */
 #include "option.h"	    /* options and default values */


### PR DESCRIPTION
As identified by @jpetrie in issue #72, the Tiger SDK doesn't support
the CGSInternal headers previously pulled in from iTerm2. This commit
wraps all of the blur code in CPP guards that check
MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_5.