### PR TITLE
Add macthinstrokes option

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -111,8 +111,8 @@ to your .gvimrc file to revert back to the default Vim tab label.
 							*macvim-options*
 These are the non-standard options that MacVim supports:
 	'antialias'	'blurradius'	'fullscreen'
-	'fuoptions'	'macligatures'	'macmeta'	'toolbariconsize'
-	'transparency'
+	'fuoptions'	'macligatures'	'macmeta'	'macthinstrokes'
+	'toolbariconsize'	'transparency'
 
 							*macvim-commands*
 These are the non-standard commands that MacVim supports:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5045,6 +5045,18 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Note: Currently this option only has an effect if
 	'Use Core Text renderer' is enabled in the GUI preferences pane.
 
+				*'macthinstrokes'* *'nomacthinstrokes'*
+'macthinstrokes' 		boolean (default off)
+			global
+			{not in Vi}
+                        {only available when compiled with GUI enabled on
+			 Mac OS X}
+	This option only has an effect in the GUI version of Vim on Mac OS X
+	v10.8 or later.  When on, Vim will render the text a little lighter
+	which looks nice with a dark colorscheme.
+	Note: Currently this option only has an effect if
+	'Use Core Text renderer' is enabled in the GUI preferences pane.
+
 				*'macmeta'* *'mmta'* *'nomacmeta'* *'nommta'*
 'macmeta'		boolean	(default off)
 			local to buffer

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -785,6 +785,7 @@ Short explanation of each option:		*option-list*
 'macatsui'		    Mac GUI: use ATSUI text drawing
 'macligatures'		    display ligatures (MacVim GUI only)
 'macmeta'	  'mmta'    use option as meta key (MacVim GUI only)
+'macthinstrokes'	    render the text lighter by using thin strokes (MacVim GUI only)
 'magic'			    changes special characters in search patterns
 'makeef'	  'mef'     name of the errorfile for ":make"
 'makeprg'	  'mp'	    program to use for the ":make" command

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -433,6 +433,7 @@ $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 'macatsui'	options.txt	/*'macatsui'*
 'macligatures'	options.txt	/*'macligatures'*
 'macmeta'	options.txt	/*'macmeta'*
+'macthinstrokes'	options.txt	/*'macthinstrokes'*
 'magic'	options.txt	/*'magic'*
 'makeef'	options.txt	/*'makeef'*
 'makeprg'	options.txt	/*'makeprg'*
@@ -614,6 +615,7 @@ $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 'nomacatsui'	options.txt	/*'nomacatsui'*
 'nomacligatures'	options.txt	/*'nomacligatures'*
 'nomacmeta'	options.txt	/*'nomacmeta'*
+'nomacthinstrokes'	options.txt	/*'nomacthinstrokes'*
 'nomagic'	options.txt	/*'nomagic'*
 'nomh'	options.txt	/*'nomh'*
 'noml'	options.txt	/*'noml'*

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -665,6 +665,8 @@ if has("gui")
     call <SID>BinOptionG("macligatures", &macligatures)
     call append("$", "macmeta\tuse option as meta key")
     call append("$", "\t(local to buffer)")
+    call append("$", "macthinstrokes\tuse thin strokes")
+    call <SID>BinOptionG("macthinstrokes", &macthinstrokes)
     call <SID>BinOptionL("mmta")
   endif
 endif

--- a/src/MacVim/MMBackend.h
+++ b/src/MacVim/MMBackend.h
@@ -135,6 +135,7 @@ extern NSTimeInterval MMBalloonEvalInternalDelay;
 
 - (void)setAntialias:(BOOL)antialias;
 - (void)setLigatures:(BOOL)ligatures;
+- (void)setThinStrokes:(BOOL)thinStrokes;
 - (void)setBlurRadius:(int)radius;
 
 - (void)updateModifiedFlag;

--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -1183,6 +1183,13 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
     [self queueMessage:msgid data:nil];
 }
 
+- (void)setThinStrokes:(BOOL)thinStrokes
+{
+    int msgid = thinStrokes ? EnableThinStrokesMsgID : DisableThinStrokesMsgID;
+
+    [self queueMessage:msgid data:nil];
+}
+
 - (void)setBlurRadius:(int)radius
 {
     NSMutableData *data = [NSMutableData data];

--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -29,6 +29,7 @@
     float                       fontDescent;
     BOOL                        antialias;
     BOOL                        ligatures;
+    BOOL                        thinStrokes;
     NSMutableArray              *drawData;
 
     MMTextViewHelper            *helper;
@@ -77,6 +78,7 @@
 - (void)setMouseShape:(int)shape;
 - (void)setAntialias:(BOOL)state;
 - (void)setLigatures:(BOOL)state;
+- (void)setThinStrokes:(BOOL)state;
 - (void)setImControl:(BOOL)enable;
 - (void)activateIm:(BOOL)enable;
 - (void)checkImState;

--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -48,6 +48,10 @@
 #define kCTFontOrientationDefault kCTFontDefaultOrientation
 #endif // MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_8
 
+extern void CGContextSetFontSmoothingStyle(CGContextRef, int);
+extern int CGContextGetFontSmoothingStyle(CGContextRef);
+#define fontSmoothingStyleLight (2 << 3)
+
 #if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_7
     static void
 CTFontDrawGlyphs(CTFontRef fontRef, const CGGlyph glyphs[],
@@ -394,6 +398,11 @@ defaultAdvanceForFont(NSFont *font)
 - (void)setLigatures:(BOOL)state
 {
     ligatures = state;
+}
+
+- (void)setThinStrokes:(BOOL)state
+{
+    thinStrokes = state;
 }
 
 - (void)setImControl:(BOOL)enable
@@ -1299,6 +1308,13 @@ recurseDraw(const unichar *chars, CGGlyph *glyphs, CGPoint *positions,
 
     CGContextSaveGState(context);
 
+    int originalFontSmoothingStyle = 0;
+    if (thinStrokes) {
+        CGContextSetShouldSmoothFonts(context, YES);
+        originalFontSmoothingStyle = CGContextGetFontSmoothingStyle(context);
+        CGContextSetFontSmoothingStyle(context, fontSmoothingStyleLight);
+    }
+
     // NOTE!  'cells' is zero if we're drawing a composing character
     CGFloat clipWidth = cells > 0 ? cells*cellSize.width : w;
     CGRect clipRect = { {x, y}, {clipWidth, cellSize.height} };
@@ -1389,6 +1405,8 @@ recurseDraw(const unichar *chars, CGGlyph *glyphs, CGPoint *positions,
     recurseDraw(chars, glyphs, positions, length, context, fontRef, fontCache, ligatures);
 
     CFRelease(fontRef);
+    if (thinStrokes)
+        CGContextSetFontSmoothingStyle(context, originalFontSmoothingStyle);
     CGContextRestoreGState(context);
 }
 

--- a/src/MacVim/MMTextView.h
+++ b/src/MacVim/MMTextView.h
@@ -21,6 +21,7 @@
     int                 insertionPointFraction;
     BOOL                antialias;
     BOOL                ligatures;
+    BOOL                thinStrokes;
     NSRect              *invertRects;
     int                 numInvertRects;
 
@@ -34,6 +35,7 @@
 - (void)setMouseShape:(int)shape;
 - (void)setAntialias:(BOOL)antialias;
 - (void)setLigatures:(BOOL)ligatures;
+- (void)setThinStrokes:(BOOL)thinStrokes;
 - (void)setImControl:(BOOL)enable;
 - (void)activateIm:(BOOL)enable;
 - (void)checkImState;

--- a/src/MacVim/MMTextView.m
+++ b/src/MacVim/MMTextView.m
@@ -312,6 +312,11 @@
     ligatures = state;
 }
 
+- (void)setThinStrokes:(BOOL)state
+{
+    thinStrokes = state;
+}
+
 - (void)setImControl:(BOOL)enable
 {
     [helper setImControl:enable];

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -806,6 +806,10 @@ static BOOL isUnsafeMessage(int msgid);
         [[[windowController vimView] textView] setLigatures:YES];
     } else if (DisableLigaturesMsgID == msgid) {
         [[[windowController vimView] textView] setLigatures:NO];
+    } else if (EnableThinStrokesMsgID == msgid) {
+        [[[windowController vimView] textView] setThinStrokes:YES];
+    } else if (DisableThinStrokesMsgID == msgid) {
+        [[[windowController vimView] textView] setThinStrokes:NO];
     } else if (SetVimStateMsgID == msgid) {
         NSDictionary *dict = [NSDictionary dictionaryWithData:data];
         if (dict) {

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -203,6 +203,8 @@ enum {
     SetBlurRadiusMsgID,
     EnableLigaturesMsgID,
     DisableLigaturesMsgID,
+    EnableThinStrokesMsgID,
+    DisableThinStrokesMsgID,
     LastMsgID   // NOTE: MUST BE LAST MESSAGE IN ENUM!
 };
 

--- a/src/MacVim/MacVim.m
+++ b/src/MacVim/MacVim.m
@@ -102,6 +102,8 @@ char *MessageStrings[] =
     "SetBlurRadiusMsgID",
     "EnableLigaturesMsgID",
     "DisableLigaturesMsgID",
+    "EnableThinStrokesMsgID",
+    "DisableThinStrokesMsgID",
     "END OF MESSAGE IDs"     // NOTE: Must be last!
 };
 

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -1818,6 +1818,11 @@ gui_macvim_set_ligatures(int ligatures)
 {
     [[MMBackend sharedInstance] setLigatures:ligatures];
 }
+    void
+gui_macvim_set_thinstrokes(int thinStrokes)
+{
+    [[MMBackend sharedInstance] setThinStrokes:thinStrokes];
+}
 
     void
 gui_macvim_wait_for_startup()

--- a/src/option.c
+++ b/src/option.c
@@ -1834,6 +1834,11 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 #endif
 			    {(char_u *)FALSE, (char_u *)0L}},
+#ifdef FEAT_GUI_MACVIM
+    {"macthinstrokes", NULL,  P_BOOL|P_VI_DEF|P_RCLR,
+			    (char_u *)&p_macthinstrokes, PV_NONE,
+			    {(char_u *)FALSE, (char_u *)0L}},
+#endif
     {"magic",	    NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_magic, PV_NONE,
 			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
@@ -8237,6 +8242,10 @@ set_bool_option(
     else if ((int *)varp == &p_macligatures)
     {
         gui_macvim_set_ligatures(p_macligatures);
+    }
+    else if ((int*)varp == &p_macthinstrokes)
+    {
+        gui_macvim_set_thinstrokes(p_macthinstrokes);
     }
 #endif
 

--- a/src/option.h
+++ b/src/option.h
@@ -643,6 +643,7 @@ EXTERN int	p_macatsui;	/* 'macatsui' */
 #endif
 #ifdef FEAT_GUI_MACVIM
 EXTERN int	p_macligatures;	/* 'macligatures' */
+EXTERN int	p_macthinstrokes;	/* 'macthinstrokes' */
 #endif
 EXTERN int	p_magic;	/* 'magic' */
 #ifdef FEAT_QUICKFIX

--- a/src/proto/gui_macvim.pro
+++ b/src/proto/gui_macvim.pro
@@ -212,6 +212,7 @@ void gui_macvim_update_modified_flag();
 void gui_macvim_add_to_find_pboard(char_u *pat);
 void gui_macvim_set_antialias(int antialias);
 void gui_macvim_set_ligatures(int ligatures);
+void gui_macvim_set_thinstrokes(int thinStrokes);
 void gui_macvim_set_blur(int blur);
 
 int16_t odb_buffer_close(buf_T *buf);


### PR DESCRIPTION
The macthinstrokes option renders the text a
little lighter which looks nice when using a dark
colorscheme and a retina display.