### PR TITLE
Fix #401

### DIFF
--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -410,7 +410,9 @@ gui_mch_wait_for_chars(int wtime)
 # ifdef FEAT_TIMERS
     did_add_timer = FALSE;
 # endif
+
     parse_queued_messages();
+
 # ifdef FEAT_TIMERS
     if (did_add_timer)
         return FAIL;

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -407,8 +407,18 @@ gui_mch_wait_for_chars(int wtime)
     [[MMBackend sharedInstance] flushQueue:YES];
 
 #ifdef MESSAGE_QUEUE
+# ifdef FEAT_TIMERS
+    did_add_timer = FALSE;
+# endif
     parse_queued_messages();
+# ifdef FEAT_TIMERS
+    if (did_add_timer)
+        return FAIL;
+# endif
 #endif
+
+    if (input_available())
+        return OK;
 
     return [[MMBackend sharedInstance] waitForInput:wtime];
 }

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1370,7 +1370,7 @@ function MyExitTimeCb(job, status)
 endfunction
 
 func Test_exit_callback_interval()
-  if !has('job') || has('gui_macvim')
+  if !has('job')
     return
   endif
 


### PR DESCRIPTION
#401 GUI should check for the events about job/channel/timer more often.

Additionally, this changes enable GUI to pass `Test_exit_callback_interval()`.