### PR TITLE
Fix drawing screen in the case of TUI

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -6166,9 +6166,11 @@ screen_line(
 	    hl = ScreenAttrs[off_to + CHAR_CELLS];
 	    if (hl > HL_ALL)
 		hl = syn_attr2attr(hl);
-# ifndef FEAT_GUI_MACVIM /* see comment on subpixel antialiasing */
-	    if (hl & HL_BOLD)
+	    if ((hl & HL_BOLD)
+# ifdef FEAT_GUI_MACVIM /* see comment on subpixel antialiasing */
+		    || gui.in_use
 # endif
+		    )
 		redraw_this = TRUE;
 	}
 #endif
@@ -6299,9 +6301,11 @@ screen_line(
 		hl = ScreenAttrs[off_to];
 		if (hl > HL_ALL)
 		    hl = syn_attr2attr(hl);
-# ifndef FEAT_GUI_MACVIM /* see comment on subpixel antialiasing */
-		if (hl & HL_BOLD)
+		if ((hl & HL_BOLD)
+# ifdef FEAT_GUI_MACVIM /* see comment on subpixel antialiasing */
+			|| gui.in_use
 # endif
+			)
 		    redraw_next = TRUE;
 	    }
 #endif
@@ -6387,9 +6391,11 @@ screen_line(
 	    if (gui.in_use && (col > startCol || !redraw_this))
 	    {
 		hl = ScreenAttrs[off_to];
-# ifndef FEAT_GUI_MACVIM /* see comment on subpixel antialiasing */
-		if (hl > HL_ALL || (hl & HL_BOLD))
+		if (hl > HL_ALL || (hl & HL_BOLD)
+# ifdef FEAT_GUI_MACVIM /* see comment on subpixel antialiasing */
+			|| gui.in_use
 # endif
+			)
 		{
 		    int prev_cells = 1;
 # ifdef FEAT_MBYTE
@@ -7591,9 +7597,11 @@ screen_puts_len(
 
 		if (n > HL_ALL)
 		    n = syn_attr2attr(n);
-# ifndef FEAT_GUI_MACVIM /* see comment on subpixel antialiasing */
-		if (n & HL_BOLD)
+		if ((n & HL_BOLD)
+# ifdef FEAT_GUI_MACVIM /* see comment on subpixel antialiasing */
+			|| gui.in_use
 # endif
+			)
 		    force_redraw_next = TRUE;
 	    }
 #endif
@@ -8673,21 +8681,22 @@ screen_fill(
 # endif
 		   )
 		{
-# ifndef FEAT_GUI_MACVIM
+# ifdef FEAT_GUI_MACVIM
+		    /* Mac OS X does subpixel antialiasing which often causes a
+		     * glyph to spill over into neighboring cells.  For this
+		     * reason we always clear the neighboring glyphs whenever a
+		     * glyph is cleared, just like other GUIs cope with the
+		     * bold trick. */
+		    if (gui.in_use)
+			force_next = (ScreenLines[off] != ' ');
+		    else
+# endif
 		    if (ScreenLines[off] != ' '
 			    && (ScreenAttrs[off] > HL_ALL
 				|| ScreenAttrs[off] & HL_BOLD))
 			force_next = TRUE;
 		    else
 			force_next = FALSE;
-# else
-		    /* Mac OS X does subpixel antialiasing which often causes a
-		     * glyph to spill over into neighboring cells.  For this
-		     * reason we always clear the neighboring glyphs whenever a
-		     * glyph is cleared, just like other GUIs cope with the
-		     * bold trick. */
-		    force_next = (ScreenLines[off] != ' ');
-# endif
 		}
 #endif
 		ScreenLines[off] = c;


### PR DESCRIPTION
This PR will fix CI status.

Because of the previous fix for GUI issue (according to the source comments),
the state of the screen output on TUI has been different from the original.
Thus it should check `gui.in_use`.
