### PR TITLE
Make mvim smarter about remote logins

### DIFF
--- a/src/MacVim/mvim
+++ b/src/MacVim/mvim
@@ -53,6 +53,11 @@ opts=
 # GUI mode, implies forking
 case "$name" in m*|g*|rm*|rg*) gui=true ;; esac
 
+# Logged in over SSH? No gui.
+if [ -n "${SSH_CONNECTION}" ]; then
+	gui=
+fi
+
 # Restricted mode
 case "$name" in r*) opts="$opts -Z";; esac
 


### PR DESCRIPTION
Every now and then I need to ssh to an osx machine. Given that I have following aliases defined:
```
$ alias | grep '^vi'
vi=mvim
vim=mvim
vimdiff='mvim -d'
```
I can't easily launch MacVim in terminal. Instead, a window opens on the remote machine, I smack my forehead, kill it, unalias `vi` and use that. One workaround is to have vi/vim/vimdiff symlinks in place, that will affect `argv0` and make `mvim` launch in terminal. This solution is suboptimal though - when I'm logged in directly, I actually like having MacVim launch the gui version for `vim` (muscle memory is a horrible thing to change). The shell I'm using (`zsh`) allows for `argv0` manipulation, but `mvim` is a shell script, and `$0` it is using is unaffected by those kind of manipulations.

This small patch to mvim makes it skip the `-g` flag if `SSH_CONNECTION` environment variable is present. Doing it this way has the extra benefit of working seamlessly with `tmux`, as by default it'll add `SSH_CONNECTION` flag to newly created windows if you attach a session after sshing in.