### PR TITLE
Vimrc python37

### DIFF
--- a/src/MacVim/vimrc
+++ b/src/MacVim/vimrc
@@ -17,10 +17,14 @@ set langmenu=none
 " Python2
 " MacVim uses Homebrew python2 if installed, otherwise configured one
 if exists("&pythondll") && exists("&pythonhome")
-  if filereadable("/usr/local/Frameworks/Python.framework/Versions/2.7/Python")
+  if filereadable("/usr/local/Library/Frameworks/Python.framework/Versions/2.7/Python")
     " Homebrew python 2.7
     set pythondll=/usr/local/Frameworks/Python.framework/Versions/2.7/Python
     set pythonhome=/usr/local/Frameworks/Python.framework/Versions/2.7
+  elseif filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python")
+    " MacPorts python 2.7
+    set pythondll=/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python
+    set pythonhome=/opt/local/Library/Frameworks/Python.framework/Versions/2.7
   endif
 endif
 
@@ -28,7 +32,11 @@ endif
 " MacVim uses Homebrew python3 if installed, next try to use python.org binary
 if exists("&pythonthreedll") && exists("&pythonthreehome") &&
       \ !filereadable(&pythonthreedll)
-  if filereadable("/Library/Frameworks/Python.framework/Versions/3.7/Python")
+  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.7/Python")
+    " MacPorts python 3.7
+    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.7/Python
+    set pythonthreehome=/opt/local/Library/Frameworks/Python.framework/Versions/3.7
+  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.7/Python")
     " https://www.python.org/downloads/mac-osx/
     set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.7/Python
     set pythonthreehome=/Library/Frameworks/Python.framework/Versions/3.7

--- a/src/MacVim/vimrc
+++ b/src/MacVim/vimrc
@@ -15,7 +15,9 @@ set backspace+=indent,eol,start
 set langmenu=none
 
 " Python2
-" MacVim uses Homebrew python2 if installed, otherwise configured one
+" MacVim is configured by default to use the pre-installed System python2
+" version. However, following code tries to find a Homebrew, MacPorts or
+" an installation from python.org:
 if exists("&pythondll") && exists("&pythonhome")
   if filereadable("/usr/local/Library/Frameworks/Python.framework/Versions/2.7/Python")
     " Homebrew python 2.7
@@ -25,11 +27,17 @@ if exists("&pythondll") && exists("&pythonhome")
     " MacPorts python 2.7
     set pythondll=/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python
     set pythonhome=/opt/local/Library/Frameworks/Python.framework/Versions/2.7
+  elseif filereadable("/Library/Frameworks/Python.framework/Versions/2.7/Python")
+    " https://www.python.org/downloads/mac-osx/
+    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/2.7/Python
+    set pythonthreehome=/Library/Frameworks/Python.framework/Versions/2.7
   endif
 endif
 
 " Python3
-" MacVim uses Homebrew python3 if installed, next try to use python.org binary
+" MacVim is configured by default to use Homebrew python3 version
+" If this cannot be found, following code tries to find a MacPorts
+" or an installation from python.org:
 if exists("&pythonthreedll") && exists("&pythonthreehome") &&
       \ !filereadable(&pythonthreedll)
   if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.7/Python")

--- a/src/MacVim/vimrc
+++ b/src/MacVim/vimrc
@@ -28,10 +28,10 @@ endif
 " MacVim uses Homebrew python3 if installed, next try to use python.org binary
 if exists("&pythonthreedll") && exists("&pythonthreehome") &&
       \ !filereadable(&pythonthreedll)
-  if filereadable("/Library/Frameworks/Python.framework/Versions/3.6/Python")
+  if filereadable("/Library/Frameworks/Python.framework/Versions/3.7/Python")
     " https://www.python.org/downloads/mac-osx/
-    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.6/Python
-    set pythonthreehome=/Library/Frameworks/Python.framework/Versions/3.6
+    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.7/Python
+    set pythonthreehome=/Library/Frameworks/Python.framework/Versions/3.7
   endif
 endif
 


### PR DESCRIPTION
Uses Python 3.7 from Python.org if installed (this was overlooked since build 150), credits to @kiryph
Adds checks MacPorts if python from it is used after Homebrew. 