### PR TITLE
fix expansion issue in mvim

### DIFF
--- a/src/MacVim/mvim
+++ b/src/MacVim/mvim
@@ -11,22 +11,22 @@
 #
 
 # Find Vim executable
-if [ -L $0 ]; then
+if [ -L "$0" ]; then
 	# readlink -f
 	curdir=`pwd -P`
 	self_path=$0
-	cd `dirname $self_path`
-	while [ -L $self_path ]; do
+	cd "`dirname $self_path`"
+	while [ -L "$self_path" ]; do
 		self_path=`readlink $self_path`
-		cd `dirname $self_path`
+		cd "`dirname $self_path`"
 		self_path=`basename $self_path`
 	done
 	binary="`pwd -P`/../MacOS/Vim"
-	cd $curdir
+	cd "$curdir"
 else
 	binary="`dirname "$0"`/../MacOS/Vim"
 fi
-if ! [ -x $binary ]; then
+if ! [ -x "$binary" ]; then
 	echo "Sorry, cannot find Vim executable."
 	exit 1
 fi


### PR DESCRIPTION
Currently the mvim script fails if there's a space in you $PWD, this PR adds proper quoting to avoid word splitting upon expansion.