### PR TITLE
Fix conflict with emoji U+25C0 and airline_right_sep

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -1290,7 +1290,11 @@ utf_char2cells(c)
 	{0x23e9, 0x23f3},
 	{0x23f8, 0x23fa},
 	{0x24c2, 0x24c2},
+# ifndef FEAT_GUI
+	/* conflict emoji simbol U+25c0 BLACK LEFT-POINTING TRIANGLE with
+	 * vim-airline g:airline_right_sep = '◀' */
 	{0x25c0, 0x25c0},
+# endif
 	{0x25fb, 0x25fe},
 	{0x2600, 0x2604},
 	{0x260e, 0x260e},


### PR DESCRIPTION
Problem appeared in the snapshot-88 after added emoji.

![macvim_airline](https://cloud.githubusercontent.com/assets/5517778/12517912/5c165b20-c146-11e5-9f4e-ef4fb916b887.png)

in the terminal all ok

![vim_airline](https://cloud.githubusercontent.com/assets/5517778/12517928/6b3f3284-c146-11e5-9699-2fd28ee50b19.png)

conflict emoji simbol U+25c0 BLACK LEFT-POINTING TRIANGLE with
vim-airline g:airline_right_sep = '◀' 


 