### PR TITLE
 Mark flaky tests as pending when they failed

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -370,6 +370,15 @@ for s:test in sort(s:tests)
       if run_nr == 5 || prev_error == v:errors[0]
         call add(total_errors, 'Flaky test failed too often, giving up')
         let v:errors = total_errors
+        if has('gui_macvim')
+          " MacVim's currently doesn't always pass these tests. Make these
+          " tests pending for now before a more proper fix is implemented.
+          call extend(s:messages, [
+                \ 'Flaky test failed too often, giving up',
+                \ 'MacVim marked ' . s:test . ' as pending',
+                \ ])
+          let v:errors = []
+        endif
         break
       endif
 

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -4,12 +4,6 @@ if !has('channel')
   finish
 endif
 
-if has('gui_macvim')
-  " MacVim's currently doesn't always pass these tests. Disable these tests
-  " for now before a more proper fix is implemented.
-  finish
-endif
-
 source shared.vim
 
 let s:python = PythonProg()

--- a/src/testdir/test_stat.vim
+++ b/src/testdir/test_stat.vim
@@ -142,7 +142,6 @@ func Test_getftype()
     call delete('Xfifo')
   endif
 
-  if !has("gui_macvim")
   for cdevfile in systemlist('find /dev -type c -maxdepth 2 2>/dev/null')
     let type = getftype(cdevfile)
     " ignore empty result, can happen if the file disappeared
@@ -150,7 +149,6 @@ func Test_getftype()
       call assert_equal('cdev', type)
     endif
   endfor
-  endif
 
   for bdevfile in systemlist('find /dev -type b -maxdepth 2 2>/dev/null')
     let type = getftype(bdevfile)

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -645,12 +645,6 @@ func Test_terminal_write_stdin()
 endfunc
 
 func Test_terminal_no_cmd()
-  if has('gui_macvim') && has('gui_running')
-    " MacVim: For some reason this test is failing in GUI unit tests. Need to
-    " investigate.
-    return
-  endif
-
   let buf = term_start('NONE', {})
   call assert_notequal(0, buf)
 

--- a/src/testdir/test_timers.vim
+++ b/src/testdir/test_timers.vim
@@ -4,12 +4,6 @@ if !has('timers')
   finish
 endif
 
-if has('gui_macvim')
-  " MacVim's GUI currently doesn't always pass these tests. Disable these
-  " tests for now when testing before a more proper fix is implemented.
-  finish
-endif
-
 source shared.vim
 source screendump.vim
 


### PR DESCRIPTION
Skipping whole test_channel and test_timers looks a too rough way.

I propose marking flaky tests as pending (and not regard as NG) when they failed for now.