### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ sudo: false
 
 script:
   - set -e
+  - if [ "$TRAVIS_OSX_IMAGE" = "xcode8.3" ]; then brew reinstall --build-from-source ruby; fi
   - echo "Configuring MacVim" && echo -en "travis_fold:start:config\\r"
   - NPROC=$(getconf _NPROCESSORS_ONLN)
   - ./configure $CONFOPT --enable-fail-if-missing


### PR DESCRIPTION
build error in if_ruby.c:

```
if_ruby.c:1069:9: error: use of unknown builtin '__builtin_alloca_with_align' [-Wimplicit-function-declaration]
        buff = ALLOCA_N(char, RSTRING_LEN(str) + 1);
               ^
/usr/local/Cellar/ruby/2.6.0/include/ruby-2.6.0/ruby/ruby.h:1666:12: note: expanded from macro 'ALLOCA_N'
    (type*)__builtin_alloca_with_align((sizeof(type)*(n)), \
           ^
if_ruby.c:1069:9: warning: cast to 'char *' from smaller integer type 'int' [-Wint-to-pointer-cast]
/usr/local/Cellar/ruby/2.6.0/include/ruby-2.6.0/ruby/ruby.h:1666:5: note: expanded from macro 'ALLOCA_N'
    (type*)__builtin_alloca_with_align((sizeof(type)*(n)), \
    ^
```

Homebrew's ruby bottle for sierra has built by Xcode 9.x, which supports '__builtin_alloca_with_align' so 'ALLOCA_N' macro in ruby.h uses it, but Xcode 8.x doesn't support it then causes the above error.

For workaround, should reinstall ruby from source in xcode8.3.