### PR TITLE
Fix dragging tabs not working properly

### DIFF
--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -2013,6 +2013,14 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
         // based.
         int idx = *((int*)bytes);
 
+        // Also, this index doesn't take itself into account, so if the move is
+        // to a later tab, need to add one to it since Vim's tabpage_move *does*
+        // count the current tab.
+        int curtab_index = tabpage_index(curtab);
+        if (idx >= curtab_index) {
+            idx += 1;
+        }
+
         tabpage_move(idx);
     } else if (SetTextDimensionsMsgID == msgid || LiveResizeMsgID == msgid
             || SetTextDimensionsNoResizeWindowMsgID == msgid

--- a/src/MacVim/PSMTabBarControl/source/PSMTabBarCell.m
+++ b/src/MacVim/PSMTabBarControl/source/PSMTabBarCell.m
@@ -338,7 +338,10 @@
     if(([self state] == NSOnState) && ([[_controlView styleName] isEqualToString:@"Metal"]))
         cellFrame.size.width += 1.0;
     [_controlView lockFocus];
-    NSBitmapImageRep *rep = [[[NSBitmapImageRep alloc] initWithFocusedViewRect:cellFrame] autorelease];
+
+    NSBitmapImageRep *rep = [[self controlView] bitmapImageRepForCachingDisplayInRect:cellFrame];
+    [[self controlView] cacheDisplayInRect:cellFrame toBitmapImageRep:rep];
+
     [_controlView unlockFocus];
     NSImage *image = [[[NSImage alloc] initWithSize:[rep size]] autorelease];
     [image addRepresentation:rep];


### PR DESCRIPTION
Fix tab dragging not working when dragging a tab to the right. Vim's tabmove has two positions where it doesn't do anything (where index is immediately before or after the current tab), so need to add 1 to index when moving tab to the right (after the current tab).

Also, fix tab dragging crashing under 10.14 due to deprecated API use the newer `cacheDisplayInRect:toBitmapImageRep:` API instead to work around this.

Fix #257