### PR TITLE
GUI test should skip Test_syntax_c

### DIFF
--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -527,7 +527,7 @@ endfunc
 " Check highlighting for a small piece of C code with a screen dump.
 func Test_syntax_c()
   " Need to be able to run terminal Vim with 256 colors.
-  if !has('terminal') || has('win32')
+  if !has('terminal') || has('win32') || has('gui_running')
     return
   endif
   call writefile([


### PR DESCRIPTION
`Test_syntax_c` tests the content of the terminal window where Vim run on, but when on GUI test, `RunVimInTerminal` launches GUI Vim so then the terminal window will be blank.
Therefore `Test_syntax_c` and its cleanup will fail and influence later tests.

NOTE: I reported to the upstream. (https://github.com/vim/vim/pull/2666) This pull-req may be a quick-fix.