### PR TITLE
Report focus change on window key (not main)

### DIFF
--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -969,7 +969,6 @@
 - (void)windowDidBecomeMain:(NSNotification *)notification
 {
     [[MMAppController sharedInstance] setMainMenu:[vimController mainMenu]];
-    [vimController sendMessage:GotFocusMsgID data:nil];
 
     if ([vimView textView]) {
         NSFontManager *fm = [NSFontManager sharedFontManager];
@@ -977,7 +976,12 @@
     }
 }
 
-- (void)windowDidResignMain:(NSNotification *)notification
+- (void)windowDidBecomeKey:(NSNotificationCenter *)notification
+{
+    [vimController sendMessage:GotFocusMsgID data:nil];
+}
+
+- (void)windowDidResignKey:(NSNotification *)notification
 {
     [vimController sendMessage:LostFocusMsgID data:nil];
 }


### PR DESCRIPTION
MacVim should report `FocusGained` and `FocusLost` events not just when its windows become main, but when they become key — if a panel is opened, or a background application (i.e. an `LSUIElement` app) becomes active, MacVim should reflect the focus state.

For example, I use [vim-focusclip](https://github.com/idbrii/vim-focusclip) to avoid polluting my clipboard with vim yanks and deletes; when I go to paste from my clipboard, I often bring up the UI for my clipboard manager (in this case, LaunchBar). Terminals send `FocusLost` and `FocusGained` events when this happens (because, say, iTerm2 sends a `FocusLost` event when its main window loses key, even though it is still the main window), but MacVim does not, because it only reports focus events when a window becomes or loses main. This brings feature parity, and in general, I think this is a more useful reflection of window focus.