### PR TITLE
Revert "Add themes under packpath to Edit > Color Scheme."

### DIFF
--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -389,7 +389,6 @@ endfun
 
 " get NL separated string with file names
 let s:n = globpath(&runtimepath, "colors/*.vim")
-let s:n .= globpath(&packpath, "pack/*/{opt,start}/*/colors/*.vim")
 
 " split at NL, Ignore case for VMS and windows, sort on name
 let s:names = sort(map(split(s:n, "\n"), 'substitute(v:val, "\\c.*[/\\\\:\\]]\\([^/\\\\:]*\\)\\.vim", "\\1", "")'), 1)


### PR DESCRIPTION
Reverts macvim-dev/macvim#331
Fix #351 