### PR TITLE
Fix beginModalSheetForWindow warning.

### DIFF
--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -1523,10 +1523,15 @@ static BOOL isUnsafeMessage(int msgid);
         }
     }
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_10
+  [alert beginSheetModalForWindow:[windowController window]
+                completionHandler: ^(NSModalResponse code) { [self alertDidEnd:alert code:code context:NULL]; }];
+#else
     [alert beginSheetModalForWindow:[windowController window]
                       modalDelegate:self
                      didEndSelector:@selector(alertDidEnd:code:context:)
                         contextInfo:NULL];
+#endif
 
     [alert release];
 }


### PR DESCRIPTION
This PR fixes a deprecation warning introduced in OS X 10.10 concerning the use of `beginModalSheetForWindow`; rather than using delegates and `@selector`, it calls the preferred variant of the message that takes a completion handler block.