### PR TITLE
Fix ex_popup for MacVim

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -8766,7 +8766,8 @@ ex_tearoff(exarg_T *eap)
     static void
 ex_popup(exarg_T *eap)
 {
-# if defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_GTK)
+# if defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_GTK) \
+	|| defined(FEAT_GUI_MACVIM)
     if (gui.in_use)
 	gui_make_popup(eap->arg, eap->forceit);
 #  ifdef FEAT_TERM_POPUP_MENU


### PR DESCRIPTION
It appears that should use `gui_make_popup` in `ex_popup` for GUI MacVim.