### PR TITLE
add env DYNAMIC_PYTHON_DLL and DYNAMIC_PYTHON3_DLL vars for python dll

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -6023,7 +6023,25 @@ __:
 eof
 	    	    eval "`cd ${PYTHON_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
 	    rm -f -- "${tmp_mkf}"
-	    if test "x$MACOSX" = "xyes" && ${vi_cv_path_python} -c \
+	    { $as_echo "$as_me:${as_lineno-$LINENO}: python_BASEMODLIBS=${python_BASEMODLIBS}" >&5
+$as_echo "$as_me: python_BASEMODLIBS=${python_BASEMODLIBS}" >&6;}
+	    { $as_echo "$as_me:${as_lineno-$LINENO}: python_LIBS=${python_LIBS}" >&5
+$as_echo "$as_me: python_LIBS=${python_LIBS}" >&6;}
+	    { $as_echo "$as_me:${as_lineno-$LINENO}: python_SYSLIBS=${python_SYSLIBS}" >&5
+$as_echo "$as_me: python_SYSLIBS=${python_SYSLIBS}" >&6;}
+	    { $as_echo "$as_me:${as_lineno-$LINENO}: python_LINKFORSHARED=${python_LINKFORSHARED}" >&5
+$as_echo "$as_me: python_LINKFORSHARED=${python_LINKFORSHARED}" >&6;}
+	    { $as_echo "$as_me:${as_lineno-$LINENO}: python_DLLLIBRARY=${python_DLLLIBRARY}" >&5
+$as_echo "$as_me: python_DLLLIBRARY=${python_DLLLIBRARY}" >&6;}
+	    { $as_echo "$as_me:${as_lineno-$LINENO}: python_INSTSONAME=${python_INSTSONAME}" >&5
+$as_echo "$as_me: python_INSTSONAME=${python_INSTSONAME}" >&6;}
+	    { $as_echo "$as_me:${as_lineno-$LINENO}: python_PYTHONFRAMEWORK=${python_PYTHONFRAMEWORK}" >&5
+$as_echo "$as_me: python_PYTHONFRAMEWORK=${python_PYTHONFRAMEWORK}" >&6;}
+	    { $as_echo "$as_me:${as_lineno-$LINENO}: python_PYTHONFRAMEWORKPREFIX=${python_PYTHONFRAMEWORKPREFIX}" >&5
+$as_echo "$as_me: python_PYTHONFRAMEWORKPREFIX=${python_PYTHONFRAMEWORKPREFIX}" >&6;}
+	    { $as_echo "$as_me:${as_lineno-$LINENO}: python_PYTHONFRAMEWORKINSTALLDIR=${python_PYTHONFRAMEWORKINSTALLDIR}" >&5
+$as_echo "$as_me: python_PYTHONFRAMEWORKINSTALLDIR=${python_PYTHONFRAMEWORKINSTALLDIR}" >&6;}
+        if test "x$MACOSX" = "xyes" && ${vi_cv_path_python} -c \
 		"import sys; sys.exit(${vi_cv_var_python_version} < 2.3)"; then
 	      vi_cv_path_python_plibs="-framework Python"
 	      if test "x${vi_cv_path_python}" != "x/usr/bin/python" && test -n "${python_PYTHONFRAMEWORKPREFIX}"; then
@@ -6052,18 +6070,25 @@ eof
 
 fi
 
-	if ${vi_cv_dll_name_python+:} false; then :
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking Python's dll name" >&5
+$as_echo_n "checking Python's dll name... " >&6; }
+if ${vi_cv_dll_name_python+:} false; then :
   $as_echo_n "(cached) " >&6
 else
 
-	  if test "X$python_DLLLIBRARY" != "X"; then
-	    vi_cv_dll_name_python="$python_DLLLIBRARY"
-	  else
-	    vi_cv_dll_name_python="$python_INSTSONAME"
-	  fi
+      if test "X$DYNAMIC_PYTHON_DLL" == "X"; then
+        if test "X$python_DLLLIBRARY" != "X"; then
+          vi_cv_dll_name_python="$python_DLLLIBRARY"
+        else
+          vi_cv_dll_name_python="$python_INSTSONAME"
+        fi
+      else
+         vi_cv_dll_name_python="$DYNAMIC_PYTHON_DLL"
+      fi
 
 fi
-
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $vi_cv_dll_name_python" >&5
+$as_echo "$vi_cv_dll_name_python" >&6; }
 
 	PYTHON_LIBS="${vi_cv_path_python_plibs}"
 	if test "${vi_cv_path_python_pfx}" = "${vi_cv_path_python_epfx}"; then
@@ -6379,27 +6404,44 @@ __:
 	@echo "python3_DLLLIBRARY='$(DLLLIBRARY)'"
 	@echo "python3_INSTSONAME='$(INSTSONAME)'"
 eof
-	    	    eval "`cd ${PYTHON3_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
-	    rm -f -- "${tmp_mkf}"
-	    vi_cv_path_python3_plibs="-L${PYTHON3_CONFDIR} -lpython${vi_cv_var_python3_version}${vi_cv_var_python3_abiflags}"
-	    vi_cv_path_python3_plibs="${vi_cv_path_python3_plibs} ${python3_BASEMODLIBS} ${python3_LIBS} ${python3_SYSLIBS}"
-	    	    vi_cv_path_python3_plibs=`echo $vi_cv_path_python3_plibs | sed s/-ltermcap//`
-	    vi_cv_path_python3_plibs=`echo $vi_cv_path_python3_plibs | sed s/-lffi//`
+                        eval "`cd ${PYTHON3_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
+            rm -f -- "${tmp_mkf}"
+            { $as_echo "$as_me:${as_lineno-$LINENO}: python3_BASEMODLIBS=${python3_BASEMODLIBS}" >&5
+$as_echo "$as_me: python3_BASEMODLIBS=${python3_BASEMODLIBS}" >&6;}
+            { $as_echo "$as_me:${as_lineno-$LINENO}: python3_LIBS=${python3_LIBS}" >&5
+$as_echo "$as_me: python3_LIBS=${python3_LIBS}" >&6;}
+            { $as_echo "$as_me:${as_lineno-$LINENO}: python3_SYSLIBS=${python3_SYSLIBS}" >&5
+$as_echo "$as_me: python3_SYSLIBS=${python3_SYSLIBS}" >&6;}
+            { $as_echo "$as_me:${as_lineno-$LINENO}: python3_DLLLIBRARY=${python3_DLLLIBRARY}" >&5
+$as_echo "$as_me: python3_DLLLIBRARY=${python3_DLLLIBRARY}" >&6;}
+            { $as_echo "$as_me:${as_lineno-$LINENO}: python3_INSTSONAME=${python3_INSTSONAME}" >&5
+$as_echo "$as_me: python3_INSTSONAME=${python3_INSTSONAME}" >&6;}
+            vi_cv_path_python3_plibs="-L${PYTHON3_CONFDIR} -lpython${vi_cv_var_python3_version}${vi_cv_var_python3_abiflags}"
+            vi_cv_path_python3_plibs="${vi_cv_path_python3_plibs} ${python3_BASEMODLIBS} ${python3_LIBS} ${python3_SYSLIBS}"
+                        vi_cv_path_python3_plibs=`echo $vi_cv_path_python3_plibs | sed s/-ltermcap//`
+            vi_cv_path_python3_plibs=`echo $vi_cv_path_python3_plibs | sed s/-lffi//`
 
 fi
 
-	if ${vi_cv_dll_name_python3+:} false; then :
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking Python3's dll name" >&5
+$as_echo_n "checking Python3's dll name... " >&6; }
+if ${vi_cv_dll_name_python3+:} false; then :
   $as_echo_n "(cached) " >&6
 else
 
-	  if test "X$python3_DLLLIBRARY" != "X"; then
-	    vi_cv_dll_name_python3="$python3_DLLLIBRARY"
-	  else
-	    vi_cv_dll_name_python3="$python3_INSTSONAME"
-	  fi
+          if test "X$DYNAMIC_PYTHON3_DLL" == "X"; then
+            if test "X$python3_DLLLIBRARY" != "X"; then
+              vi_cv_dll_name_python3="$python3_DLLLIBRARY"
+            else
+              vi_cv_dll_name_python3="$python3_INSTSONAME"
+            fi
+          else
+             vi_cv_dll_name_python3="$DYNAMIC_PYTHON3_DLL"
+          fi
 
 fi
-
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $vi_cv_dll_name_python3" >&5
+$as_echo "$vi_cv_dll_name_python3" >&6; }
 
         PYTHON3_LIBS="${vi_cv_path_python3_plibs}"
         if test "${vi_cv_path_python3_pfx}" = "${vi_cv_path_python3_epfx}"; then
@@ -6551,7 +6593,7 @@ else
     int no_rtl_global_needed_for(char *python_instsoname, char *prefix)
     {
       int needed = 0;
-      void* pylib = dlopen(python_instsoname, RTLD_LAZY);
+      void* pylib = dlopen(python_instsoname, RTLD_LAZY|RTLD_LOCAL);
       if (pylib != 0)
       {
           void (*pfx)(char *home) = dlsym(pylib, "Py_SetPythonHome");
@@ -6617,7 +6659,7 @@ else
     int no_rtl_global_needed_for(char *python_instsoname, wchar_t *prefix)
     {
       int needed = 0;
-      void* pylib = dlopen(python_instsoname, RTLD_LAZY);
+      void* pylib = dlopen(python_instsoname, RTLD_LAZY|RTLD_LOCAL);
       if (pylib != 0)
       {
           void (*pfx)(wchar_t *home) = dlsym(pylib, "Py_SetPythonHome");

--- a/src/configure.in
+++ b/src/configure.in
@@ -1,4 +1,5 @@
 dnl configure.in: autoconf script for Vim
+dnl vim: set ts=4 sw=2 sts=2 et :
 
 dnl Process this file with autoconf 2.12 or 2.13 to produce "configure".
 dnl Should also work with autoconf 2.54 and later.
@@ -1213,7 +1214,16 @@ eof
 	    dnl -- delete the lines from make about Entering/Leaving directory
 	    eval "`cd ${PYTHON_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
 	    rm -f -- "${tmp_mkf}"
-	    if test "x$MACOSX" = "xyes" && ${vi_cv_path_python} -c \
+	    AC_MSG_NOTICE(python_BASEMODLIBS=${python_BASEMODLIBS})
+	    AC_MSG_NOTICE(python_LIBS=${python_LIBS})
+	    AC_MSG_NOTICE(python_SYSLIBS=${python_SYSLIBS})
+	    AC_MSG_NOTICE(python_LINKFORSHARED=${python_LINKFORSHARED})
+	    AC_MSG_NOTICE(python_DLLLIBRARY=${python_DLLLIBRARY})
+	    AC_MSG_NOTICE(python_INSTSONAME=${python_INSTSONAME})
+	    AC_MSG_NOTICE(python_PYTHONFRAMEWORK=${python_PYTHONFRAMEWORK})
+	    AC_MSG_NOTICE(python_PYTHONFRAMEWORKPREFIX=${python_PYTHONFRAMEWORKPREFIX})
+	    AC_MSG_NOTICE(python_PYTHONFRAMEWORKINSTALLDIR=${python_PYTHONFRAMEWORKINSTALLDIR})
+        if test "x$MACOSX" = "xyes" && ${vi_cv_path_python} -c \
 		"import sys; sys.exit(${vi_cv_var_python_version} < 2.3)"; then
 	      vi_cv_path_python_plibs="-framework Python"
 	      if test "x${vi_cv_path_python}" != "x/usr/bin/python" && test -n "${python_PYTHONFRAMEWORKPREFIX}"; then
@@ -1249,13 +1259,17 @@ eof
 	      vi_cv_path_python_plibs=`echo $vi_cv_path_python_plibs | sed s/-ltermcap//`
 	    fi
 	])
-	AC_CACHE_VAL(vi_cv_dll_name_python,
+	AC_CACHE_CHECK(Python's dll name,vi_cv_dll_name_python,
 	[
-	  if test "X$python_DLLLIBRARY" != "X"; then
-	    vi_cv_dll_name_python="$python_DLLLIBRARY"
-	  else
-	    vi_cv_dll_name_python="$python_INSTSONAME"
-	  fi
+      if test "X$DYNAMIC_PYTHON_DLL" == "X"; then
+        if test "X$python_DLLLIBRARY" != "X"; then
+          vi_cv_dll_name_python="$python_DLLLIBRARY"
+        else
+          vi_cv_dll_name_python="$python_INSTSONAME"
+        fi
+      else
+         vi_cv_dll_name_python="$DYNAMIC_PYTHON_DLL"
+      fi
 	])
 
 	PYTHON_LIBS="${vi_cv_path_python_plibs}"
@@ -1459,23 +1473,32 @@ __:
 	@echo "python3_DLLLIBRARY='$(DLLLIBRARY)'"
 	@echo "python3_INSTSONAME='$(INSTSONAME)'"
 eof
-	    dnl -- delete the lines from make about Entering/Leaving directory
-	    eval "`cd ${PYTHON3_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
-	    rm -f -- "${tmp_mkf}"
-	    vi_cv_path_python3_plibs="-L${PYTHON3_CONFDIR} -lpython${vi_cv_var_python3_version}${vi_cv_var_python3_abiflags}"
-	    vi_cv_path_python3_plibs="${vi_cv_path_python3_plibs} ${python3_BASEMODLIBS} ${python3_LIBS} ${python3_SYSLIBS}"
-	    dnl remove -ltermcap, it can conflict with an earlier -lncurses
-	    vi_cv_path_python3_plibs=`echo $vi_cv_path_python3_plibs | sed s/-ltermcap//`
-	    vi_cv_path_python3_plibs=`echo $vi_cv_path_python3_plibs | sed s/-lffi//`
-	])
-	AC_CACHE_VAL(vi_cv_dll_name_python3,
-	[
-	  if test "X$python3_DLLLIBRARY" != "X"; then
-	    vi_cv_dll_name_python3="$python3_DLLLIBRARY"
-	  else
-	    vi_cv_dll_name_python3="$python3_INSTSONAME"
-	  fi
-	])
+            dnl -- delete the lines from make about Entering/Leaving directory
+            eval "`cd ${PYTHON3_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
+            rm -f -- "${tmp_mkf}"
+            AC_MSG_NOTICE(python3_BASEMODLIBS=${python3_BASEMODLIBS})
+            AC_MSG_NOTICE(python3_LIBS=${python3_LIBS})
+            AC_MSG_NOTICE(python3_SYSLIBS=${python3_SYSLIBS})
+            AC_MSG_NOTICE(python3_DLLLIBRARY=${python3_DLLLIBRARY})
+            AC_MSG_NOTICE(python3_INSTSONAME=${python3_INSTSONAME})
+            vi_cv_path_python3_plibs="-L${PYTHON3_CONFDIR} -lpython${vi_cv_var_python3_version}${vi_cv_var_python3_abiflags}"
+            vi_cv_path_python3_plibs="${vi_cv_path_python3_plibs} ${python3_BASEMODLIBS} ${python3_LIBS} ${python3_SYSLIBS}"
+            dnl remove -ltermcap, it can conflict with an earlier -lncurses
+            vi_cv_path_python3_plibs=`echo $vi_cv_path_python3_plibs | sed s/-ltermcap//`
+            vi_cv_path_python3_plibs=`echo $vi_cv_path_python3_plibs | sed s/-lffi//`
+        ])
+        AC_CACHE_CHECK(Python3's dll name,vi_cv_dll_name_python3,
+        [
+          if test "X$DYNAMIC_PYTHON3_DLL" == "X"; then
+            if test "X$python3_DLLLIBRARY" != "X"; then
+              vi_cv_dll_name_python3="$python3_DLLLIBRARY"
+            else
+              vi_cv_dll_name_python3="$python3_INSTSONAME"
+            fi
+          else
+             vi_cv_dll_name_python3="$DYNAMIC_PYTHON3_DLL"
+          fi
+        ])
 
         PYTHON3_LIBS="${vi_cv_path_python3_plibs}"
         if test "${vi_cv_path_python3_pfx}" = "${vi_cv_path_python3_epfx}"; then
@@ -1586,7 +1609,7 @@ if test "$python_ok" = yes && test "$python3_ok" = yes; then
     int no_rtl_global_needed_for(char *python_instsoname, char *prefix)
     {
       int needed = 0;
-      void* pylib = dlopen(python_instsoname, RTLD_LAZY);
+      void* pylib = dlopen(python_instsoname, RTLD_LAZY|RTLD_LOCAL);
       if (pylib != 0)
       {
           void (*pfx)(char *home) = dlsym(pylib, "Py_SetPythonHome");
@@ -1632,7 +1655,7 @@ if test "$python_ok" = yes && test "$python3_ok" = yes; then
     int no_rtl_global_needed_for(char *python_instsoname, wchar_t *prefix)
     {
       int needed = 0;
-      void* pylib = dlopen(python_instsoname, RTLD_LAZY);
+      void* pylib = dlopen(python_instsoname, RTLD_LAZY|RTLD_LOCAL);
       if (pylib != 0)
       {
           void (*pfx)(wchar_t *home) = dlsym(pylib, "Py_SetPythonHome");


### PR DESCRIPTION
configure.in - detect relative python dll path, if python not installed in the /system/library/frameworks then thes python not loaded correctly.
Result - any python build - :py load system python!! 

in the :help python-dynamic

On Unix the 'pythondll' or 'pythonthreedll' option can be used to specify the
Python shared library file instead of DYNAMIC_PYTHON_DLL or
DYNAMIC_PYTHON3_DLL file what were specified at compile time.  The version of
the shared library must match the Python 2.x or Python 3 version Vim was
compiled with.

but this variable not used in the configure.in, checked only in the src/Make_cyg_ming.mak

with this patch worked next build on my system with installed pyenv python:
```
export DYNAMIC_PYTHON_DLL=/Users/svolkov/.pyenv/versions/2.7.10/Python.framework/Versions/2.7/Python
export DYNAMIC_PYTHON3_DLL=/Users/svolkov/.pyenv/versions/3.4.3/Python.framework/Versions/3.4/Python
./configure --with-features=huge  \
  --enable-pythoninterp=dynamic  \
  --enable-python3interp=dynamic  \
  --enable-rubyinterp=dynamic  \
  --enable-perlinterp=dynamic  \
  --enable-cscope  \
  --enable-luainterp=dynamic  \
  --with-lua-prefix=/usr/local  \
  --with-properly-linked-python2-python3
```