### PR TITLE
Fix touchbar doc typo

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -487,7 +487,7 @@ difference is that you use the special menu "TouchBar" instead of "ToolBar": >
 	:an TouchBar.Hello          :echo "Hello"<CR>
 
 The separators work similar to how toolbars work: >
-	:an TouchBar.-Sep-          <Nop>
+	:an TouchBar.-sep-          <Nop>
 	:an TouchBar.-space1-       <Nop>
 	:an TouchBar.-flexspace2-   <Nop>
 


### PR DESCRIPTION
I noticed that when using the new feature `an TouchBar.-sep- <Nop>` added a separator but an TouchBar.-Sep- <Nop>` did not. I think it could be a typo. This change makes the S lowercase. 