### PR TITLE
Fix: A display of unicode composing characters by CoreText renderer

### DIFF
--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -477,41 +477,16 @@ gui_mch_delete_lines(int row, int num_lines)
 }
 
 
-    void
-gui_mch_draw_string(int row, int col, char_u *s, int len, int cells, int flags)
-{
-#ifdef FEAT_MBYTE
-    char_u *conv_str = NULL;
-    if (output_conv.vc_type != CONV_NONE) {
-        conv_str = string_convert(&output_conv, s, &len);
-        if (conv_str)
-            s = conv_str;
-    }
-#endif
-
-    [[MMBackend sharedInstance] drawString:s
-                                    length:len
-                                       row:row
-                                    column:col
-                                     cells:cells
-                                     flags:flags];
-#ifdef FEAT_MBYTE
-    if (conv_str)
-        vim_free(conv_str);
-#endif
-}
-
-
     int
 gui_macvim_draw_string(int row, int col, char_u *s, int len, int flags)
 {
-    int c, cn, cl, i;
+    MMBackend *backend = [MMBackend sharedInstance];
+#ifdef FEAT_MBYTE
+    int c, cw, cl, ccl;
     int start = 0;
     int endcol = col;
     int startcol = col;
     BOOL wide = NO;
-    MMBackend *backend = [MMBackend sharedInstance];
-#ifdef FEAT_MBYTE
     char_u *conv_str = NULL;
 
     if (output_conv.vc_type != CONV_NONE) {
@@ -519,45 +494,62 @@ gui_macvim_draw_string(int row, int col, char_u *s, int len, int flags)
         if (conv_str)
             s = conv_str;
     }
-#endif
 
     // Loop over each character and output text when it changes from normal to
     // wide and vice versa.
-    for (i = 0; i < len; i += cl) {
+    for (int i = 0; i < len; i += cl) {
         c = utf_ptr2char(s + i);
-        cn = utf_char2cells(c);
+        cw = utf_char2cells(c);
         cl = utf_ptr2len(s + i);
-        if (0 == cl)
+        ccl = utfc_ptr2len(s + i);
+        if (cl == 0)
             len = i;    // len must be wrong (shouldn't happen)
 
-        if (!utf_iscomposing(c)) {
-            if ((cn > 1 && !wide) || (cn <= 1 && wide)) {
-                // Changed from normal to wide or vice versa.
-                [backend drawString:(s+start) length:i-start
-                                   row:row column:startcol
-                                 cells:endcol-startcol
-                                 flags:(wide ? flags|DRAW_WIDE : flags)];
+        if (i > start && (cl < ccl || (cw > 1 && !wide) || (cw <= 1 && wide))) {
+            // Changed from normal to wide or vice versa.
+            [backend drawString:(s+start) length:i-start
+                            row:row column:startcol
+                          cells:endcol-startcol
+                          flags:flags|(wide ? DRAW_WIDE : 0)];
 
-                start = i;
-                startcol = endcol;
-            }
+            start = i;
+            startcol = endcol;
+        }
 
-            wide = cn > 1;
-            endcol += cn;
+        wide = cw > 1;
+        endcol += cw;
+
+        if (cl < ccl) {
+            // Changed from normal to wide or vice versa.
+            [backend drawString:(s+start) length:ccl
+                            row:row column:startcol
+                          cells:endcol-startcol
+                          flags:flags|DRAW_COMP|(wide ? DRAW_WIDE : 0)];
+
+            start = i + ccl;
+            startcol = endcol;
+            cl = ccl;
         }
     }
 
-    // Output remaining characters.
-    [backend drawString:(s+start) length:len-start
-                    row:row column:startcol cells:endcol-startcol
-                  flags:(wide ? flags|DRAW_WIDE : flags)];
+    if (len > start) {
+        // Output remaining characters.
+        [backend drawString:(s+start) length:len-start
+			row:row column:startcol
+		      cells:endcol-startcol
+		      flags:flags|(wide ? DRAW_WIDE : 0)];
+    }
 
-#ifdef FEAT_MBYTE
     if (conv_str)
         vim_free(conv_str);
-#endif
 
     return endcol - col;
+#else
+    [backend drawString:s length:len
+                    row:row column:col
+                  cells:len flags:flags];
+    return len;
+#endif
 }
 
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -2469,16 +2469,11 @@ gui_outstr_nowrap(
 #ifdef FEAT_GUI_GTK
     /* The value returned is the length in display cells */
     len = gui_gtk2_draw_string(gui.row, col, s, len, draw_flags);
+#elif defined(FEAT_GUI_MACVIM)
+    /* The value returned is the length in display cells */
+    len = gui_macvim_draw_string(gui.row, col, s, len, draw_flags);
 #else
 # ifdef FEAT_MBYTE
-#  ifdef FEAT_GUI_MACVIM
-    if (use_gui_macvim_draw_string)
-    {
-	/* The value returned is the length in display cells */
-	len = gui_macvim_draw_string(gui.row, col, s, len, draw_flags);
-    }
-    else
-#  endif
     if (enc_utf8)
     {
 	int	start;		/* index of bytes to be drawn */
@@ -2512,9 +2507,6 @@ gui_outstr_nowrap(
 		cells += cn;
 	    if (!comping || sep_comp)
 	    {
-#  ifdef FEAT_GUI_MACVIM
-		curr_wide = (cn > 1);
-#  else
 		if (cn > 1
 #  ifdef FEAT_XFONTSET
 			&& fontset == NOFONTSET
@@ -2523,7 +2515,6 @@ gui_outstr_nowrap(
 		    curr_wide = TRUE;
 		else
 		    curr_wide = FALSE;
-#  endif
 	    }
 	    cl = utf_ptr2len(s + i);
 	    if (cl == 0)	/* hit end of string */
@@ -2555,13 +2546,7 @@ gui_outstr_nowrap(
 		    if (prev_wide)
 			gui_mch_set_font(wide_font);
 		    gui_mch_draw_string(gui.row, scol, s + start, thislen,
-#  ifdef FEAT_GUI_MACVIM
-				    cells,
-				    draw_flags | (prev_wide ? DRAW_WIDE : 0)
-# else
-				    draw_flag
-#  endif
-				    );
+								  draw_flags);
 		    if (prev_wide)
 			gui_mch_set_font(font);
 		    start += thislen;
@@ -2591,17 +2576,13 @@ gui_outstr_nowrap(
 	    /* Draw a composing char on top of the previous char. */
 	    if (comping && sep_comp)
 	    {
-#  if !defined(FEAT_GUI_MACVIM) && \
-	(defined(__APPLE_CC__) && TARGET_API_MAC_CARBON)
+#  if defined(__APPLE_CC__) && TARGET_API_MAC_CARBON
 		/* Carbon ATSUI autodraws composing char over previous char */
 		gui_mch_draw_string(gui.row, scol, s + i, cl,
 						    draw_flags | DRAW_TRANSP);
 #  else
 		gui_mch_draw_string(gui.row, scol - cn, s + i, cl,
-#  ifdef FEAT_GUI_MACVIM
-					            0,
-#  endif
-					draw_flags | DRAW_TRANSP | DRAW_COMP);
+						    draw_flags | DRAW_TRANSP);
 #  endif
 		start = i + cl;
 	    }
@@ -2613,11 +2594,7 @@ gui_outstr_nowrap(
     else
 # endif
     {
-	gui_mch_draw_string(gui.row, col, s, len,
-#  ifdef FEAT_GUI_MACVIM
-						len,
-#  endif
-						draw_flags);
+	gui_mch_draw_string(gui.row, col, s, len, draw_flags);
 # ifdef FEAT_MBYTE
 	if (enc_dbcs == DBCS_JPNU)
 	{

--- a/src/proto/gui_macvim.pro
+++ b/src/proto/gui_macvim.pro
@@ -30,8 +30,6 @@ gui_mch_clear_all(void);
 gui_mch_clear_block(int row1, int col1, int row2, int col2);
     void
 gui_mch_delete_lines(int row, int num_lines);
-    void
-gui_mch_draw_string(int row, int col, char_u *s, int len, int cells, int flags);
     int
 gui_macvim_draw_string(int row, int col, char_u *s, int len, int flags);
     void


### PR DESCRIPTION
To reconstruct and use `gui_macvim_draw_string` for CoreText renderer.
This PR will fix #400 #604 https://github.com/vim-jp/issues/issues/1114.

Current:

* Cannot display correctly Unicode IVS and composing characters

![macvim-coretextrenderer 1](https://user-images.githubusercontent.com/943423/39391531-cc426e6e-4adf-11e8-84cb-d69472db156c.png)

Patched: almost fixed

* NOTE: cannot display correctly sequences with virama (e.g. devanagari. the last 3 lines)
* NOTE: `'macligatures'` doesn't work. (always ligatures at using FiraCode font) This may be undesirable?

![macvim-coretextrenderer 2](https://user-images.githubusercontent.com/943423/39391532-d05562ae-4adf-11e8-8ebe-928261055aa5.png)