### PR TITLE
Fix timer handling

### DIFF
--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -431,7 +431,16 @@ gui_mch_wait_for_chars(int wtime)
     [[MMBackend sharedInstance] flushQueue:YES];
 
 #ifdef MESSAGE_QUEUE
+# ifdef FEAT_TIMERS
+    did_add_timer = FALSE;
+# endif
+
     parse_queued_messages();
+
+# ifdef FEAT_TIMERS
+    if (did_add_timer)
+        wtime = 0;
+# endif
 #endif
 
     return [[MMBackend sharedInstance] waitForInput:wtime];


### PR DESCRIPTION
## Problem

On GUI, timer callback can be delayed when the callback is called from job/channel callback.

## Repro steps

sample.vim
```vim
function! TimerCb(timer)
  echo printf('elapsed: %f', reltimefloat(reltime(g:elapsed)))
endfunction

function! ExitCb(job, status)
  let g:elapsed = reltime()
  let g:timer = timer_start(1, 'TimerCb')
endfunction

let g:job = job_start(['true'], {'exit_cb': 'ExitCb'})
call repeat('A', 10000)
```

Start GUI MacVim:

`mvim --clean -g`

and do:

```vim
:so sample.vim
```

The message "elapsed: ..." does not show until any user-input (key, mouse, ..) given.
That is, `TimerCb` is delayed.

## Cause

Timer callback does not execute in `[MMBackend waitForInput]`.
Thus, when a timer is created in `parse_queued_messaged()` in `gui_mch_wait_for_chars()`, the timer is ignored while waiting for input.

## Solution

* Need check `did_add_timer` after `parse_queued_messaged()` in `gui_mch_wait_for_chars()`.