### PR TITLE
Fix borderless (MMNoTitleBarWindow) mode in pre-Mojave renderers

### DIFF
--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -114,6 +114,7 @@
 - (NSRect)rectForRow:(int)row column:(int)column numRows:(int)nr
           numColumns:(int)nc;
 - (void)setCGLayerEnabled:(BOOL)enabled;
+- (BOOL)getCGLayerEnabled;
 
 //
 // NSTextView methods

--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -809,6 +809,11 @@ defaultAdvanceForFont(NSFont *font)
         [self releaseCGLayer];
 }
 
+- (BOOL)getCGLayerEnabled
+{
+    return cgLayerEnabled;
+}
+
 - (void)releaseCGLayer
 {
     if (cgLayer)  {

--- a/src/MacVim/MMFullScreenWindow.h
+++ b/src/MacVim/MMFullScreenWindow.h
@@ -34,6 +34,9 @@
     // Controls the speed of the fade in and out.
     double      fadeTime;
     double      fadeReservationTime;
+    
+    // For pre-10.14 we manually sets CGLayer mode, so need to remember the original state
+    BOOL        origCGLayerEnabled;
 }
 
 - (MMFullScreenWindow *)initWithWindow:(NSWindow *)t view:(MMVimView *)v

--- a/src/MacVim/MMFullScreenWindow.m
+++ b/src/MacVim/MMFullScreenWindow.m
@@ -113,6 +113,8 @@ enum {
     fadeTime = MIN(fadeTime, 0.5 * (kCGMaxDisplayReservationInterval - 1));
     fadeReservationTime = 2.0 * fadeTime + 1;
     
+    origCGLayerEnabled = NO;
+    
     return self;
 }
 
@@ -172,8 +174,11 @@ enum {
     oldPosition = [view frame].origin;
 
     [view removeFromSuperviewWithoutNeedingDisplay];
-    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_12)
+    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_12) {
+        // This shouldn't do much in 10.14+.
+        origCGLayerEnabled = [[view textView] getCGLayerEnabled];
         [[view textView] setCGLayerEnabled:YES];
+    }
     [[self contentView] addSubview:view];
     [self setInitialFirstResponder:[view textView]];
     
@@ -289,7 +294,7 @@ enum {
     [self close];
 
     if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_12)
-        [[view textView] setCGLayerEnabled:NO];
+        [[view textView] setCGLayerEnabled:origCGLayerEnabled];
 
     // Set the text view to initial first responder, otherwise the 'plus'
     // button on the tabline steals the first responder status.

--- a/src/MacVim/MMTextView.h
+++ b/src/MacVim/MMTextView.h
@@ -74,4 +74,5 @@
 - (void)deleteSign:(NSString *)signName;
 - (void)setToolTipAtMousePoint:(NSString *)string;
 - (void)setCGLayerEnabled:(BOOL)enabled;
+- (BOOL)getCGLayerEnabled;
 @end

--- a/src/MacVim/MMTextView.m
+++ b/src/MacVim/MMTextView.m
@@ -527,6 +527,11 @@
     // ONLY in Core Text!
 }
 
+- (BOOL)getCGLayerEnabled
+{
+    return NO;
+}
+
 - (BOOL)isOpaque
 {
     return NO;

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -200,6 +200,15 @@
     // Make us safe on pre-tiger OSX
     if ([win respondsToSelector:@selector(_setContentHasShadow:)])
         [win _setContentHasShadow:NO];
+    
+    if (!(styleMask & NSWindowStyleMaskTitled)) {
+        // In the no titlebar mode (aka borderless), we need to set CGLayer
+        // mode since otherwise the legacy renderer would not render properly.
+        // For more reference see MMFullscreenWindow's enterFullscreen:
+        // This shouldn't do much in 10.14+.
+        if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_12)
+            [[vimView textView] setCGLayerEnabled:YES];
+    }
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
     // Building on Mac OS X 10.7 or greater.


### PR DESCRIPTION
In the legacy renderer, the view gets invalidated frequently in both non-native fullscreen and no titlebar modes. Fix no-titlebar mode to auto-set CGLayer similar to non-native fullscreen so it would work properly.

This doesn't affect 10.14 Mojave or above as it uses a newer renderer that doesn't have this issue.

Fix #490