### PR TITLE
use NSTextStorage for speedups

### DIFF
--- a/src/MacVim/MMTextStorage.h
+++ b/src/MacVim/MMTextStorage.h
@@ -25,7 +25,7 @@ typedef struct {
 
 
 @interface MMTextStorage : NSTextStorage {
-    NSMutableAttributedString   *attribString;
+    NSTextStorage               *backingStore;
     int                         maxRows, maxColumns;
     int                         actualRows, actualColumns;
     NSAttributedString          *emptyRowString;


### PR DESCRIPTION
Replace NSMutableAttributesString with a concrete instance of
NSTextStorage that performs optimizations when processing
attribute changes.