### PR TITLE
Fix rendering performance issue when using :version or echo commands

### DIFF
--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -277,6 +277,8 @@ enum {
     SetCursorPosDrawType,
     DrawInvertedRectDrawType,
     DrawSignDrawType,
+
+    InvalidDrawType = -1
 };
 
 enum {


### PR DESCRIPTION
This fixes 10.14 Mojave's CoreText renderer taking a long time to render `:version` / `:ls` / `:!` / `:echo` or similar commands.

This issue happened because the way Vim echos the output of those commands is by issuing a draw calls in the pattern of "delete 1 line, draw some text, delete another line...". Each line delete causes the renderer to do a scroll. The pre-Mojave renderer relies on calling [`scrollRect:by:`](https://developer.apple.com/documentation/appkit/nsview/1483497-scrollrect) but this doesn't work in Mojave anymore since that function is deprecated and doesn't work in layer-backed views (which are now mandatory). The new renderer's scroll implementation is a lot slower since it's doing image blits on CPU.

The fix is to implement a draw command optimizer that pre-processes the draw calls first. It works by batching together all the "delete 1 line" calls and combine into a single "delete N lines" call and put that in the beginning, and fixing up all the other draw string command so they draw to the right line instead of needing to be scrolled up. This makes `:version` or the other calls feel instaneous now.

This fix is ultimately a hack and an intermediary solution before the renderer can be replaced (since the slow CPU scrolling causes normal usage to feel sluggish as well) by a GPU-based renderer and/or a glyph-based one that caches the state of the texts so repeated scrolling can be done by shuffling the glpyh data around instead of an actualy image blit.

Fix #815