### PR TITLE
Use %hhd for BOOLs in format string.

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -1239,7 +1239,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
             kCFPreferencesCurrentApplication);
     CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
 
-    ASLogInfo(@"Use ligatures=%ld", enable);
+    ASLogInfo(@"Use ligatures=%hhd", enable);
 
     // This action is called when the user clicks the "enable support for ligatures"
     // button in the advanced preferences pane.


### PR DESCRIPTION
Xcode 7 appears to introduce somewhat more aggressive "fix-it" warnings, one of them caught this minor typo in the format string for a log messages that came in with the recent ligature changes.