### PR TITLE
MMNoTitleBarWindowKey for hiding titlebar

### DIFF
--- a/src/MacVim/MMWindow.m
+++ b/src/MacVim/MMWindow.m
@@ -108,6 +108,14 @@ static CGSSetWindowBackgroundBlurRadiusFunction* GetCGSSetWindowBackgroundBlurRa
     [super dealloc];
 }
 
+- (BOOL) canBecomeMainWindow {
+    return YES;
+}
+
+- (BOOL) canBecomeKeyWindow {
+    return YES;
+}
+
 - (BOOL)hideTablineSeparator:(BOOL)hide
 {
     BOOL isHidden = [tablineSeparator isHidden];
@@ -225,6 +233,17 @@ static CGSSetWindowBackgroundBlurRadiusFunction* GetCGSSetWindowBackgroundBlurRa
     if ([NSWindow instancesRespondToSelector:@selector(toggleFullScreen:)])
         [super toggleFullScreen:sender];
 #endif
+}
+
+- (void)setToolbar:(NSToolbar *)toolbar
+{
+    if ([[NSUserDefaults standardUserDefaults] 
+            boolForKey:MMNoTitleBarWindowKey]) {
+        // MacVim can't have toolbar with No title bar setting.
+        return;
+    }
+
+    [super setToolbar:toolbar];
 }
 
 @end // MMWindow

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -130,6 +130,12 @@
             | NSMiniaturizableWindowMask | NSResizableWindowMask
             | NSUnifiedTitleAndToolbarWindowMask;
 
+    if ([[NSUserDefaults standardUserDefaults]
+            boolForKey:MMNoTitleBarWindowKey]) {
+        // No title bar setting
+        styleMask &= ~NSTitledWindowMask;
+    }
+
     // Use textured background on Leopard or later (skip the 'if' on Tiger for
     // polished metal window).
     if ([[NSUserDefaults standardUserDefaults] boolForKey:MMTexturedWindowKey]

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -37,6 +37,7 @@ extern NSString *MMTranslateCtrlClickKey;
 extern NSString *MMTopLeftPointKey;
 extern NSString *MMOpenInCurrentWindowKey;
 extern NSString *MMNoFontSubstitutionKey;
+extern NSString *MMNoTitleBarWindowKey;
 extern NSString *MMLoginShellKey;
 extern NSString *MMUntitledWindowKey;
 extern NSString *MMTexturedWindowKey;

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -29,6 +29,7 @@ NSString *MMTranslateCtrlClickKey       = @"MMTranslateCtrlClick";
 NSString *MMTopLeftPointKey             = @"MMTopLeftPoint";
 NSString *MMOpenInCurrentWindowKey      = @"MMOpenInCurrentWindow";
 NSString *MMNoFontSubstitutionKey       = @"MMNoFontSubstitution";
+NSString *MMNoTitleBarWindowKey         = @"MMNoTitleBarWindow";
 NSString *MMLoginShellKey               = @"MMLoginShell";
 NSString *MMUntitledWindowKey           = @"MMUntitledWindow";
 NSString *MMTexturedWindowKey           = @"MMTexturedWindow";


### PR DESCRIPTION
    $ defaults write org.vim.MacVim MMNoTitleBarWindow true

<del>
but it's not finished yet, needs to fix the error.

    ERROR: Can't have a toolbar in a window with <NSNextStepFrame: 0x7ff618f46a20> as it's borderview
</del>