### PR TITLE
Add MAC_OS_X_VERSION_10_12_2 definition.

### DIFF
--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -29,6 +29,9 @@
 #ifndef MAC_OS_X_VERSION_10_12
 # define MAC_OS_X_VERSION_10_12 101200
 #endif
+#ifndef MAC_OS_X_VERSION_10_12_2
+# define MAC_OS_X_VERSION_10_12_2 101202
+#endif
 
 #ifndef NSAppKitVersionNumber10_10
 # define NSAppKitVersionNumber10_10 1343


### PR DESCRIPTION
Some build environments don't have MAC_OS_X_VERSION_10_12_2 definition.
It could cause the build error on macOS prior to 10.12.
This fix adds the MAC_OS_X_VERSION_10_12_2 based on Apple's header:
https://opensource.apple.com/source/xnu/xnu-3789.60.24/EXTERNAL_HEADERS/AvailabilityMacros.h.auto.html