### PR TITLE
Fix starting up in non-native fullscreen resulting in black screen

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -137,8 +137,13 @@ defaultAdvanceForFont(NSFont *font)
             boolForKey:MMBufferedDrawingKey];
     cgBufferDrawNeedsUpdateContext = NO;
 
-    cgLayerEnabled = [[NSUserDefaults standardUserDefaults]
-            boolForKey:MMUseCGLayerAlwaysKey];
+    cgLayerEnabled = NO;
+    if (!cgBufferDrawEnabled) {
+        // Buffered draw supercedes the CGLayer renderer, which is deprecated
+        // and doesn't actually work in 10.14+.
+        cgLayerEnabled = [[NSUserDefaults standardUserDefaults]
+                boolForKey:MMUseCGLayerAlwaysKey];
+    }
     cgLayerLock = [NSLock new];
 
     // NOTE!  It does not matter which font is set here, Vim will set its
@@ -795,7 +800,7 @@ defaultAdvanceForFont(NSFont *font)
 
 - (void)setCGLayerEnabled:(BOOL)enabled
 {
-    if (cgContext)
+    if (cgContext || cgBufferDrawEnabled)
         return;
 
     cgLayerEnabled = enabled;

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -348,6 +348,7 @@
         // GUIEnter auto command could cause this).
         [fullScreenWindow enterFullScreen];
         fullScreenEnabled = YES;
+        shouldResizeVimView = YES;
     } else if (delayEnterFullScreen) {
         // Set alpha to zero so that the decorated window doesn't pop up
         // before we enter full-screen.


### PR DESCRIPTION
This fixes issues related to starting up in fullscreen mode (by setting `set fullscreen` in gvimrc).

Fix black screen when starting in non-native fullscreen:
- Fix #804
- Non-native fullscreen has an old behavior where it sets CGLayer mode on core text renderer to address rendering artifacts in pre-Mojave, and we have an insufficient block against it (by checking cgContext).  In Mojave, we use buffered draws instead and prevent setting CGLayer by checking cgContext, but it is not yet initialized yet in this situation (since it's lazily initialized). Block against cgBufferDrawEnabled instead.
- The CGLayer renderer is really deprecated at this point so ideally we could clean up the code a little bit in the future.

Setting `MMUseCGLayerAlways` no longer results in black screen:
- Fix #801
- CGLayer renderer is basically deprecated doesn't actually work in Mojave. Make sure setting `MMUseCGLayerAlways` won't trigger it if we are already using buffered draw (which is automatically the case in Mojave).

Fix starting up in fullscreen resulting in a small Vim window:
- When starting MacVim in fullscreen mode, the presentation is delayed until the window is made. need to make sure to set `shouldResizeVimView` in this code path too. Before the guioption-k fixes, there were a lot of random calls to recalculate sizes which was why this happened implicitly. Now need to make sure we do the right thing and call it.
