### PR TITLE
Add more Xcode / macOS versions to test in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ os:
   - osx
 
 osx_image:
+  - xcode7.3
+  - xcode8.3
   - xcode9.4
-  # Pending Core Text rendering fix for Mojave (#751)
-  #- xcode10.1
+  - xcode10.1
 
 compiler:
   - clang
@@ -74,6 +75,8 @@ deploy:
   file: src/MacVim/build/Release/MacVim.dmg
   skip_cleanup: true
   on:
+    # Pending Core Text rendering fix for Mojave (#751) before this can be swithced to Xcode 10 / macOS 10.14
+    condition: $TRAVIS_OSX_IMAGE = xcode9.4
     all_branches: true
     tags: true
     repo: macvim-dev/macvim


### PR DESCRIPTION
This helps make sure changes utilizing newer OS features won't break old
OS versions. CI now tests from Xcode 7.3 to 10.1.