### PR TITLE
fix up core graphics full-screen animations

### DIFF
--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -39,6 +39,8 @@
     CGPoint                     *positions;
     NSMutableArray              *fontCache;
 
+    BOOL                        shouldBlankUntilRedraw;
+
     BOOL                        cgLayerEnabled;
     CGLayerRef                  cgLayer;
     CGContextRef                cgLayerContext;
@@ -90,7 +92,7 @@
 - (NSRect)rectForRow:(int)row column:(int)column numRows:(int)nr
           numColumns:(int)nc;
 - (void)setCGLayerEnabled:(BOOL)enabled;
-
+- (void)blankUntilRedraw;
 //
 // NSTextView methods
 //

--- a/src/MacVim/MMFullScreenWindow.m
+++ b/src/MacVim/MMFullScreenWindow.m
@@ -151,6 +151,8 @@ enum {
         didBlend = YES;
     }
 
+    [[view textView] blankUntilRedraw];
+
     // NOTE: The window may have moved to another screen in between init.. and
     // this call so set the frame again just in case.
     [self setFrame:[[target screen] frame] display:NO];
@@ -236,6 +238,8 @@ enum {
             kCGDisplayBlendSolidColor, .0, .0, .0, true);
         didBlend = YES;
     }
+
+    [[view textView] blankUntilRedraw];
 
     // restore old vim view size
     int currRows, currColumns;

--- a/src/MacVim/MMTextView.h
+++ b/src/MacVim/MMTextView.h
@@ -73,4 +73,5 @@
 - (void)deleteSign:(NSString *)signName;
 - (void)setToolTipAtMousePoint:(NSString *)string;
 - (void)setCGLayerEnabled:(BOOL)enabled;
+- (void)blankUntilRedraw;
 @end

--- a/src/MacVim/MMTextView.m
+++ b/src/MacVim/MMTextView.m
@@ -522,6 +522,11 @@
     // ONLY in Core Text!
 }
 
+- (void)blankUntilRedraw
+{
+    // ONLY in Core Text!
+}
+
 - (BOOL)isOpaque
 {
     return NO;


### PR DESCRIPTION
This improves a "flickering" seen when entering and exiting full-screen, which is due to the layer code incorrectly drawing the non-fullscreen layer (often with the vim command `set invfu`) as an intermediate state.  Here we just tell the layer code to draw an empty screen until it receives the "redraw-the-screen" batch of commands from vim.

This solution isn't 100%, as it doesn't seem possible to control just when cocoa actually does work; sometimes the resize of the window doesn't take affect until some milliseconds after we start fading up into fullscreen, which means you catch a dim view of the old title bar whilst fading up.  Conversely, sometimes when exiting fullscreen the resize event hasn't taken place yet and you end 
fading out and then still painting the fullscreen window.

In short; I think this improves things, but not all the way.