### PR TITLE
Fix Double Wide Glyph Rendering

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -8386,7 +8386,7 @@ screen_char(unsigned off, int row, int col)
 	    /* not sure where the cursor is after drawing the ambiguous width
 	     * character */
 # ifdef FEAT_GUI_MACVIM
-           if (!gui.in_use)
+           if (*p_ambw == 'd' || !gui.in_use)
 # endif
                screen_cur_col = 9999;
 	}

--- a/src/screen.c
+++ b/src/screen.c
@@ -8385,7 +8385,15 @@ screen_char(unsigned off, int row, int col)
 	    }
 	    /* not sure where the cursor is after drawing the ambiguous width
 	     * character */
+# ifdef FEAT_GUI_MACVIM
+	    if (!gui.in_use)
+	    {
+		screen_cur_col = 9999;
+	    }
+# else
 	    screen_cur_col = 9999;
+# endif
+
 	}
 	else if (utf_char2cells(ScreenLinesUC[off]) > 1)
 	    ++screen_cur_col;

--- a/src/screen.c
+++ b/src/screen.c
@@ -8386,14 +8386,9 @@ screen_char(unsigned off, int row, int col)
 	    /* not sure where the cursor is after drawing the ambiguous width
 	     * character */
 # ifdef FEAT_GUI_MACVIM
-	    if (!gui.in_use)
-	    {
-		screen_cur_col = 9999;
-	    }
-# else
-	    screen_cur_col = 9999;
+           if (!gui.in_use)
 # endif
-
+               screen_cur_col = 9999;
 	}
 	else if (utf_char2cells(ScreenLinesUC[off]) > 1)
 	    ++screen_cur_col;


### PR DESCRIPTION
Applying the suggestions mentioned in this diff and tested locally.

https://github.com/macvim-dev/macvim/pull/648