### PR TITLE
Fix changing font size in full screen.

### DIFF
--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -40,6 +40,7 @@
     int                 userCols;
     NSPoint             userTopLeft;
     NSPoint             defaultTopLeft;
+    NSSize              desiredWindowSize;
     NSToolbar           *toolbar;
     BOOL                resizingDueToMove;
     int                 blurRadius;

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -594,11 +594,12 @@
         // TODO: What if the resize message fails to make it back?
         if (!didMaximize) {
             NSSize originalSize = [vimView frame].size;
-            NSSize contentSize = [vimView desiredSize];
-            contentSize = [self constrainContentSizeToScreenSize:contentSize];
             int rows = 0, cols = 0;
-            contentSize = [vimView constrainRows:&rows columns:&cols
-                                          toSize:contentSize];
+            NSSize contentSize = [vimView constrainRows:&rows columns:&cols
+                                                 toSize:
+                                  fullScreenWindow ? [fullScreenWindow frame].size :
+                                  fullScreenEnabled ? desiredWindowSize :
+                                  [self constrainContentSizeToScreenSize:[vimView desiredSize]]];
             [vimView setFrameSize:contentSize];
 
             if (fullScreenWindow) {
@@ -1001,6 +1002,11 @@
             (int)(NSMaxY([[decoratedWindow screen] frame]) - topLeft.y) };
     NSData *data = [NSData dataWithBytes:pos length:2*sizeof(int)];
     [vimController sendMessage:SetWindowPositionMsgID data:data];
+}
+
+- (NSSize)windowWillResize:(NSWindow *)sender toSize:(NSSize)frameSize {
+    desiredWindowSize = frameSize;
+    return frameSize;
 }
 
 - (void)windowDidResize:(id)sender


### PR DESCRIPTION
Fixes #127 and #488. Please take a look! (cc @chdiza)

## Choose how to resize the Vim view based on the full screen mode.

- Native full screen: Use the last externally-set window size. This lets Split View work without slowly growing or shrinking.

- Non-native full screen: Use the size of the full screen window.

- Not full screen: Use `[vimView desiredSize]` (unchanged).

This is somewhat nasty, but the different full screen code paths behave differently enough that there doesn't seem to be one universally-correct answer. It would be great to simplify them.