### PR TITLE
Fix for menu not found: Tools.Spelling.To Next error

### DIFF
--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -1241,7 +1241,7 @@ if has("gui_macvim")
   macm Edit.Font.Smaller			key=<D--> action=fontSizeDown:
   macm Edit.Emoji\ &&\ Symbols			key=<D-C-Space> action=orderFrontCharacterPalette:
 
-  macm Tools.Spelling.To\ Next\ error<Tab>]s	key=<D-;>
+  macm Tools.Spelling.To\ Next\ Error<Tab>]s	key=<D-;>
   macm Tools.Spelling.Suggest\ Corrections<Tab>z=   key=<D-:>
   macm Tools.Make<Tab>:make			key=<D-b>
   macm Tools.List\ Errors<Tab>:cl		key=<D-l>


### PR DESCRIPTION
After pulling and building the most recent changes, I see these messages when I start MacVim:

```
Error detected while processing /Applications/MacVim.app/Contents/Resources/vim/runtime/menu.vim:
line 1244:
E334: Menu not found: Tools.Spelling.To\ Next\ error^I]s
E334: Menu not found: Tools.Spelling.To\ Next\ error^I]s
```

It appears that a recent Vim patch made the "e" in "error" uppercase, so we have to make the same change in our macmenu command.
