### PR TITLE
Fix deprecation warnings (except for NSCopyBits).

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -1721,12 +1721,17 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         while ((param = [enumerator nextObject])) {
             NSArray *arr = [param componentsSeparatedByString:@"="];
             if ([arr count] == 2) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_11
+              [dict setValue:[[arr lastObject] stringByRemovingPercentEncoding]
+                      forKey:[[arr objectAtIndex:0] stringByRemovingPercentEncoding]];
+#else
                 [dict setValue:[[arr lastObject]
                             stringByReplacingPercentEscapesUsingEncoding:
                                 NSUTF8StringEncoding]
                         forKey:[[arr objectAtIndex:0]
                             stringByReplacingPercentEscapesUsingEncoding:
                                 NSUTF8StringEncoding]];
+#endif
             }
         }
 

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -1722,8 +1722,8 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
             NSArray *arr = [param componentsSeparatedByString:@"="];
             if ([arr count] == 2) {
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_11
-              [dict setValue:[[arr lastObject] stringByRemovingPercentEncoding]
-                      forKey:[[arr objectAtIndex:0] stringByRemovingPercentEncoding]];
+                [dict setValue:[[arr lastObject] stringByRemovingPercentEncoding]
+                        forKey:[[arr objectAtIndex:0] stringByRemovingPercentEncoding]];
 #else
                 [dict setValue:[[arr lastObject]
                             stringByReplacingPercentEscapesUsingEncoding:

--- a/src/MacVim/MMTextViewHelper.m
+++ b/src/MacVim/MMTextViewHelper.m
@@ -340,7 +340,11 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
         // marked text moves outside the view as a result of scrolling.
         [self sendMarkedText:nil position:0];
         [self unmarkText];
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_6
+        [[NSTextInputContext currentInputContext] discardMarkedText];
+#else
         [[NSInputManager currentInputManager] markedTextAbandoned:self];
+#endif
     }
 
     float dx = [event deltaX];
@@ -1117,9 +1121,13 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
     // the Kotoeri manager "commits" the text on left clicks).
 
     if (event) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_6
+        return [[NSTextInputContext currentInputContext] handleEvent:event];
+#else
         NSInputManager *imgr = [NSInputManager currentInputManager];
         if ([imgr wantsToHandleMouseEvents])
             return [imgr handleMouseEvent:event];
+#endif
     }
 
     return NO;
@@ -1152,7 +1160,11 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
     // that the marked text should be abandoned.  (If pos is set to 0 Vim will
     // send backspace sequences to delete the old marked text.)
     [self sendMarkedText:nil position:-1];
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_6
+    [[NSTextInputContext currentInputContext] discardMarkedText];
+#else
     [[NSInputManager currentInputManager] markedTextAbandoned:self];
+#endif
 }
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6)

--- a/src/MacVim/MMTextViewHelper.m
+++ b/src/MacVim/MMTextViewHelper.m
@@ -777,7 +777,11 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
         rect.origin.y += rect.size.height;
 
     rect.origin = [textView convertPoint:rect.origin toView:nil];
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_7
+    rect = [[textView window] convertRectToScreen:rect];
+#else
     rect.origin = [[textView window] convertBaseToScreen:rect.origin];
+#endif
 
     return rect;
 }

--- a/src/MacVim/MMVimView.m
+++ b/src/MacVim/MMVimView.m
@@ -396,7 +396,10 @@ enum {
     // which tab should be selected at all times.  However, the AppKit will
     // automatically select the first tab added to a tab view.
 
-    NSTabViewItem *tvi = [[NSTabViewItem alloc] initWithIdentifier:nil];
+    // The documentation claims initWithIdentifier can be given a nil identifier, but the API itself
+    // is decorated such that doing so produces a warning, so the tab count is used as identifier.
+    NSInteger identifier = [[self tabView] numberOfTabViewItems];
+    NSTabViewItem *tvi = [[NSTabViewItem alloc] initWithIdentifier:[NSNumber numberWithInt:identifier]];
 
     // NOTE: If this is the first tab it will be automatically selected.
     vimTaskSelectedTab = YES;


### PR DESCRIPTION
These changes fix the last remaining deprecation warnings in MacVim itself (except for the one related to `NSCopyBits`, which as documented in #88 has me stumped).

They don't address the warnings in PSMTabBarFramework, as it's a third-party library and updating it to fix the warnings might create difficulties building for older OS X SDKs.