### PR TITLE
Fix: stopBlink checks whether should update cursor

### DIFF
--- a/src/MacVim/MMBackend.h
+++ b/src/MacVim/MMBackend.h
@@ -121,7 +121,7 @@ extern NSTimeInterval MMBalloonEvalInternalDelay;
 - (void)setMouseShape:(int)shape;
 - (void)setBlinkWait:(int)wait on:(int)on off:(int)off;
 - (void)startBlink;
-- (void)stopBlink;
+- (void)stopBlink:(BOOL)updateCursor;
 - (void)adjustLinespace:(int)linespace;
 - (void)adjustColumnspace:(int)columnspace;
 - (void)activate;

--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -1078,9 +1078,9 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
     }
 }
 
-- (void)stopBlink
+- (void)stopBlink:(BOOL)updateCursor
 {
-    if (MMBlinkStateOff == blinkState) {
+    if (MMBlinkStateOff == blinkState && updateCursor) {
         gui_update_cursor(TRUE, FALSE);
         [self flushQueue:YES];
     }

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -1254,9 +1254,7 @@ gui_mch_start_blink(void)
     void
 gui_mch_stop_blink(int may_call_gui_update_cursor)
 {
-    if (may_call_gui_update_cursor)
-        gui_update_cursor(TRUE, FALSE);
-    [[MMBackend sharedInstance] stopBlink];
+    [[MMBackend sharedInstance] stopBlink:may_call_gui_update_cursor];
 }
 
 


### PR DESCRIPTION
This PR will remove calling of `gui_update_cursor` in `gui_mch_stop_blink` and let `[MMBackend stopBlink]` take `updateCursor` argument in order to avoid calling `gui_update_cursor` twice.