### PR TITLE
Add MMUseMouseTime, Revise #77

### DIFF
--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -1844,6 +1844,7 @@ static void netbeansReadCallback(CFSocketRef s,
         [NSNumber numberWithBool:mmta], @"p_mmta",
         [NSNumber numberWithInt:numTabs], @"numTabs",
         [NSNumber numberWithInt:fuoptions_flags], @"fullScreenOptions",
+        [NSNumber numberWithLong:p_mouset], @"p_mouset",
         nil];
 
     // Put the state before all other messages.
@@ -1932,12 +1933,12 @@ static void netbeansReadCallback(CFSocketRef s,
         int col = *((int*)bytes);  bytes += sizeof(int);
         int button = *((int*)bytes);  bytes += sizeof(int);
         int flags = *((int*)bytes);  bytes += sizeof(int);
-        int count = *((int*)bytes);  bytes += sizeof(int);
+        int repeat = *((int*)bytes);  bytes += sizeof(int);
 
         button = eventButtonNumberToVimMouseButton(button);
         if (button >= 0) {
             flags = eventModifierFlagsToVimMouseModMask(flags);
-            gui_send_mouse_event(button, col, row, count>1, flags);
+            gui_send_mouse_event(button, col, row, repeat, flags);
         }
     } else if (MouseUpMsgID == msgid) {
         if (!data) return;

--- a/src/MacVim/MMTextViewHelper.h
+++ b/src/MacVim/MMTextViewHelper.h
@@ -35,6 +35,8 @@
     BOOL                interpretKeyEventsSwallowedKey;
     NSEvent             *currentEvent;
     NSMutableDictionary *signImages;
+    BOOL                useMouseTime;
+    NSDate              *mouseDownTime;
 
     // Input Manager
     NSRange             imRange;

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -55,6 +55,7 @@ extern NSString *MMUseInlineImKey;
 #endif // INCLUDE_OLD_IM_CODE
 extern NSString *MMSuppressTerminationAlertKey;
 extern NSString *MMNativeFullScreenKey;
+extern NSString *MMUseMouseTimeKey;
 
 
 // Enum for MMUntitledWindowKey

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -47,6 +47,7 @@ NSString *MMUseInlineImKey              = @"MMUseInlineIm";
 #endif // INCLUDE_OLD_IM_CODE
 NSString *MMSuppressTerminationAlertKey = @"MMSuppressTerminationAlert";
 NSString *MMNativeFullScreenKey         = @"MMNativeFullScreen";
+NSString *MMUseMouseTimeKey             = @"MMUseMouseTime";
 
 
 


### PR DESCRIPTION
`MMUseMouseTime` allows to override the time threshold for detecting multiple
mouse down events using Vim `mousetime` option.

    $ defaults write org.vim.MacVim MMUseMouseTime -bool TRUE