### PR TITLE
Really turn off ligatures when not turned on

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -1173,15 +1173,20 @@ lookupFont(NSMutableArray *fontCache, const unichar *chars, UniCharCount count,
 attributedStringForString(NSString *string, const CTFontRef font,
                           BOOL useLigatures)
 {
-    NSDictionary *attrs = [NSDictionary dictionaryWithObjectsAndKeys:
-                            (id)font, kCTFontAttributeName,
-                            // 2 - full ligatures including rare
-                            // 1 - basic ligatures
-                            // 0 - no ligatures
-                            [NSNumber numberWithBool:useLigatures],
-                            kCTLigatureAttributeName,
-                            nil
-    ];
+    NSDictionary *attrs = nil;
+    if (useLigatures) {
+        attrs = [NSDictionary dictionaryWithObjectsAndKeys:
+                 (id)font, kCTFontAttributeName,
+                 // 2 - full ligatures including rare
+                 // 1 - basic ligatures
+                 // 0 - only ligatures essential for proper rendering of text
+                 //     this option seems to render ligatures for some
+                 //     monospace fonts with ligatures, eg Iosevka, ...
+                 [NSNumber numberWithInt:1],
+                 kCTLigatureAttributeName,
+                 nil
+                 ];
+    }
 
     return CFAttributedStringCreate(NULL, (CFStringRef)string,
                                     (CFDictionaryRef)attrs);

--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -1182,10 +1182,10 @@ attributedStringForString(NSString *string, const CTFontRef font,
                  // 0 - only ligatures essential for proper rendering of text
                  //     this option seems to render ligatures for some
                  //     monospace fonts with ligatures, eg Iosevka, ...
-                 [NSNumber numberWithInt:1],
+                 [NSNumber numberWithBool: useLigatures],
                  kCTLigatureAttributeName,
                  nil
-                 ];
+                ];
     }
 
     return CFAttributedStringCreate(NULL, (CFStringRef)string,


### PR DESCRIPTION
According to the documentation for kCTLigatureAttributeName [1], the
value 0 turns on essential ligatures for the rendering of the given
text. It seems that some monospace fonts with ligature support, eg
Iosevka and Fira Code, declares all ligatures as essential. The
rendering is "a bit" broken when you use one of such fonts and turn off
ligatures. When we do not include kCTLigatureAttributeName at all in the
attributes dictionary, it seems that no ligatures are rendered, which is
what we want.

This fixes #711 (for `MMCoreTextView`).

[1] https://developer.apple.com/documentation/coretext/kctligatureattributename