### PR TITLE
Fix a display of some non-composing glyphs

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -1271,8 +1271,10 @@ recurseDraw(const unichar *chars, CGGlyph *glyphs, CGPoint *positions,
 {
     if (CTFontGetGlyphsForCharacters(fontRef, chars, glyphs, length)) {
         // All chars were mapped to glyphs, so draw all at once and return.
-        length = composeGlyphsForChars(chars, glyphs, positions, length,
-                                       fontRef, isComposing, useLigatures);
+        length = isComposing || useLigatures
+                ? composeGlyphsForChars(chars, glyphs, positions, length,
+                                        fontRef, isComposing, useLigatures)
+                : gatherGlyphs(glyphs, length);
         CTFontDrawGlyphs(fontRef, glyphs, positions, length, context);
         return;
     }


### PR DESCRIPTION
This will fix #696 #711 

* Use `composeGlyphsForChars()` only when draw composing characters or ligatures, otherwise use `gatherGlyphs()`