### PR TITLE
Add 'noet' to MacVim docs' modeline to keep it consistent with Vim

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -838,4 +838,4 @@ page.
 Solution: ~
 Post your question on the |vim_mac| mailing list and wait for an answer.
 
- vim:tw=78:sw=4:ts=8:ft=help:norl:
+ vim:tw=78:sw=4:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
See vim/vim#3263 for more info.