### PR TITLE
Add Mojave-style tabs, which also supports Dark Mode

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -726,8 +726,12 @@ prominent bugs/missing features.
   then opened in Preview where it may be printed.
 - The toolbar looks ugly and is not very useful.
 
-If you find new bugs then please post your findings to the vim_mac mailing
-list:							*vim_mac_group*   >
+Other bugs and issues are tracked on Github. If you find new bugs then please
+file an issue there: >
+	https://github.com/macvim-dev/macvim/issues
+
+There is also a vim_mac mailing list. You can also post your findings of bugs
+and issues there as well:				*vim_mac_group*   >
 	http://groups.google.com/group/vim_mac
 
 This is also the best place for making feature requests as well as for asking

--- a/src/MacVim/MMVimView.m
+++ b/src/MacVim/MMVimView.m
@@ -125,7 +125,7 @@ enum {
     [tabBarControl setDelegate:self];
     [tabBarControl setHidden:YES];
 
-    if (shouldUseYosemiteTabBarStyle()) {
+    if (shouldUseYosemiteTabBarStyle() || shouldUseMojaveTabBarStyle()) {
         CGFloat screenWidth = [[NSScreen mainScreen] frame].size.width;
         int tabMaxWidth = [ud integerForKey:MMTabMaxWidthKey];
         if (tabMaxWidth == 0)
@@ -133,8 +133,10 @@ enum {
         int tabOptimumWidth = [ud integerForKey:MMTabOptimumWidthKey];
         if (tabOptimumWidth == 0)
             tabOptimumWidth = screenWidth;
+        
+        NSString* tabStyleName = shouldUseMojaveTabBarStyle() ? @"Mojave" : @"Yosemite";
 
-        [tabBarControl setStyleNamed:@"Yosemite"];
+        [tabBarControl setStyleNamed:tabStyleName];
         [tabBarControl setCellMinWidth:[ud integerForKey:MMTabMinWidthKey]];
         [tabBarControl setCellMaxWidth:tabMaxWidth];
         [tabBarControl setCellOptimumWidth:tabOptimumWidth];

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -32,6 +32,9 @@
 #ifndef MAC_OS_X_VERSION_10_12_2
 # define MAC_OS_X_VERSION_10_12_2 101202
 #endif
+#ifndef MAC_OS_X_VERSION_10_14
+# define MAC_OS_X_VERSION_10_14 101400
+#endif
 
 #ifndef NSAppKitVersionNumber10_10
 # define NSAppKitVersionNumber10_10 1343

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -155,3 +155,4 @@ NSArray *normalizeFilenames(NSArray *filenames);
 
 
 BOOL shouldUseYosemiteTabBarStyle();
+BOOL shouldUseMojaveTabBarStyle();

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -306,3 +306,13 @@ shouldUseYosemiteTabBarStyle()
 { 
     return floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_10;
 }
+    BOOL
+shouldUseMojaveTabBarStyle()
+{
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
+    if (@available(macos 10.14, *)) {
+        return true;
+    }
+#endif
+    return false;
+}

--- a/src/MacVim/PSMTabBarControl/Media.xcassets/Contents.json
+++ b/src/MacVim/PSMTabBarControl/Media.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBackgroundActive.colorset/Contents.json
+++ b/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBackgroundActive.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "189",
+          "alpha" : "1.000",
+          "blue" : "188",
+          "green" : "189"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "40",
+          "alpha" : "1.000",
+          "blue" : "42",
+          "green" : "40"
+        }
+      }
+    }
+  ]
+}

--- a/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBackgroundActiveHighlight.colorset/Contents.json
+++ b/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBackgroundActiveHighlight.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "168",
+          "alpha" : "1.000",
+          "blue" : "168",
+          "green" : "168"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "36",
+          "alpha" : "1.000",
+          "blue" : "39",
+          "green" : "37"
+        }
+      }
+    }
+  ]
+}

--- a/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBackgroundActiveSelected.colorset/Contents.json
+++ b/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBackgroundActiveSelected.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "209",
+          "alpha" : "1.000",
+          "blue" : "208",
+          "green" : "209"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "54",
+          "alpha" : "1.000",
+          "blue" : "57",
+          "green" : "55"
+        }
+      }
+    }
+  ]
+}

--- a/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBackgroundInactive.colorset/Contents.json
+++ b/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBackgroundInactive.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "221",
+          "alpha" : "1.000",
+          "blue" : "221",
+          "green" : "221"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "30",
+          "alpha" : "1.000",
+          "blue" : "33",
+          "green" : "31"
+        }
+      }
+    }
+  ]
+}

--- a/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBackgroundInactiveHighlight.colorset/Contents.json
+++ b/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBackgroundInactiveHighlight.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "198",
+          "alpha" : "1.000",
+          "blue" : "198",
+          "green" : "198"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "27",
+          "alpha" : "1.000",
+          "blue" : "30",
+          "green" : "28"
+        }
+      }
+    }
+  ]
+}

--- a/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBackgroundInactiveSelected.colorset/Contents.json
+++ b/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBackgroundInactiveSelected.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "246",
+          "alpha" : "1.000",
+          "blue" : "246",
+          "green" : "246"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "43",
+          "alpha" : "1.000",
+          "blue" : "47",
+          "green" : "45"
+        }
+      }
+    }
+  ]
+}

--- a/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBorderActive.colorset/Contents.json
+++ b/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBorderActive.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "169",
+          "alpha" : "1.000",
+          "blue" : "169",
+          "green" : "169"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "96",
+          "alpha" : "1.000",
+          "blue" : "99",
+          "green" : "97"
+        }
+      }
+    }
+  ]
+}

--- a/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBorderInactive.colorset/Contents.json
+++ b/src/MacVim/PSMTabBarControl/Media.xcassets/MojaveTabBorderInactive.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "210",
+          "alpha" : "1.000",
+          "blue" : "210",
+          "green" : "210"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "73",
+          "alpha" : "1.000",
+          "blue" : "77",
+          "green" : "74"
+        }
+      }
+    }
+  ]
+}

--- a/src/MacVim/PSMTabBarControl/PSMTabBarControl.xcodeproj/project.pbxproj
+++ b/src/MacVim/PSMTabBarControl/PSMTabBarControl.xcodeproj/project.pbxproj
@@ -41,6 +41,9 @@
 		52FAFCD41C30F4DF00C6E613 /* PSMYosemiteTabStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = 52FAFCD21C30F4DF00C6E613 /* PSMYosemiteTabStyle.m */; };
 		546DEAF1067F63070098DCC4 /* PSMTabBarControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 0259C576FE90428111CA0C5A /* PSMTabBarControl.m */; };
 		546DEAF2067F630E0098DCC4 /* PSMTabBarControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 0259C57AFE90428111CA0C5A /* PSMTabBarControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		90AD234F21A969C100CEF036 /* PSMMojaveTabStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 90AD234D21A969C100CEF036 /* PSMMojaveTabStyle.h */; };
+		90AD235021A969C100CEF036 /* PSMMojaveTabStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = 90AD234E21A969C100CEF036 /* PSMMojaveTabStyle.m */; };
+		90DE16CC21A955EE004F0124 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 90DE16CB21A955EE004F0124 /* Media.xcassets */; };
 		A2082A9009EAEB34009AC8BE /* PSMTabDragAssistant.h in Headers */ = {isa = PBXBuildFile; fileRef = A2082A8D09EAEB33009AC8BE /* PSMTabDragAssistant.h */; };
 		A2082A9109EAEB34009AC8BE /* PSMTabDragAssistant.m in Sources */ = {isa = PBXBuildFile; fileRef = A2082A8E09EAEB33009AC8BE /* PSMTabDragAssistant.m */; };
 		A2129BB209AEB58F00724E6C /* PSMProgressIndicator.h in Headers */ = {isa = PBXBuildFile; fileRef = A2129BAF09AEB58F00724E6C /* PSMProgressIndicator.h */; };
@@ -124,6 +127,9 @@
 		54D33B2806778E3300C9C163 /* PSMTabBarControl.ibclassdescription */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = PSMTabBarControl.ibclassdescription; sourceTree = "<group>"; };
 		8D1AC9730486D14A00FE50C9 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		8D1AC97B0486D23100FE50C9 /* English */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		90AD234D21A969C100CEF036 /* PSMMojaveTabStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PSMMojaveTabStyle.h; path = source/PSMMojaveTabStyle.h; sourceTree = "<group>"; };
+		90AD234E21A969C100CEF036 /* PSMMojaveTabStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PSMMojaveTabStyle.m; path = source/PSMMojaveTabStyle.m; sourceTree = "<group>"; };
+		90DE16CB21A955EE004F0124 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		A2072A2409ABD88600304BCB /* Folder.tif */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; name = Folder.tif; path = images/Folder.tif; sourceTree = "<group>"; };
 		A2072A2509ABD88600304BCB /* Globe.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; name = Globe.tiff; path = images/Globe.tiff; sourceTree = "<group>"; };
 		A2072B5C09AC1FA500304BCB /* Warning.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Warning.png; path = images/Warning.png; sourceTree = "<group>"; };
@@ -209,6 +215,7 @@
 		0259C582FE90428111CA0C5A /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				90DE16CB21A955EE004F0124 /* Media.xcassets */,
 				A251BEC20959BC0E0058BC7F /* MainMenu.nib */,
 				A251BE8E0959A21A0058BC7F /* Images */,
 				8D1AC9730486D14A00FE50C9 /* Info.plist */,
@@ -308,6 +315,8 @@
 		54D33B2C06778E4400C9C163 /* Framework */ = {
 			isa = PBXGroup;
 			children = (
+				90AD234D21A969C100CEF036 /* PSMMojaveTabStyle.h */,
+				90AD234E21A969C100CEF036 /* PSMMojaveTabStyle.m */,
 				0259C57AFE90428111CA0C5A /* PSMTabBarControl.h */,
 				0259C576FE90428111CA0C5A /* PSMTabBarControl.m */,
 				A251BE830959A1B90058BC7F /* PSMTabBarCell.h */,
@@ -416,6 +425,7 @@
 				A2082A9009EAEB34009AC8BE /* PSMTabDragAssistant.h in Headers */,
 				A2D98B0A0A2B432C0064C6F8 /* PSMUnifiedTabStyle.h in Headers */,
 				A2D98B120A2B43FA0064C6F8 /* NSBezierPath_AMShading.h in Headers */,
+				90AD234F21A969C100CEF036 /* PSMMojaveTabStyle.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -490,6 +500,7 @@
 				A27E47880A28EE7C007BA395 /* TabControlRep.tif in Resources */,
 				52A57C0F15BBA230003EC59C /* TabClose_Front.png in Resources */,
 				52A57C1015BBA230003EC59C /* TabClose_Front_Pressed.png in Resources */,
+				90DE16CC21A955EE004F0124 /* Media.xcassets in Resources */,
 				52A57C1115BBA230003EC59C /* TabClose_Front_Rollover.png in Resources */,
 				52FAFCCF1C30F4B500C6E613 /* TabNewYosemite.png in Resources */,
 				523897F415BDA9AC00498A53 /* TabClose_Front_Pressed@2x.png in Resources */,
@@ -519,6 +530,7 @@
 				A2D32F0109A63D7A00EC8662 /* PSMMetalTabStyle.m in Sources */,
 				A268EA6309A9831800E082AA /* PSMRolloverButton.m in Sources */,
 				A2129BB309AEB58F00724E6C /* PSMProgressIndicator.m in Sources */,
+				90AD235021A969C100CEF036 /* PSMMojaveTabStyle.m in Sources */,
 				A2082A9109EAEB34009AC8BE /* PSMTabDragAssistant.m in Sources */,
 				52FAFCD41C30F4DF00C6E613 /* PSMYosemiteTabStyle.m in Sources */,
 				A2D98B0B0A2B432C0064C6F8 /* PSMUnifiedTabStyle.m in Sources */,

--- a/src/MacVim/PSMTabBarControl/source/PSMMojaveTabStyle.h
+++ b/src/MacVim/PSMTabBarControl/source/PSMMojaveTabStyle.h
@@ -2,9 +2,14 @@
 //  PSMMojaveTabStyle.h
 //  PSMTabBarControl
 //
-//  Created by Christoffer Winterkvist on 25/08/14.
+//  This file is copied from PSMYosemiteTabStyle to allow for modifications to
+//  adapt to Mojave-specific functionality such as Dark Mode without needing to
+//  pollute the implementation of Yosemite tab style.
 //
 //
+
+#if defined(MAC_OS_X_VERSION_10_14) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
+#define HAS_MOJAVE_TAB_STYLE 1
 
 #import <Cocoa/Cocoa.h>
 #import "PSMTabStyle.h"
@@ -13,16 +18,18 @@
     NSImage *closeButton;
     NSImage *closeButtonDown;
     NSImage *closeButtonOver;
+    NSImage *closeButtonOverDark;
     NSImage *_addTabButtonImage;
-    NSImage *_addTabButtonPressedImage;
-    NSImage *_addTabButtonRolloverImage;
     NSMutableParagraphStyle *truncatingTailParagraphStyle;
     NSMutableParagraphStyle *centeredParagraphStyle;
 }
 
 - (void)drawInteriorWithTabCell:(PSMTabBarCell *)cell inView:(NSView*)controlView;
 
+- (void)styleAddTabButton:(PSMRolloverButton *)addTabButton;
+
 - (void)encodeWithCoder:(NSCoder *)aCoder;
 - (id)initWithCoder:(NSCoder *)aDecoder;
 
 @end
+#endif

--- a/src/MacVim/PSMTabBarControl/source/PSMMojaveTabStyle.h
+++ b/src/MacVim/PSMTabBarControl/source/PSMMojaveTabStyle.h
@@ -1,0 +1,28 @@
+//
+//  PSMMojaveTabStyle.h
+//  PSMTabBarControl
+//
+//  Created by Christoffer Winterkvist on 25/08/14.
+//
+//
+
+#import <Cocoa/Cocoa.h>
+#import "PSMTabStyle.h"
+
+@interface PSMMojaveTabStyle : NSObject <PSMTabStyle> {
+    NSImage *closeButton;
+    NSImage *closeButtonDown;
+    NSImage *closeButtonOver;
+    NSImage *_addTabButtonImage;
+    NSImage *_addTabButtonPressedImage;
+    NSImage *_addTabButtonRolloverImage;
+    NSMutableParagraphStyle *truncatingTailParagraphStyle;
+    NSMutableParagraphStyle *centeredParagraphStyle;
+}
+
+- (void)drawInteriorWithTabCell:(PSMTabBarCell *)cell inView:(NSView*)controlView;
+
+- (void)encodeWithCoder:(NSCoder *)aCoder;
+- (id)initWithCoder:(NSCoder *)aDecoder;
+
+@end

--- a/src/MacVim/PSMTabBarControl/source/PSMMojaveTabStyle.m
+++ b/src/MacVim/PSMTabBarControl/source/PSMMojaveTabStyle.m
@@ -1,0 +1,498 @@
+//
+//  PSMMojaveTabStyle.m
+//  PSMTabBarControl
+//
+//  Created by Christoffer Winterkvist on 25/08/14.
+//
+//
+
+#import "PSMMojaveTabStyle.h"
+
+#define kPSMMetalObjectCounterRadius 7.0
+#define kPSMMetalCounterMinWidth 20
+
+void MojaveNSDrawWindowBackground(NSRect rect, NSColor *color)
+{
+    [color set];
+    NSRectFill( rect );
+}
+
+@implementation PSMMojaveTabStyle
+
+- (void)dealloc
+{
+    [closeButton release];
+    [closeButtonDown release];
+    [closeButtonOver release];
+    [_addTabButtonImage release];
+    [_addTabButtonPressedImage release];
+    [_addTabButtonRolloverImage release];
+
+    [truncatingTailParagraphStyle release];
+    [centeredParagraphStyle release];
+
+    [super dealloc];
+}
+
+#pragma mark -
+#pragma mark Initializers
+
+- (id)init
+{
+    self = [super init];
+    if (!self) return nil;
+
+    closeButton = [[NSImage alloc] initByReferencingFile:[[PSMTabBarControl bundle] pathForImageResource:@"TabClose_Front"]];
+    //NSLog(@"closeButton=%@ path=%@", metalCloseButton,
+    //        [[PSMTabBarControl bundle] pathForImageResource:@"TabClose_Front"]);
+    closeButtonDown = [[NSImage alloc] initByReferencingFile:[[PSMTabBarControl bundle] pathForImageResource:@"TabClose_Front_Pressed"]];
+    closeButtonOver = [[NSImage alloc] initByReferencingFile:[[PSMTabBarControl bundle] pathForImageResource:@"TabClose_Front_Rollover"]];
+
+    _addTabButtonImage = [[NSImage alloc] initByReferencingFile:[[PSMTabBarControl bundle] pathForImageResource:@"TabNewMetal"]];
+    _addTabButtonPressedImage = [[NSImage alloc] initByReferencingFile:[[PSMTabBarControl bundle] pathForImageResource:@"TabNewMetalPressed"]];
+    _addTabButtonRolloverImage = [[NSImage alloc] initByReferencingFile:[[PSMTabBarControl bundle] pathForImageResource:@"TabNewMetalRollover"]];
+
+    return self;
+}
+
+- (NSString *)name
+{
+    return @"Mojave";
+}
+
+#pragma mark -
+#pragma mark Control Specific
+
+- (float)leftMarginForTabBarControl
+{
+    return -1.0f;
+}
+
+- (float)rightMarginForTabBarControl
+{
+    return 24.0f;
+}
+
+#pragma mark -
+#pragma mark Add Tab Button
+
+- (NSImage *)addTabButtonImage
+{
+    return _addTabButtonImage;
+}
+
+- (NSImage *)addTabButtonPressedImage
+{
+    return _addTabButtonPressedImage;
+}
+
+- (NSImage *)addTabButtonRolloverImage
+{
+    return _addTabButtonRolloverImage;
+}
+
+- (NSColor *)backgroundColor:(BOOL)isKeyWindow
+{
+    NSColor *backgroundColor;
+    if (isKeyWindow) {
+        backgroundColor = [NSColor colorWithCalibratedHue:0.000 saturation:0.000 brightness:0.875 alpha:1];
+    } else {
+        backgroundColor = [NSColor colorWithCalibratedHue:0.000 saturation:0.000 brightness:0.957 alpha:1];
+    }
+
+    return backgroundColor;
+}
+
+- (NSColor *)borderColor
+{
+    return [NSColor colorWithCalibratedHue:0.000 saturation:0.000 brightness:0.678 alpha:1];
+}
+
+#pragma mark -
+#pragma mark Cell Specific
+
+- (NSRect) closeButtonRectForTabCell:(PSMTabBarCell *)cell
+{
+    NSRect cellFrame = [cell frame];
+
+    if ([cell hasCloseButton] == NO) {
+        return NSZeroRect;
+    }
+
+    NSRect result;
+    result.size = [closeButton size];
+    result.origin.x = cellFrame.origin.x + MARGIN_X;
+    result.origin.y = cellFrame.origin.y + MARGIN_Y + 2.0;
+
+    return result;
+}
+
+- (NSRect)iconRectForTabCell:(PSMTabBarCell *)cell
+{
+    NSRect cellFrame = [cell frame];
+
+    if ([cell hasIcon] == NO) {
+        return NSZeroRect;
+    }
+
+    NSRect result;
+    result.size = NSMakeSize(kPSMTabBarIconWidth, kPSMTabBarIconWidth);
+    result.origin.x = cellFrame.origin.x + MARGIN_X;
+    result.origin.y = cellFrame.origin.y + MARGIN_Y;
+
+    if([cell hasCloseButton] && ![cell isCloseButtonSuppressed])
+        result.origin.x += [closeButton size].width + kPSMTabBarCellPadding;
+
+    if([cell state] == NSOnState){
+        result.origin.y += 1;
+    }
+
+    return result;
+}
+
+- (NSRect)indicatorRectForTabCell:(PSMTabBarCell *)cell
+{
+    NSRect cellFrame = [cell frame];
+
+    if ([[cell indicator] isHidden]) {
+        return NSZeroRect;
+    }
+
+    NSRect result;
+    result.size = NSMakeSize(kPSMTabBarIndicatorWidth, kPSMTabBarIndicatorWidth);
+    result.origin.x = cellFrame.origin.x + cellFrame.size.width - MARGIN_X - kPSMTabBarIndicatorWidth;
+    result.origin.y = cellFrame.origin.y + MARGIN_Y;
+
+    if([cell state] == NSOnState){
+        result.origin.y -= 1;
+    }
+
+    return result;
+}
+
+- (NSRect)objectCounterRectForTabCell:(PSMTabBarCell *)cell
+{
+    NSRect cellFrame = [cell frame];
+
+    if ([cell count] == 0) {
+        return NSZeroRect;
+    }
+
+    float countWidth = [[self attributedObjectCountValueForTabCell:cell] size].width;
+    countWidth += (2 * kPSMMetalObjectCounterRadius - 6.0);
+    if(countWidth < kPSMMetalCounterMinWidth)
+        countWidth = kPSMMetalCounterMinWidth;
+
+    NSRect result;
+    result.size = NSMakeSize(countWidth, 2 * kPSMMetalObjectCounterRadius); // temp
+    result.origin.x = cellFrame.origin.x + cellFrame.size.width - MARGIN_X - result.size.width;
+    result.origin.y = cellFrame.origin.y + MARGIN_Y + 1.0;
+
+    if(![[cell indicator] isHidden])
+        result.origin.x -= kPSMTabBarIndicatorWidth + kPSMTabBarCellPadding;
+
+    return result;
+}
+
+
+- (float)minimumWidthOfTabCell:(PSMTabBarCell *)cell
+{
+    float resultWidth = 0.0;
+
+    // left margin
+    resultWidth = MARGIN_X;
+
+    // close button?
+    if([cell hasCloseButton] && ![cell isCloseButtonSuppressed])
+        resultWidth += [closeButton size].width + kPSMTabBarCellPadding;
+
+    // icon?
+    if([cell hasIcon])
+        resultWidth += kPSMTabBarIconWidth + kPSMTabBarCellPadding;
+
+    // the label
+    resultWidth += kPSMMinimumTitleWidth;
+
+    // object counter?
+    if([cell count] > 0)
+        resultWidth += [self objectCounterRectForTabCell:cell].size.width + kPSMTabBarCellPadding;
+
+    // indicator?
+    if ([[cell indicator] isHidden] == NO)
+        resultWidth += kPSMTabBarCellPadding + kPSMTabBarIndicatorWidth;
+
+    // right margin
+    resultWidth += MARGIN_X;
+
+    return ceil(resultWidth);
+}
+
+- (float)desiredWidthOfTabCell:(PSMTabBarCell *)cell
+{
+    float resultWidth = 0.0;
+
+    // left margin
+    resultWidth = MARGIN_X;
+
+    // close button?
+    if ([cell hasCloseButton] && ![cell isCloseButtonSuppressed])
+        resultWidth += [closeButton size].width + kPSMTabBarCellPadding;
+
+    // icon?
+    if([cell hasIcon])
+        resultWidth += kPSMTabBarIconWidth + kPSMTabBarCellPadding;
+
+    // the label
+    resultWidth += [[cell attributedStringValue] size].width;
+
+    // object counter?
+    if([cell count] > 0)
+        resultWidth += [self objectCounterRectForTabCell:cell].size.width + kPSMTabBarCellPadding;
+
+    // indicator?
+    if ([[cell indicator] isHidden] == NO)
+        resultWidth += kPSMTabBarCellPadding + kPSMTabBarIndicatorWidth;
+
+    // right margin
+    resultWidth += MARGIN_X;
+
+    return ceil(resultWidth);
+}
+
+#pragma mark -
+#pragma mark Cell Values
+
+- (NSAttributedString *)attributedObjectCountValueForTabCell:(PSMTabBarCell *)cell
+{
+    NSMutableAttributedString *attrStr;
+    NSFontManager *fm = [NSFontManager sharedFontManager];
+    NSNumberFormatter *nf = [[[NSNumberFormatter alloc] init] autorelease];
+    [nf setLocalizesFormat:YES];
+    [nf setFormat:@"0"];
+    [nf setHasThousandSeparators:YES];
+    NSString *contents = [nf stringFromNumber:[NSNumber numberWithInt:[cell count]]];
+    attrStr = [[[NSMutableAttributedString alloc] initWithString:contents] autorelease];
+    NSRange range = NSMakeRange(0, [contents length]);
+
+    // Add font attribute
+    [attrStr addAttribute:NSFontAttributeName value:[fm convertFont:[NSFont fontWithName:@"Helvetica" size:11.0] toHaveTrait:NSBoldFontMask] range:range];
+    [attrStr addAttribute:NSForegroundColorAttributeName value:[[NSColor whiteColor] colorWithAlphaComponent:0.85] range:range];
+
+    return attrStr;
+}
+
+- (NSAttributedString *)attributedStringValueForTabCell:(PSMTabBarCell *)cell
+{
+    NSMutableAttributedString *attrStr;
+    NSString *contents = [cell stringValue];
+    attrStr = [[[NSMutableAttributedString alloc] initWithString:contents] autorelease];
+    NSRange range = NSMakeRange(0, [contents length]);
+
+    // Add font attribute
+    [attrStr addAttribute:NSFontAttributeName value:[NSFont systemFontOfSize:11.0] range:range];
+
+    PSMTabBarControl *bar = (PSMTabBarControl *)cell.controlView;
+    BOOL isKeyWindow = [bar.window isKeyWindow];
+
+    CGFloat textAlpha;
+    if ([cell state] == NSOnState) {
+        textAlpha = (isKeyWindow) ? 1.0f : 0.5f;
+    } else {
+        textAlpha = (isKeyWindow) ? 0.5f : 0.25f;
+    }
+    NSColor *textColor = [[NSColor textColor] colorWithAlphaComponent:textAlpha];
+
+    [attrStr addAttribute:NSForegroundColorAttributeName value:textColor range:range];
+
+    // Paragraph Style for Truncating Long Text
+    if (!truncatingTailParagraphStyle) {
+        truncatingTailParagraphStyle = [[[NSParagraphStyle defaultParagraphStyle] mutableCopy] retain];
+        [truncatingTailParagraphStyle setLineBreakMode:NSLineBreakByTruncatingHead];
+        [truncatingTailParagraphStyle setAlignment:NSTextAlignmentCenter];
+    }
+    [attrStr addAttribute:NSParagraphStyleAttributeName value:truncatingTailParagraphStyle range:range];
+
+    return attrStr;
+}
+
+#pragma mark -
+#pragma mark ---- drawing ----
+
+- (void)drawTabCell:(PSMTabBarCell *)cell
+{
+    NSRect cellFrame = [cell frame];
+    NSColor * lineColor = nil;
+    NSBezierPath* bezier = [NSBezierPath bezierPath];
+    lineColor = [self borderColor];
+
+    if ([cell state] == NSOnState) {
+        // selected tab
+        NSRect aRect = NSMakeRect(cellFrame.origin.x, cellFrame.origin.y, cellFrame.size.width, cellFrame.size.height);
+
+        PSMTabBarControl *bar = (PSMTabBarControl *)cell.controlView;
+        BOOL isKeyWindow = [bar.window isKeyWindow];
+
+        // background
+        MojaveNSDrawWindowBackground(aRect, [self backgroundColor:isKeyWindow]);
+
+        aRect.size.height -= 1.0f;
+        aRect.origin.y += 0.5f;
+        // frame
+        [lineColor set];
+        [bezier moveToPoint:NSMakePoint(aRect.origin.x, aRect.origin.y)];
+        [bezier lineToPoint:NSMakePoint(aRect.origin.x, aRect.origin.y+aRect.size.height)];
+        [bezier lineToPoint:NSMakePoint(aRect.origin.x+aRect.size.width, aRect.origin.y+aRect.size.height)];
+        [bezier lineToPoint:NSMakePoint(aRect.origin.x+aRect.size.width, aRect.origin.y)];
+        [bezier lineToPoint:NSMakePoint(aRect.origin.x, aRect.origin.y)];
+        [bezier stroke];
+    } else {
+
+        // unselected tab
+        NSRect aRect = NSMakeRect(cellFrame.origin.x, cellFrame.origin.y, cellFrame.size.width, cellFrame.size.height);
+
+        aRect.origin.x += 0.5;
+
+        [[NSColor colorWithCalibratedWhite:0.0 alpha:0.1] set];
+        NSRectFillUsingOperation(aRect, NSCompositingOperationSourceAtop);
+
+        // frame
+        [lineColor set];
+        [bezier moveToPoint:NSMakePoint(aRect.origin.x, aRect.origin.y)];
+        [bezier lineToPoint:NSMakePoint(aRect.origin.x + aRect.size.width, aRect.origin.y)];
+        if(!([cell tabState] & PSMTab_RightIsSelectedMask)){
+            [bezier lineToPoint:NSMakePoint(aRect.origin.x + aRect.size.width, aRect.origin.y + aRect.size.height)];
+        }
+        [bezier stroke];
+    }
+
+    [self drawInteriorWithTabCell:cell inView:[cell controlView]];
+}
+
+
+
+- (void)drawInteriorWithTabCell:(PSMTabBarCell *)cell inView:(NSView*)controlView
+{
+    NSRect cellFrame = [cell frame];
+    float labelPosition = cellFrame.origin.x + MARGIN_X;
+
+    // close button
+    if ([cell hasCloseButton] && ![cell isCloseButtonSuppressed]) {
+        NSSize closeButtonSize = NSZeroSize;
+        NSRect closeButtonRect = [cell closeButtonRectForFrame:cellFrame];
+        NSImage *button = nil;
+
+        if ([cell closeButtonOver]) button = closeButtonOver;
+        if ([cell closeButtonPressed]) button = closeButtonDown;
+
+        closeButtonSize = [button size];
+        [button drawInRect:closeButtonRect fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0 respectFlipped:YES hints:nil];
+    }
+
+    // object counter
+    if([cell count] > 0){
+        [[NSColor colorWithCalibratedWhite:0.3 alpha:0.6] set];
+        NSBezierPath *path = [NSBezierPath bezierPath];
+        NSRect myRect = [self objectCounterRectForTabCell:cell];
+        [path moveToPoint:NSMakePoint(myRect.origin.x + kPSMMetalObjectCounterRadius, myRect.origin.y)];
+        [path lineToPoint:NSMakePoint(myRect.origin.x + myRect.size.width - kPSMMetalObjectCounterRadius, myRect.origin.y)];
+        [path appendBezierPathWithArcWithCenter:NSMakePoint(myRect.origin.x + myRect.size.width - kPSMMetalObjectCounterRadius, myRect.origin.y + kPSMMetalObjectCounterRadius) radius:kPSMMetalObjectCounterRadius startAngle:270.0 endAngle:90.0];
+        [path lineToPoint:NSMakePoint(myRect.origin.x + kPSMMetalObjectCounterRadius, myRect.origin.y + myRect.size.height)];
+        [path appendBezierPathWithArcWithCenter:NSMakePoint(myRect.origin.x + kPSMMetalObjectCounterRadius, myRect.origin.y + kPSMMetalObjectCounterRadius) radius:kPSMMetalObjectCounterRadius startAngle:90.0 endAngle:270.0];
+        [path fill];
+
+        // draw attributed string centered in area
+        NSRect counterStringRect;
+        NSAttributedString *counterString = [self attributedObjectCountValueForTabCell:cell];
+        counterStringRect.size = [counterString size];
+        counterStringRect.origin.x = myRect.origin.x + ((myRect.size.width - counterStringRect.size.width) / 2.0) + 0.25;
+        counterStringRect.origin.y = myRect.origin.y + ((myRect.size.height - counterStringRect.size.height) / 2.0) + 0.5;
+        [counterString drawInRect:counterStringRect];
+    }
+
+    // label rect
+    NSRect labelRect;
+    labelRect.origin.x = labelPosition;
+    labelRect.size.width = cellFrame.size.width - (labelRect.origin.x - cellFrame.origin.x) - kPSMTabBarCellPadding;
+    labelRect.size.height = cellFrame.size.height;
+    labelRect.origin.y = cellFrame.origin.y + MARGIN_Y + 1.0;
+
+    if(![[cell indicator] isHidden])
+        labelRect.size.width -= (kPSMTabBarIndicatorWidth + kPSMTabBarCellPadding);
+
+    if([cell count] > 0)
+        labelRect.size.width -= ([self objectCounterRectForTabCell:cell].size.width + kPSMTabBarCellPadding);
+
+    // label
+    [[cell attributedStringValue] drawInRect:labelRect];
+}
+
+- (void)drawTabBar:(PSMTabBarControl *)bar inRect:(NSRect)rect
+{
+    BOOL isKeyWindow = [bar.window isKeyWindow];
+    MojaveNSDrawWindowBackground(rect, [self backgroundColor:isKeyWindow]);
+
+    [[NSColor colorWithCalibratedWhite:0.0 alpha:0.0] set];
+    NSRectFillUsingOperation(rect, NSCompositingOperationSourceAtop);
+    [[self borderColor] set];
+    [NSBezierPath strokeLineFromPoint:NSMakePoint(rect.origin.x,rect.origin.y+0.5) toPoint:NSMakePoint(rect.origin.x+rect.size.width,rect.origin.y+0.5)];
+    [NSBezierPath strokeLineFromPoint:NSMakePoint(rect.origin.x,rect.origin.y+rect.size.height-0.5) toPoint:NSMakePoint(rect.origin.x+rect.size.width,rect.origin.y+rect.size.height-0.5)];
+
+    // no tab view == not connected
+    if(![bar tabView]){
+        NSRect labelRect = rect;
+        labelRect.size.height -= 4.0;
+        labelRect.origin.y += 4.0;
+        NSMutableAttributedString *attrStr;
+        NSString *contents = @"PSMTabBarControl";
+        attrStr = [[[NSMutableAttributedString alloc] initWithString:contents] autorelease];
+        NSRange range = NSMakeRange(0, [contents length]);
+        [attrStr addAttribute:NSFontAttributeName value:[NSFont systemFontOfSize:11.0] range:range];
+        if (!centeredParagraphStyle) {
+            centeredParagraphStyle = [[[NSParagraphStyle defaultParagraphStyle] mutableCopy] retain];
+            [centeredParagraphStyle setAlignment:NSTextAlignmentCenter];
+        }
+        [attrStr addAttribute:NSParagraphStyleAttributeName value:centeredParagraphStyle range:range];
+        [attrStr drawInRect:labelRect];
+        return;
+    }
+
+    // draw cells
+    NSEnumerator *e = [[bar cells] objectEnumerator];
+    PSMTabBarCell *cell;
+    while(cell = [e nextObject]){
+        if(![cell isInOverflowMenu]){
+            [cell drawWithFrame:[cell frame] inView:bar];
+        }
+    }
+}
+
+#pragma mark -
+#pragma mark Archiving
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    if ([aCoder allowsKeyedCoding]) {
+        [aCoder encodeObject:closeButton forKey:@"metalCloseButton"];
+        [aCoder encodeObject:closeButtonDown forKey:@"metalCloseButtonDown"];
+        [aCoder encodeObject:closeButtonOver forKey:@"metalCloseButtonOver"];
+        [aCoder encodeObject:_addTabButtonImage forKey:@"addTabButtonImage"];
+        [aCoder encodeObject:_addTabButtonPressedImage forKey:@"addTabButtonPressedImage"];
+        [aCoder encodeObject:_addTabButtonRolloverImage forKey:@"addTabButtonRolloverImage"];
+    }
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    if ([aDecoder allowsKeyedCoding]) {
+        closeButton = [[aDecoder decodeObjectForKey:@"metalCloseButton"] retain];
+        closeButtonDown = [[aDecoder decodeObjectForKey:@"metalCloseButtonDown"] retain];
+        closeButtonOver = [[aDecoder decodeObjectForKey:@"metalCloseButtonOver"] retain];
+        _addTabButtonImage = [[aDecoder decodeObjectForKey:@"addTabButtonImage"] retain];
+        _addTabButtonPressedImage = [[aDecoder decodeObjectForKey:@"addTabButtonPressedImage"] retain];
+        _addTabButtonRolloverImage = [[aDecoder decodeObjectForKey:@"addTabButtonRolloverImage"] retain];
+    }
+
+    return self;
+}
+
+@end

--- a/src/MacVim/PSMTabBarControl/source/PSMTabBarControl.m
+++ b/src/MacVim/PSMTabBarControl/source/PSMTabBarControl.m
@@ -12,6 +12,7 @@
 #import "PSMRolloverButton.h"
 #import "PSMTabStyle.h"
 #import "PSMMetalTabStyle.h"
+#import "PSMMojaveTabStyle.h"
 #import "PSMUnifiedTabStyle.h"
 #import "PSMYosemiteTabStyle.h"
 #import "PSMTabDragAssistant.h"
@@ -259,21 +260,29 @@
         style = [[PSMUnifiedTabStyle alloc] init];
     } else if([name isEqualToString:@"Yosemite"]){
         style = [[PSMYosemiteTabStyle alloc] init];
+#if HAS_MOJAVE_TAB_STYLE
+    } else if([name isEqualToString:@"Mojave"]){
+        style = [[PSMMojaveTabStyle alloc] init];
+#endif
     } else {
         style = [[PSMMetalTabStyle alloc] init];
     }
    
     // restyle add tab button
     if(_addTabButton){
-        NSImage *newButtonImage = [style addTabButtonImage];
-        if(newButtonImage)
-            [_addTabButton setUsualImage:newButtonImage];
-        newButtonImage = [style addTabButtonPressedImage];
-        if(newButtonImage)
-            [_addTabButton setAlternateImage:newButtonImage];
-        newButtonImage = [style addTabButtonRolloverImage];
-        if(newButtonImage)
-            [_addTabButton setRolloverImage:newButtonImage];
+        if ([style respondsToSelector:@selector(styleAddTabButton:)]) {
+            [style performSelector:@selector(styleAddTabButton:) withObject:_addTabButton];
+        } else {
+            NSImage *newButtonImage = [style addTabButtonImage];
+            if(newButtonImage)
+                [_addTabButton setUsualImage:newButtonImage];
+            newButtonImage = [style addTabButtonPressedImage];
+            if(newButtonImage)
+                [_addTabButton setAlternateImage:newButtonImage];
+            newButtonImage = [style addTabButtonRolloverImage];
+            if(newButtonImage)
+                [_addTabButton setRolloverImage:newButtonImage];
+        }
     }
     
     [self update];


### PR DESCRIPTION
Add a new tab style "Mojave". The files were copied from Yosemite-style tabs but with additional improvements. It now reads the colors from an asset catalog with colors for both dark and light modes. The colors and style are also retuned to look more like native Mojave tabs. The new tab and close tab buttons are now using a style much more similar to what native macOS are like, with the close tab button showing up when mouse is hovering over a particular tab.
    
Reason for cloning PSMYosemiteTabStyle is to avoid having too many special cases in a single file and to avoid breaking its behaviors on older systems. Also, PSMTabBarControl is mostly a dead project, so it's wise to modify existing code as little as possible.
    
MacVim will only use this style if it's compiled with Mojave SDKs and it's actually being run in Mojave (10.14) or higher.
    
Fix #775
