### PR TITLE
Fix problems with non-native fullscreen and mac 10.12

### DIFF
--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -38,7 +38,8 @@
     CGGlyph                     *glyphs;
     CGPoint                     *positions;
     NSMutableArray              *fontCache;
-
+    CGLayerRef                  layer;
+    CGContextRef                layerContext;
     // These are used in MMCoreTextView+ToolTip.m
     id trackingRectOwner_;              // (not retained)
     void *trackingRectUserData_;


### PR DESCRIPTION
When you set a borderless style on a subclassed window in 10.12, the
original behavior in which you could progressively draw partially on a
stale window seems to be gone; it blanks the thing after each draw. It's
totally unclear to me whether the CoreText engine as written was ever
"correct", or maybe it just "accidentally worked" -- no documentation on
the internets seems to indicate you're allowed to only draw partial
updates to a raw window in drawRect.

This PR works around that by drawing onto a persistent background layer
which we then blit to the screen.

nn-fullscreen seems to work, as do most common operations.  This PR also
makes resizing a CoreGraphics view much smoother; the old code was
pretty flickery.

I haven't dealt with DrawSignDrawType yet; not sure how to trigger that
code path.

maintainers: am I on the right track here? Any tips?

addreses #312 (though not fully, yet).