### PR TITLE
Add themes under packpath to Edit > Color Scheme.

### DIFF
--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -389,6 +389,7 @@ endfun
 
 " get NL separated string with file names
 let s:n = globpath(&runtimepath, "colors/*.vim")
+let s:n .= globpath(&packpath, "pack/*/{opt,start}/*/colors/*.vim")
 
 " split at NL, Ignore case for VMS and windows, sort on name
 let s:names = sort(map(split(s:n, "\n"), 'substitute(v:val, "\\c.*[/\\\\:\\]]\\([^/\\\\:]*\\)\\.vim", "\\1", "")'), 1)


### PR DESCRIPTION
Currently, in order to populate the Edit > Color Scheme menu, MacVim searches
for color schemes only in the paths defined in `runtimepath`. Since MacVim is
compiled with `+packages`, it makes sense to also look for color schemes under
`packpath`. This commit addresses this deficiency.

Note that color schemes may be found below `pack/*/opt` or
`pack/*/start` (see `:h pack-add`): `:colorscheme` searches both
locations.