### PR TITLE
Fix `Class MMBackend` duplication bug on launch

### DIFF
--- a/src/MacVim/mvim
+++ b/src/MacVim/mvim
@@ -11,21 +11,17 @@
 # Bjorn Winckler (Aug 13 2007).
 
 # Find Vim executable
-if [ -L "$0" ]; then
-	# readlink -f
-	curdir=`pwd -P`
-	self_path=$0
-	cd "`dirname $self_path`"
-	while [ -L "$self_path" ]; do
-		self_path=`readlink $self_path`
-		cd "`dirname $self_path`"
-		self_path=`basename $self_path`
-	done
-	binary="`pwd -P`/../MacOS/Vim"
-	cd "$curdir"
-else
-	binary="`dirname "$0"`/../MacOS/Vim"
-fi
+orig_path="$(pwd -P)"
+self_path="$0"
+while [ -L "$self_path" ]; do  # dereference links
+	link="$(basename "$self_path")"
+	cd "$(dirname "$self_path")"
+	self_path="$(readlink "$link")"
+done
+cd "$(dirname "$self_path")"
+binary="$(dirname "$(pwd -P)")/MacOS/Vim"
+cd "$orig_path"
+
 if ! [ -x "$binary" ]; then
 	echo "Sorry, cannot find Vim executable."
 	exit 1


### PR DESCRIPTION
This issue was detected on both Homebrew and Github released MacVim for v8.1 on a fresh install of OS High Sierra with no .vim or .vimrc configuration

Basically, when starting vim from the command line, it produces the following error (from homebrew -- similar with different paths for Github release version):

```
objc[4513]: Class MMBackend is implemented in both /usr/local/Cellar/macvim/8.1-153/MacVim.app/Contents/bin/../MacOS/Vim (0x10b303f38) and /usr/local/Cellar/macvim/8.1-153/MacVim.app/Contents/MacOS/Vim (0x217f5bf38). One of the two will be used. Which one is undefined.
```

If launching graphical interface, the error shows up twice.

The issue was traced to the use of '/../' in the binary path for launching the application which somehow pollutes the library path for the executable, finding copies of the MMBackend class in both the absolute path and the quazi-relative path.

To resolve this, the relative component was removed from the path resolution of the actual Vim binary by actually dropping down a directory from the script location.  It also simplifies the dereferencing of any link chains to that script.