### PR TITLE
Use proper NSImageName constant NSImageNameAdvanced in Preferences panel

### DIFF
--- a/src/MacVim/MMPreferenceController.m
+++ b/src/MacVim/MMPreferenceController.m
@@ -36,7 +36,7 @@ static void loadSymbols()
     void *ptr;
     if ((ptr = dlsym(RTLD_DEFAULT, "NSImageNamePreferencesGeneral")) != NULL)
         nsImageNamePreferencesGeneral = *(NSString**)ptr;
-    if ((ptr = dlsym(RTLD_DEFAULT, "NSImageNamePreferencesAdvanced")) != NULL)
+    if ((ptr = dlsym(RTLD_DEFAULT, "NSImageNameAdvanced")) != NULL)
         nsImageNamePreferencesAdvanced = *(NSString**)ptr;
 }
 


### PR DESCRIPTION
Use the proper NSImageName constant NSImageNameAdvanced in order to use the system provided icon for the Advanced tab of the Preferences panel. As far as I can tell, there is no NSImageNamePreferencesAdvanced which was the name previously used.