### PR TITLE
Fix scrollbar to update properly when switching Vim windows

### DIFF
--- a/src/MacVim/MMVimView.h
+++ b/src/MacVim/MMVimView.h
@@ -27,6 +27,7 @@
     NSMutableArray      *scrollbars;
 }
 
+@property BOOL pendingPlaceScrollbars;
 @property BOOL pendingLiveResize;
 
 - (MMVimView *)initWithFrame:(NSRect)frame vimController:(MMVimController *)c;
@@ -51,6 +52,7 @@
 - (void)setScrollbarThumbValue:(float)val proportion:(float)prop
                     identifier:(int32_t)ident;
 - (void)setScrollbarPosition:(int)pos length:(int)len identifier:(int32_t)ident;
+- (void)finishPlaceScrollbars;
 
 - (void)setDefaultColorsBackground:(NSColor *)back foreground:(NSColor *)fore;
 

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -661,6 +661,11 @@
         keepOnScreen = NO;
         shouldKeepGUISize = NO;
     }
+    
+    // Tell Vim view to update its scrollbars which is done once per update.
+    // Do it last so whatever resizing we have done above will take effect
+    // immediate too instead of waiting till next frame.
+    [vimView finishPlaceScrollbars];
 }
 
 - (void)showTabBar:(BOOL)on


### PR DESCRIPTION
Previously, showing/hiding scrollbars didn't call placeScrollbars which was why sometimes when certain Vim commands that would show/hide Vim scrollbars get called, the scrollbar positions/sizes were not updated properly, leaving them with the wrong size.

Fix this by adding a new pending flag so placeScrollbars only gets called once per update, and make sure showing/hiding scrollbars call it.

Fix #802