### PR TITLE
Switch Travis CI to deploy MacVim in Xcode 10 / Mojave SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,7 @@ deploy:
   file: src/MacVim/build/Release/MacVim.dmg
   skip_cleanup: true
   on:
-    # Pending Core Text rendering fix for Mojave (#751) before this can be swithced to Xcode 10 / macOS 10.14
-    condition: $TRAVIS_OSX_IMAGE = xcode9.4
+    condition: $TRAVIS_OSX_IMAGE = xcode10.1
     all_branches: true
     tags: true
     repo: macvim-dev/macvim


### PR DESCRIPTION
The previous Mojave rendering artifacts have now been fixed, so we can deploy MacVim for Mojave / Xcode 10 now.