### PR TITLE
Using floats fails when using a comma-as-a-decimal-separator locale

### DIFF
--- a/src/os_mac_conv.c
+++ b/src/os_mac_conv.c
@@ -584,6 +584,7 @@ mac_lang_init() {
 	    vim_setenv((char_u *)"LANG", (char_u *)buf);
 #   ifdef HAVE_LOCALE_H
 	    setlocale(LC_ALL, "");
+            setlocale(LC_NUMERIC, "C");
 #   endif
 	}
     }


### PR DESCRIPTION
_This is a copy of my pull request made [against the original repo](https://github.com/b4winckler/macvim/pull/50)_

**What steps will reproduce the problem?**

Set either language to French or the region to France in the Preferences.

Type the following commands in Macvim's console ( lines prefixed by >> are the answer, E123 are error codes):

```
:let a=0.5
>> E806 + E15
:let a=0,5
>> E806 + E15 + E15
:let a=str2float('0.5')
:let a
>> 0,0
:let a=str2float('0,5')
:let a
>> 0,5
```

*What is the expected output? What do you see instead?*

Here's what I should get:

```
:let a=0.5
:let a
>> 0.5
:let a=0,5
>> E15
:let a=str2float('0.5')
:let a
>> 0.5
:let a=str2float('0,5')
:let a
>> 0.0
```

Note that I was able to get the expected result when I started /Applications/MacVim.app/Contents/MacOS/MacVim from the Terminal with no LC_* env variables. The problem only exists when the app is started from the finder, the dock or Alfred.

What version of MacVim and OS X are you using (see "MacVim->About MacVim"
and  "Apple Menu->About This Mac" menu items, e.g. "Snapshot 40, 10.5.6
Intel")?

Tested with both snapshots 69 and release 73 (which I hoped would fix the issue), under Mavericks 10.9.4