### PR TITLE
draw the layer from the background thread

### DIFF
--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -42,6 +42,7 @@
     BOOL                        cgLayerEnabled;
     CGLayerRef                  cgLayer;
     CGContextRef                cgLayerContext;
+    NSLock                      *cgLayerLock;
 
     // These are used in MMCoreTextView+ToolTip.m
     id trackingRectOwner_;              // (not retained)


### PR DESCRIPTION
during layer draw we know what parts of the screen will need repainting, so we can call set setNeedsDisplayInRect and do a partial draw of the screen.  This brings down overall keyDown-to-drawRect(finish) latency when in "layer" mode from 17ms to 4.5ms (about what the "stock" CoreText renderer does).

With this PR, the layer-backed code is about as fast as the standard code (I measured average latency with https://github.com/osheroff/macvim/commit/56bb7eb), fast enough that I think we could swap out the old draw-direct code with the layer code, but I thought I would offer that code in a separate PR so you could easily see the methods I'm using here. 

cc @splhack @nuc who apparently can feel 10ms of latency much better than I can.