### PR TITLE
Disable macOS native tabs (introduced in 10.12)

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -182,6 +182,20 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
                              CFSTR(""),
                              kCFPreferencesCurrentApplication);
 
+    if ([NSWindow respondsToSelector:@selector(setAllowsAutomaticWindowTabbing:)]) {
+        // Disable automatic tabbing on 10.12+. MacVim already has its own
+        // tabbing interface, so we don't want multiple hierarchy of tabs mixing
+        // native and Vim tabs. MacVim also doesn't work well with native tabs
+        // right now since it doesn't respond well to the size change, and it
+        // doesn't show the native menu items (e.g. move tab to new window) in
+        // all the tabs.
+        //
+        // Note: MacVim cannot use macOS native tabs for Vim tabs because Vim
+        // assumes only one tab can be shown at a time, and it would be hard to
+        // handle native tab's "move tab to a new window" functionality.
+        [NSWindow setAllowsAutomaticWindowTabbing:NO];
+    }
+
     int tabMinWidthKey;
     int tabMaxWidthKey;
     int tabOptimumWidthKey;


### PR DESCRIPTION
MacVim already has its own tabbing interface and native tabs (configurable in System Preferences) introduce a second layer of tabs which is confusing. MacVim also doesn't behave properly under such circumstances such as rendering artifacts, lacking proper native menu items (e.g. "Move Tab to New Window"), and keyboard shortcuts like Cmd-W don't work.

Note that it's currently not a good idea to implement Vim tabs using native tabs since they assume multiple NSWindow instances and assume they can be split off into multiple windows, which Vim doesn't support.