### PR TITLE
Don't associate a single fd with both channel out and err

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1028,11 +1028,18 @@ channel_set_pipes(channel_T *channel, sock_T in, sock_T out, sock_T err)
 	channel_gui_unregister_one(channel, PART_ERR);
 # endif
 	ch_close_part(channel, PART_ERR);
-	channel->CH_ERR_FD = err;
-	channel->ch_to_be_closed |= (1 << PART_ERR);
-# if defined(FEAT_GUI)
-	channel_gui_register_one(channel, PART_ERR);
+# if defined(FEAT_GUI_MACVIM)
+	if (err == out && gui.in_use)
+	    channel->CH_ERR_FD = INVALID_FD;
+	else
 # endif
+	{
+	    channel->CH_ERR_FD = err;
+	    channel->ch_to_be_closed |= (1 << PART_ERR);
+# if defined(FEAT_GUI)
+	    channel_gui_register_one(channel, PART_ERR);
+# endif
+	}
     }
 }
 


### PR DESCRIPTION
fixes #579 (maybe there is more)

When register a single fd to dispatch-source twice (as ch-out and ch-err), the order of dispatching read-event of ch-out and ch-err cannot be determined.
Meanwhile, write-to-buffer is executed in the order of ch-out and ch-err.

1. receive read-event from ch-err ... (A)
2. receive read-eventfrom ch-out ... (B)
3. write the content of ch-out (B) to buffer
4. write the content of ch-err (A) to buffer

In this way the content of buffer becomes messed up.

Therefore, a single fd should be handled by a single handler.