### PR TITLE
Update Travis to Xcode 10.2, which also uses macOS Mojave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ osx_image:
   - xcode7.3
   - xcode8.3
   - xcode9.4
-  - xcode10.1
+  - xcode10.2
 
 compiler:
   - clang


### PR DESCRIPTION
Update to Xcode 10.2 beta, which is still in beta but the VM now use
Mojave which is what we want.

See https://blog.travis-ci.com/2019-02-12-xcode-10-2-beta-2-is-now-available