### PR TITLE
Fix Vim breaking guioption 'k' initialization for non-GTK

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -687,10 +687,16 @@ gui_init(void)
     gui.shell_created = TRUE;
 
 #ifndef FEAT_GUI_GTK
+#ifdef FEAT_GUI_MACVIM
+    // The below code setting gui_set_shellsize breaks guioption-k, so patching
+    // around it here by passing TRUE to muset.
+    gui_set_shellsize(TRUE, TRUE, RESIZE_BOTH);
+#else
     // Set the shell size, adjusted for the screen size.  For GTK this only
     // works after the shell has been opened, thus it is further down.
     // For MS-Windows pass FALSE for "mustset" to make --windowid work.
     gui_set_shellsize(FALSE, TRUE, RESIZE_BOTH);
+#endif
 #endif
 #if defined(FEAT_GUI_MOTIF) && defined(FEAT_MENU)
     /* Need to set the size of the menubar after all the menus have been


### PR DESCRIPTION
Recent Vim change (8.1.0626) seems to have broken Vim GUI initialization if guioption 'k' is set, by passing the wrong value to the mustset parameter. Patch around it by making it initialize with the right one in MacVim. This should ideally be fixed upstream in Vim.

The pull request in question is vim/vim#3616.