### PR TITLE
Use 'mousetime' to recognize multi clicks

### DIFF
--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -1834,6 +1834,7 @@ static void netbeansReadCallback(CFSocketRef s,
     NSDictionary *vimState = [NSDictionary dictionaryWithObjectsAndKeys:
         [[NSFileManager defaultManager] currentDirectoryPath], @"pwd",
         [NSNumber numberWithInt:p_mh], @"p_mh",
+        [NSNumber numberWithLong:p_mouset], @"p_mouset",
         [NSNumber numberWithBool:mmta], @"p_mmta",
         [NSNumber numberWithInt:numTabs], @"numTabs",
         [NSNumber numberWithInt:fuoptions_flags], @"fullScreenOptions",
@@ -1925,12 +1926,12 @@ static void netbeansReadCallback(CFSocketRef s,
         int col = *((int*)bytes);  bytes += sizeof(int);
         int button = *((int*)bytes);  bytes += sizeof(int);
         int flags = *((int*)bytes);  bytes += sizeof(int);
-        int count = *((int*)bytes);  bytes += sizeof(int);
+        int repeat = *((int*)bytes);  bytes += sizeof(int);
 
         button = eventButtonNumberToVimMouseButton(button);
         if (button >= 0) {
             flags = eventModifierFlagsToVimMouseModMask(flags);
-            gui_send_mouse_event(button, col, row, count>1, flags);
+            gui_send_mouse_event(button, col, row, repeat, flags);
         }
     } else if (MouseUpMsgID == msgid) {
         if (!data) return;

--- a/src/MacVim/MMTextViewHelper.h
+++ b/src/MacVim/MMTextViewHelper.h
@@ -15,6 +15,9 @@
 #import <Carbon/Carbon.h>
 #endif
 
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+
 
 #define BLUE(argb)      ((argb & 0xff)/255.0f)
 #define GREEN(argb)     (((argb>>8) & 0xff)/255.0f)
@@ -61,6 +64,7 @@
 - (void)doCommandBySelector:(SEL)selector;
 - (BOOL)performKeyEquivalent:(NSEvent *)event;
 - (void)scrollWheel:(NSEvent *)event;
+- (uint64_t)getTick;
 - (void)mouseDown:(NSEvent *)event;
 - (void)mouseUp:(NSEvent *)event;
 - (void)mouseDragged:(NSEvent *)event;


### PR DESCRIPTION
Use the value of the Vim mousetime setting to recognize multi clicks. MacVim currently uses the mouse event property clickCount to recognize mulit clicks.