### PR TITLE
Fix version-check code

### DIFF
--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -285,14 +285,12 @@ gui_mch_init(void)
         [[MMBackend sharedInstance] addToMRU:filenames];
     }
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_10
-    {
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)]) {
 	NSOperatingSystemVersion version = {10, 13, 0};
 
 	is_macos_high_sierra_or_later =
 	    [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:version];
     }
-#endif
 
     return OK;
 }


### PR DESCRIPTION
In .travis.yml `MACOSX_DEPLOYMENT_TARGET=10.8` is set, thus, on Travis CI, version-check code is skipped and the issues #620 #632 have recurred in released MacVim.