### PR TITLE
Fix Core Text renderer

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -1431,7 +1431,7 @@ recurseDraw(const unichar *chars, CGGlyph *glyphs, CGPoint *positions,
         }
 
         CGContextSetRGBStrokeColor(context, RED(sp), GREEN(sp), BLUE(sp),
-                                 ALPHA(sp));
+                                   ALPHA(sp));
         CGContextStrokePath(context);
     }
 
@@ -1449,13 +1449,10 @@ recurseDraw(const unichar *chars, CGGlyph *glyphs, CGPoint *positions,
     CGContextSetFontSize(context, [font pointSize]);
 
     // Calculate position of each glyph relative to (x,y).
-    if (!composing) {
-        float xrel = 0;
-        for (unsigned i = 0; i < length; ++i) {
-            positions[i].x = xrel;
-            positions[i].y = .0;
-            xrel += w;
-        }
+    float xrel = composing ? .0 : w;
+    for (unsigned i = 0; i < length; ++i) {
+        positions[i].x = i * xrel;
+        positions[i].y = .0;
     }
 
     CTFontRef fontRef = (CTFontRef)(wide ? [fontWide retain]

--- a/src/screen.c
+++ b/src/screen.c
@@ -8380,7 +8380,13 @@ screen_char(unsigned off, int row, int col)
     {
 	char_u	    buf[MB_MAXBYTES + 1];
 
-	if (utf_ambiguous_width(ScreenLinesUC[off]))
+	if (utf_ambiguous_width(ScreenLinesUC[off])
+# ifdef FEAT_GUI_MACVIM
+		/* In the GUI, check if the cell width is actually 1 in order
+		 * to display 2-cells emoji correctly. */
+		&& (!gui.in_use || utf_char2cells(ScreenLinesUC[off]) == 1)
+# endif
+		)
 	{
 	    if (*p_ambw == 'd'
 # ifdef FEAT_GUI
@@ -8396,9 +8402,9 @@ screen_char(unsigned off, int row, int col)
 	    /* not sure where the cursor is after drawing the ambiguous width
 	     * character */
 # ifdef FEAT_GUI_MACVIM
-           if (*p_ambw == 'd' || !gui.in_use)
+	    if (*p_ambw == 'd' || !gui.in_use)
 # endif
-               screen_cur_col = 9999;
+		screen_cur_col = 9999;
 	}
 	else if (utf_char2cells(ScreenLinesUC[off]) > 1)
 	    ++screen_cur_col;


### PR DESCRIPTION
## Fix display of some unicode composing characters

e.g. A̮︠  (U+0041 032E FE20)

present:
![before](https://user-images.githubusercontent.com/943423/39919335-38e809a2-554e-11e8-9358-71922dcb5153.png)

patched:
![patched](https://user-images.githubusercontent.com/943423/39919338-3c421aca-554e-11e8-8a72-80a267524a17.png)


## Fix display of 2-cells emoji

e.g. 💻 (U+1F4BB)

present: the value of `&t_nd` (==`<C-L>`: move cursor right) is appended just after emoji
![before emoji](https://user-images.githubusercontent.com/943423/39919472-b652d692-554e-11e8-9c3b-c925e0abd264.png)

patched:
![patched emoji](https://user-images.githubusercontent.com/943423/39919480-bc91c13a-554e-11e8-9e30-1e1c1114487b.png)