### PR TITLE
Fix white line in tiled fullscreen windows.

### DIFF
--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1207,6 +1207,9 @@
     // Store window frame and use it when exiting full-screen.
     preFullScreenFrame = [decoratedWindow frame];
 
+    // The separator should never be visible in fullscreen or split-screen.
+    [decoratedWindow hideTablineSeparator:YES];
+  
     // ASSUMPTION: fullScreenEnabled always reflects the state of Vim's 'fu'.
     if (!fullScreenEnabled) {
         ASLogDebug(@"Full-screen out of sync, tell Vim to set 'fu'");
@@ -1306,6 +1309,8 @@
         // full-screen by moving the window out from Split View.
         [vimController sendMessage:BackingPropertiesChangedMsgID data:nil];
     }
+  
+    [self updateTablineSeparator];
 }
 
 - (void)windowDidFailToExitFullScreen:(NSWindow *)window


### PR DESCRIPTION
Tiled fullscreen windows (aka split screen windows) don't use quite the same set of messages as true fullscreen windows, which prevented MacVim from getting a chance to update tab line state when entering a tiled fullscreen mode.

This addresses #250.