### PR TITLE
Introduce MMUseCGLayerAlways user default

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -233,6 +233,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         [NSNumber numberWithBool:NO],     MMSuppressTerminationAlertKey,
         [NSNumber numberWithBool:YES],    MMNativeFullScreenKey,
         [NSNumber numberWithDouble:0.25], MMFullScreenFadeTimeKey,
+        [NSNumber numberWithBool:NO],     MMUseCGLayerAlwaysKey,
         nil];
 
     [[NSUserDefaults standardUserDefaults] registerDefaults:dict];

--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -132,6 +132,8 @@ defaultAdvanceForFont(NSFont *font)
     if (!(self = [super initWithFrame:frame]))
         return nil;
 
+    cgLayerEnabled = [[NSUserDefaults standardUserDefaults]
+            boolForKey:MMUseCGLayerAlwaysKey];
     cgLayerLock = [NSLock new];
 
     // NOTE!  It does not matter which font is set here, Vim will set its

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -52,6 +52,7 @@ extern NSString *MMSuppressTerminationAlertKey;
 extern NSString *MMNativeFullScreenKey;
 extern NSString *MMUseMouseTimeKey;
 extern NSString *MMFullScreenFadeTimeKey;
+extern NSString *MMUseCGLayerAlwaysKey;
 
 
 // Enum for MMUntitledWindowKey

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -48,6 +48,7 @@ NSString *MMSuppressTerminationAlertKey = @"MMSuppressTerminationAlert";
 NSString *MMNativeFullScreenKey         = @"MMNativeFullScreen";
 NSString *MMUseMouseTimeKey             = @"MMUseMouseTime";
 NSString *MMFullScreenFadeTimeKey       = @"MMFullScreenFadeTime";
+NSString *MMUseCGLayerAlwaysKey         = @"MMUseCGLayerAlways";
 
 
 


### PR DESCRIPTION
Add user default key `MMUseCGLayerAlways` to control to use CGLayer
rendering always in Core Text Renderer.

    $ defaults write org.vim.MacVim MMUseCGLayerAlways -bool YES