### PR TITLE
Fix fetchGlyphsAndAdvances() in CoreText renderer

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -1203,21 +1203,23 @@ fetchGlyphsAndAdvances(const CTLineRef line, CGGlyph *glyphs, CGSize *advances,
         CTRunRef run  = (CTRunRef)item;
         CFIndex count = CTRunGetGlyphCount(run);
 
-        if (count > 0 && count - offset > length)
-            count = length - offset;
+        if (count > 0) {
+            if (count > length - offset)
+                count = length - offset;
 
-        CFRange range = CFRangeMake(0, count);
+            CFRange range = CFRangeMake(0, count);
 
-        if (glyphs != NULL)
-            CTRunGetGlyphs(run, range, &glyphs[offset]);
-        if (advances != NULL)
-            CTRunGetAdvances(run, range, &advances[offset]);
-        if (positions != NULL)
-            CTRunGetPositions(run, range, &positions[offset]);
+            if (glyphs != NULL)
+                CTRunGetGlyphs(run, range, &glyphs[offset]);
+            if (advances != NULL)
+                CTRunGetAdvances(run, range, &advances[offset]);
+            if (positions != NULL)
+                CTRunGetPositions(run, range, &positions[offset]);
 
-        offset += count;
-        if (offset >= length)
-            break;
+            offset += count;
+            if (offset >= length)
+                break;
+        }
     }
 
     return offset;


### PR DESCRIPTION
This will fix #693 

 In `fetchGlyphsAndAdvances()` when `count < offset`, `count` is signed and `offset` is unsigned so `count - offset` is a huge value then `count - offset > length` is true and `count` becomes a wrong value (`count = length - offset`).
Thus `CTRungetGlyphs()` will fail.

I think it is the correct way to check if `count > length - offset`.