### PR TITLE
Allow directory selection in Open dialog

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -1080,6 +1080,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 
     NSOpenPanel *panel = [NSOpenPanel openPanel];
     [panel setAllowsMultipleSelection:YES];
+    [panel setCanChooseDirectories:YES];
     [panel setAccessoryView:showHiddenFilesView()];
 #if (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_6)
     // NOTE: -[NSOpenPanel runModalForDirectory:file:types:] is deprecated on


### PR DESCRIPTION
This PR allows the user to select a directory from within the `File > Open...` dialog.

Directory-opening functionality is already available in MacVim (e.g. by dragging a folder onto the MacVim dock icon, or by supplying a directory path as the first argument when launching the MacVim executable from Terminal) – this PR merely gives the user a simpler method of achieving this.

N.B. Vim's default behavior when opening a directory is to use the built-in `netrw` plugin to open a buffer displaying the directory contents