### PR TITLE
Fix the responsiveness of `getchar(0)` 

### DIFF
--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -333,7 +333,7 @@ gui_mch_update(void)
     static CFAbsoluteTime lastTime = 0;
 
     CFAbsoluteTime nowTime = CFAbsoluteTimeGetCurrent();
-    if (nowTime - lastTime > 0.2) {
+    if (nowTime - lastTime > 1.0 / 30) {
         [[MMBackend sharedInstance] update];
         lastTime = nowTime;
     }

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -2301,7 +2301,7 @@ gui_macvim_add_channel(channel_T *channel, ch_part_T part)
                                0,
                                dispatch_get_main_queue());
     dispatch_source_set_event_handler(s, ^{
-        channel_read(channel, part, "gui_macvim_add_channel");
+        channel_may_read(channel, part, "gui_macvim_add_channel");
     });
     dispatch_resume(s);
     return s;

--- a/src/proto/channel.pro
+++ b/src/proto/channel.pro
@@ -33,6 +33,7 @@ void channel_clear(channel_T *channel);
 void channel_free_all(void);
 char_u *channel_read_block(channel_T *channel, ch_part_T part, int timeout);
 void common_channel_read(typval_T *argvars, typval_T *rettv, int raw);
+void channel_may_read(channel_T *channel, ch_part_T part, char *func);
 channel_T *channel_fd2channel(sock_T fd, ch_part_T *partp);
 void channel_handle_events(int only_keep_open);
 int channel_any_keep_open(void);
@@ -71,7 +72,4 @@ job_T *job_start(typval_T *argvars, jobopt_T *opt_arg);
 char *job_status(job_T *job);
 void job_info(job_T *job, dict_T *dict);
 int job_stop(job_T *job, typval_T *argvars, char *type);
-#ifdef FEAT_GUI_MACVIM
-void channel_read(channel_T *channel, ch_part_T part, char *func);
-#endif
 /* vim: set ft=c : */


### PR DESCRIPTION
fixes #522 

Now `getchar(0)` can only receive input up to 5 times per second, so it has a poor responsiveness.
This PR increases the frequency of calling `[MMBackend update]` (max 30 times/sec), and fixes above matter.