### PR TITLE
Workaround: Skip Test_edit_MOUSE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ script:
   - rm -f result; $VIMCMD -g -f -c "redir>result" -c "py3 import sys; print(\"Test\")" -c "redir END" -c q; cat result; echo; grep -q -w Test result
   - rm -f result; $VIMCMD -g -f -c "redir>result" -c "ruby puts(\"Test\")" -c "redir END" -c q; cat result; echo; grep -q -w Test result
   - make test
-  #- make -C src/testdir clean
-  #- make -C src testgui
+  - make -C src/testdir clean
+  - make -C src testgui
 
 before_deploy:
   - make -C src macvim-dmg

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -1054,7 +1054,7 @@ endfunc
 
 func! Test_edit_MOUSE()
   " This is a simple test, since we not really using the mouse here
-  if !has("mouse")
+  if !has("mouse") || (has("gui_macvim") && has("gui_running"))
     return
   endif
   10new


### PR DESCRIPTION
I confirmed that Test_edit_MOUSE (test_edit.vim) has blocked testgui on travis.