### PR TITLE
Fix: terminal-window does not update immediately

### DIFF
--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -703,24 +703,14 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
                                          forMode:NSDefaultRunLoopMode];
         }
 
-        CFAbsoluteTime lastTime =
-            milliseconds >= 0 ? CFAbsoluteTimeGetCurrent() : .0;
-
         while (CFRunLoopRunInMode(kCFRunLoopDefaultMode, dt, true)
                 == kCFRunLoopRunHandledSource) {
-            // In order to ensure that all input (except for channel) on the
-            // run-loop has been processed we set the timeout to 0 and keep
-            // processing until the run-loop times out.
-            if ([inputQueue count] > 0 || input_available() || got_int) {
-                dt = 0.0;
+            // In order to ensure that all input on the run-loop has been
+            // processed we set the timeout to 0 and keep processing until the
+            // run-loop times out.
+            dt = 0.0;
+            if ([inputQueue count] > 0 || input_available() || got_int)
                 inputReceived = YES;
-            } else if (milliseconds >= 0) {
-                CFAbsoluteTime nowTime = CFAbsoluteTimeGetCurrent();
-
-                if ((dt -= nowTime - lastTime) <= 0.0)
-                    break;
-                lastTime = nowTime;
-            }
         }
 
         if ([inputQueue count] > 0 || input_available() || got_int)

--- a/src/gui.h
+++ b/src/gui.h
@@ -577,6 +577,6 @@ typedef enum
 # endif
 #endif /* FEAT_GUI_GTK */
 
-#if defined(UNIX) && !defined(FEAT_GUI_MAC)
+#if defined(UNIX) && !(defined(FEAT_GUI_MAC) || defined(FEAT_GUI_MACVIM))
 # define GUI_MAY_FORK
 #endif

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -981,6 +981,11 @@ write_to_term(buf_T *buffer, char_u *msg, channel_T *channel)
 	     * already */
 	    if (buffer == curbuf && curbuf->b_term != NULL)
 		update_cursor(curbuf->b_term, TRUE);
+#ifdef FEAT_GUI_MACVIM
+            /* Force a flush now for better experience of interactive shell. */
+	    if (gui.in_use)
+		gui_macvim_force_flush();
+#endif
 	}
 	else
 	    redraw_after_callback(TRUE);


### PR DESCRIPTION
This PR will fix #682.

https://github.com/macvim-dev/macvim/commit/7569a35f18ae175226e50238adf29b2c07398b31#diff-f83301fc7928a73575f006ec59a872b6L975

That dropped screen-updating code for MacVim.

In addition; Fix responsiveness related to channel I/O (MMBackend.m).