### PR TITLE
Make pre-Mojave tabs also show the close button on hover over tab

### DIFF
--- a/src/MacVim/PSMTabBarControl/source/PSMYosemiteTabStyle.m
+++ b/src/MacVim/PSMTabBarControl/source/PSMYosemiteTabStyle.m
@@ -381,6 +381,7 @@ void YosemiteNSDrawWindowBackground(NSRect rect, NSColor *color)
         NSRect closeButtonRect = [cell closeButtonRectForFrame:cellFrame];
         NSImage *button = nil;
 
+        if ([cell isHighlighted]) button = closeButton;
         if ([cell closeButtonOver]) button = closeButtonOver;
         if ([cell closeButtonPressed]) button = closeButtonDown;
 


### PR DESCRIPTION
This makes them show up on tab hover, so you don't have to hover over the exact location of the close button to see it.