### PR TITLE
WORKAROUND: Allow to honor PYTHONHOME environment variable for +python/dyn and +python3/dyn

### DIFF
--- a/src/if_python.c
+++ b/src/if_python.c
@@ -932,7 +932,10 @@ Python_Init(void)
 #endif
 
 #ifdef PYTHON_HOME
-	Py_SetPythonHome(PYTHON_HOME);
+# ifdef DYNAMIC_PYTHON
+	if (mch_getenv((char_u *)"PYTHONHOME") == NULL)
+# endif
+	    Py_SetPythonHome(PYTHON_HOME);
 #endif
 
 	init_structs();

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -858,7 +858,10 @@ Python3_Init(void)
 
 
 #ifdef PYTHON3_HOME
-	Py_SetPythonHome(PYTHON3_HOME);
+# ifdef DYNAMIC_PYTHON3
+	if (mch_getenv((char_u *)"PYTHONHOME") == NULL)
+# endif
+	    Py_SetPythonHome(PYTHON3_HOME);
 #endif
 
 	PyImport_AppendInittab("vim", Py3Init_vim);


### PR DESCRIPTION
It is temporary fix and it may be changed in the future
https://github.com/vim/vim/pull/500

Example:

	let $PYTHONHOME="/usr/local/Frameworks/Python.framework/Versions/2.7"
	set pythondll=/usr/local/Frameworks/Python.framework/Versions/2.7/Python