### PR TITLE
Respect the font size setting of guifontwide.

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -328,7 +328,7 @@ defaultAdvanceForFont(NSFont *font)
         [fontWide release];
 
         // Use 'Apple Color Emoji' font for rendering emoji
-        CGFloat size = [font pointSize];
+        CGFloat size = [newFont pointSize] > [font pointSize] ? [font pointSize] : [newFont pointSize];
         NSFontDescriptor *emojiDesc = [NSFontDescriptor
             fontDescriptorWithName:@"Apple Color Emoji" size:size];
         NSFontDescriptor *newFontDesc = [newFont fontDescriptor];


### PR DESCRIPTION
Some of the fonts e.g., ProggyCleanTT expands the font height for
clearer view.
However, if the users set the customized guifontwide for CJK characters,
these CJK characters will be higher than the column height, and the top
of these characters will be cut.
This fix checks the pointSize of guifontwide, if it is bigger than the
guifont, then the font size will be fallback'd to guifont.
It provides an option to CJK users to set a smaller font size for guifontwide
to avoid the cut problem of CJK characters.