### PR TITLE
Improve redraw behavior when macligatures is active.

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -111,7 +111,7 @@ to your .gvimrc file to revert back to the default Vim tab label.
 							*macvim-options*
 These are the non-standard options that MacVim supports:
 	'antialias'	'blurradius'	'fullscreen'
-	'fuoptions'	'macmeta'	'toolbariconsize'
+	'fuoptions'	'macmeta'	'macligatures'	'toolbariconsize'
 	'transparency'
 
 							*macvim-commands*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4997,6 +4997,19 @@ A jump table for the options with a short description can be found at |Q_op|.
 	bound with the Meta flag even when this option is disabled, but this
 	is not the case for the majority of keys (e.g. <M-a>, <M-`>).
 
+				*'macligatures'* *'nomacligatures'*
+'macligatures' 		boolean (default off)
+			global
+			{not in Vi}
+                        {only available when compiled with GUI enabled on
+			 Mac OS X}
+	This option only has an effect in the GUI version of Vim on Mac OS X
+	v10.2 or later.  When on, Vim will display ligatures if the selected
+	'guifont' supports them. Examples for such fonts are Fira Code or
+	Haskelig.
+	Note: Currently this option only has an effect if
+	'Use Core Text renderer' is enabled in the GUI preferences pane.
+
 						*'magic'* *'nomagic'*
 'magic'			boolean	(default on)
 			global

--- a/src/move.c
+++ b/src/move.c
@@ -21,6 +21,9 @@
 
 static void comp_botline __ARGS((win_T *wp));
 static void redraw_for_cursorline __ARGS((win_T *wp));
+#ifdef FEAT_GUI_MACVIM
+static void redraw_for_ligatures __ARGS((win_T *wp));
+#endif
 static int scrolljump_value __ARGS((void));
 static int check_top_offset __ARGS((void));
 static void curs_rows __ARGS((win_T *wp));
@@ -164,7 +167,7 @@ redraw_for_ligatures(wp)
 	if (p_macligatures
 	    && (wp->w_p_rnu == 0
 #ifdef FEAT_SYN_HL
-	        || wp->w_p_cul == 0
+	        && wp->w_p_cul == 0
 #endif
 	    ))
 	redraw_win_later(wp, CLEAR);

--- a/src/move.c
+++ b/src/move.c
@@ -107,6 +107,9 @@ comp_botline(wp)
 	    wp->w_cline_folded = folded;
 #endif
 	    redraw_for_cursorline(wp);
+#ifdef FEATU_GUI_MACVIM
+	    redraw_for_ligatures(wp);
+#endif
 	    wp->w_valid |= (VALID_CROW|VALID_CHEIGHT);
 	}
 	if (done + n > wp->w_height)
@@ -144,6 +147,29 @@ redraw_for_cursorline(wp)
 	    )
 	redraw_win_later(wp, SOME_VALID);
 }
+
+#ifdef FEAT_GUI_MACVIM
+/*
+ * Redraw when 'macliguters' is set.
+ * This is basically the same as when 'cursorline'
+ * or 'relativenumber' is set but unconditional.
+ */
+static void
+redraw_for_ligatures(wp)
+     win_T *wp;
+{
+	/* Only if ligatures are on but neither
+	 * 'cursorline' nor 'relativenumber'.
+	 */
+	if (p_macligatures
+	    && (wp->w_p_rnu == 0
+#ifdef FEAT_SYN_HL
+	        || wp->w_p_cul == 0
+#endif
+	    ))
+	redraw_win_later(wp, CLEAR);
+}
+#endif
 
 /*
  * Update curwin->w_topline and redraw if necessary.
@@ -793,6 +819,9 @@ curs_rows(wp)
     }
 
     redraw_for_cursorline(curwin);
+#ifdef FEAT_GUI_MACVIM
+    redraw_for_ligatures(curwin);
+#endif
     wp->w_valid |= VALID_CROW|VALID_CHEIGHT;
 
 }

--- a/src/option.c
+++ b/src/option.c
@@ -344,7 +344,6 @@ static int	p_lisp;
 static int	p_ml;
 static int	p_ma;
 #ifdef FEAT_GUI_MACVIM
-static int      p_macligatures;
 static int	p_mmta;
 #endif
 static int	p_mod;

--- a/src/option.h
+++ b/src/option.h
@@ -644,6 +644,9 @@ EXTERN char_u	*p_luadll;	/* 'luadll' */
 #ifdef FEAT_GUI_MAC
 EXTERN int	p_macatsui;	/* 'macatsui' */
 #endif
+#ifdef FEAT_GUI_MACVIM
+EXTERN int	p_macligatures;	/* 'macligatures' */
+#endif
 EXTERN int	p_magic;	/* 'magic' */
 #ifdef FEAT_QUICKFIX
 EXTERN char_u	*p_mef;		/* 'makeef' */


### PR DESCRIPTION
This builds on #36, #122 and #129 and removes the need to have `cursorline` or `relativenumber` set.
If none of these options is set moving the cursor in window with `macligatures` set will create the proper redraw calls. If either `cursorline` or `relativenumber` is set no additional redraws will be performed.