### PR TITLE
Add AppleEvents usage description to manifest

### DIFF
--- a/src/MacVim/Info.plist
+++ b/src/MacVim/Info.plist
@@ -1309,6 +1309,8 @@
 	<string>https://raw.githubusercontent.com/macvim-dev/macvim/gh-pages/appcast/latest.xml</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>This permission allows MacVim to communicate with other apps via Apple Events.</string>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
 

--- a/src/MacVim/Info.plist
+++ b/src/MacVim/Info.plist
@@ -1310,7 +1310,7 @@
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>This permission allows MacVim to communicate with other apps via Apple Events.</string>
+	<string>MacVim uses Apple Events to allow you to communicate with other apps using Apple Script, and to support working as an ODB external editor.</string>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
 


### PR DESCRIPTION
MacOS Mojave requires that applications provide the NSAppleEventsUsageDescription key in their manifest to communicate with other applications via AppleEvents.

This change provides the key, populated with a string that shows in an OS prompt when AppleEvents communication takes place:

![image](https://user-images.githubusercontent.com/2735346/50112835-1b691e80-01f5-11e9-9c65-5618d30b606a.png)

I've taken a crack at wording the description, but the fix only depends on there being _something_ there.

Fixes #821.