### PR TITLE
Stateful, fast renderer for MMCoreTextView

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -248,8 +248,6 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         [NSNumber numberWithBool:NO],     MMSuppressTerminationAlertKey,
         [NSNumber numberWithBool:YES],    MMNativeFullScreenKey,
         [NSNumber numberWithDouble:0.25], MMFullScreenFadeTimeKey,
-        [NSNumber numberWithBool:NO],     MMUseCGLayerAlwaysKey,
-        @(shouldUseBufferedDrawing()),    MMBufferedDrawingKey,
         [NSNumber numberWithBool:YES],    MMShareFindPboardKey,
         nil];
 

--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -31,42 +31,13 @@
     BOOL                        antialias;
     BOOL                        ligatures;
     BOOL                        thinStrokes;
-    BOOL                        drawPending;
-    NSMutableArray              *drawData;
 
     MMTextViewHelper            *helper;
 
-    unsigned                    maxlen;
-    CGGlyph                     *glyphs;
-    CGPoint                     *positions;
-    NSMutableArray              *fontCache;
-
-    // Issue draws onto an CGImage that caches the drawn results instead of
-    // directly in drawRect:. This is the default behavior in cases where simply
-    // drawing incrementally in drawRect: doesn't work. Those cases are:
-    // 1. Non-native fullscreen
-    // 2. 10.14+ (views are always layer-backed which means the view buffer will
-    //    be cleared and we can't incrementally draw in drawRect:)
-    //    
-    // This can be configured by setting MMBufferedDrawingKey in user defaults.
-    BOOL                        cgBufferDrawEnabled;
-    BOOL                        cgBufferDrawNeedsUpdateContext;
-    CGContextRef                cgContext;
+    NSMutableDictionary<NSNumber *, NSFont *> *fontVariants;
+    NSMutableSet<NSString *> *characterStrings;
+    NSMutableDictionary<NSNumber *,NSCache<NSString *,id> *> *characterLines;
     
-    // *Deprecated*
-    // Draw onto a CGLayer instead of lazily updating the view's buffer in
-    // drawRect: which is error-prone and relying on undocumented behaviors
-    // (that the OS will preserve the old buffer).
-    //
-    // This is deprecated. Use cgBufferDrawEnabled instead which is more
-    // efficient.
-    //    
-    // This can be configured by setting MMUseCGLayerAlwaysKey in user defaults.
-    BOOL                        cgLayerEnabled;
-    CGLayerRef                  cgLayer;
-    CGContextRef                cgLayerContext;
-    NSLock                      *cgLayerLock;
-
     // These are used in MMCoreTextView+ToolTip.m
     id trackingRectOwner_;              // (not retained)
     void *trackingRectUserData_;
@@ -113,13 +84,10 @@
 - (BOOL)convertPoint:(NSPoint)point toRow:(int *)row column:(int *)column;
 - (NSRect)rectForRow:(int)row column:(int)column numRows:(int)nr
           numColumns:(int)nc;
-- (void)setCGLayerEnabled:(BOOL)enabled;
-- (BOOL)getCGLayerEnabled;
 
 //
 // NSTextView methods
 //
-- (void)setFrameSize:(NSSize)newSize;
 - (void)keyDown:(NSEvent *)event;
 - (void)insertText:(id)string;
 - (void)doCommandBySelector:(SEL)selector;

--- a/src/MacVim/MMFullScreenWindow.h
+++ b/src/MacVim/MMFullScreenWindow.h
@@ -34,9 +34,6 @@
     // Controls the speed of the fade in and out.
     double      fadeTime;
     double      fadeReservationTime;
-    
-    // For pre-10.14 we manually sets CGLayer mode, so need to remember the original state
-    BOOL        origCGLayerEnabled;
 }
 
 - (MMFullScreenWindow *)initWithWindow:(NSWindow *)t view:(MMVimView *)v

--- a/src/MacVim/MMFullScreenWindow.m
+++ b/src/MacVim/MMFullScreenWindow.m
@@ -113,8 +113,6 @@ enum {
     fadeTime = MIN(fadeTime, 0.5 * (kCGMaxDisplayReservationInterval - 1));
     fadeReservationTime = 2.0 * fadeTime + 1;
     
-    origCGLayerEnabled = NO;
-    
     return self;
 }
 
@@ -174,11 +172,6 @@ enum {
     oldPosition = [view frame].origin;
 
     [view removeFromSuperviewWithoutNeedingDisplay];
-    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_12) {
-        // This shouldn't do much in 10.14+.
-        origCGLayerEnabled = [[view textView] getCGLayerEnabled];
-        [[view textView] setCGLayerEnabled:YES];
-    }
     [[self contentView] addSubview:view];
     [self setInitialFirstResponder:[view textView]];
     
@@ -294,9 +287,6 @@ enum {
 
     [view setFrameOrigin:oldPosition];
     [self close];
-
-    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_12)
-        [[view textView] setCGLayerEnabled:origCGLayerEnabled];
 
     // Set the text view to initial first responder, otherwise the 'plus'
     // button on the tabline steals the first responder status.

--- a/src/MacVim/MMTextView.h
+++ b/src/MacVim/MMTextView.h
@@ -73,6 +73,4 @@
 // NOT IMPLEMENTED (only in Core Text renderer)
 - (void)deleteSign:(NSString *)signName;
 - (void)setToolTipAtMousePoint:(NSString *)string;
-- (void)setCGLayerEnabled:(BOOL)enabled;
-- (BOOL)getCGLayerEnabled;
 @end

--- a/src/MacVim/MMTextView.m
+++ b/src/MacVim/MMTextView.m
@@ -522,16 +522,6 @@
     // ONLY in Core Text!
 }
 
-- (void)setCGLayerEnabled:(BOOL)enabled
-{
-    // ONLY in Core Text!
-}
-
-- (BOOL)getCGLayerEnabled
-{
-    return NO;
-}
-
 - (BOOL)isOpaque
 {
     return NO;

--- a/src/MacVim/MMTextViewHelper.h
+++ b/src/MacVim/MMTextViewHelper.h
@@ -18,6 +18,7 @@
 #define GREEN(argb)     (((argb>>8) & 0xff)/255.0f)
 #define RED(argb)       (((argb>>16) & 0xff)/255.0f)
 #define ALPHA(argb)     (((argb>>24) & 0xff)/255.0f)
+#define COMPONENTS(argb) ((CGFloat[]){RED(argb), GREEN(argb), BLUE(argb), ALPHA(argb)})
 
 
 @interface MMTextViewHelper : NSObject {

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -58,6 +58,7 @@
 # define NSAlertStyleInformational NSInformationalAlertStyle
 # define NSAlertStyleWarning NSWarningAlertStyle
 # define NSCompositingOperationSourceOver NSCompositeSourceOver
+# define NSCompositingOperationDifference NSCompositeDifference
 # define NSControlSizeRegular NSRegularControlSize
 # define NSEventModifierFlagCapsLock NSAlphaShiftKeyMask
 # define NSEventModifierFlagCommand NSCommandKeyMask
@@ -367,6 +368,7 @@ extern NSString *VimFindPboardType;
 
 
 @interface NSColor (MMExtras)
+@property(readonly) unsigned argbInt;
 + (NSColor *)colorWithRgbInt:(unsigned)rgb;
 + (NSColor *)colorWithArgbInt:(unsigned)argb;
 @end

--- a/src/MacVim/MacVim.m
+++ b/src/MacVim/MacVim.m
@@ -157,6 +157,14 @@ debugStringForMessageQueue(NSArray *queue)
 
 @implementation NSColor (MMExtras)
 
+- (unsigned)argbInt {
+    CGFloat rf, gf, bf, af;
+    [[self colorUsingColorSpace:NSColorSpace.deviceRGBColorSpace]
+     getRed:&rf green:&gf blue:&bf alpha:&af];
+    unsigned r = rf * 255, g = gf * 255, b = bf * 255, a = af*255;
+    return a<<24 | r<<16 | g<<8 | b;
+}
+
 + (NSColor *)colorWithRgbInt:(unsigned)rgb
 {
     float r = ((rgb>>16) & 0xff)/255.0f;

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -55,8 +55,6 @@ extern NSString *MMSuppressTerminationAlertKey;
 extern NSString *MMNativeFullScreenKey;
 extern NSString *MMUseMouseTimeKey;
 extern NSString *MMFullScreenFadeTimeKey;
-extern NSString *MMUseCGLayerAlwaysKey;
-extern NSString *MMBufferedDrawingKey;
 
 
 // Enum for MMUntitledWindowKey
@@ -168,6 +166,5 @@ NSArray *normalizeFilenames(NSArray *filenames);
 
 BOOL shouldUseYosemiteTabBarStyle();
 BOOL shouldUseMojaveTabBarStyle();
-BOOL shouldUseBufferedDrawing();
 
 int getCurrentAppearance(NSAppearance *appearance);

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -51,8 +51,6 @@ NSString *MMSuppressTerminationAlertKey   = @"MMSuppressTerminationAlert";
 NSString *MMNativeFullScreenKey           = @"MMNativeFullScreen";
 NSString *MMUseMouseTimeKey               = @"MMUseMouseTime";
 NSString *MMFullScreenFadeTimeKey         = @"MMFullScreenFadeTime";
-NSString *MMUseCGLayerAlwaysKey           = @"MMUseCGLayerAlways";
-NSString *MMBufferedDrawingKey            = @"MMBufferedDrawing";
 
 
 
@@ -325,18 +323,6 @@ shouldUseMojaveTabBarStyle()
 #endif
     return false;
 }
-
-BOOL
-shouldUseBufferedDrawing()
-{
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
-    if (@available(macos 10.14, *)) {
-        return YES;
-    }
-#endif
-    return NO;
-}
-
 
 int
 getCurrentAppearance(NSAppearance *appearance){

--- a/src/move.c
+++ b/src/move.c
@@ -19,9 +19,6 @@
 
 #include "vim.h"
 
-#ifdef FEAT_GUI_MACVIM
-static void redraw_for_ligatures(win_T *wp);
-#endif
 static int scrolljump_value(void);
 static int check_top_offset(void);
 static void curs_rows(win_T *wp);
@@ -161,29 +158,6 @@ redraw_for_cursorline(win_T *wp)
 #endif
     }
 }
-
-#ifdef FEAT_GUI_MACVIM
-/*
- * Redraw when 'macligatures' is set.
- * This is basically the same as when 'cursorline'
- * or 'relativenumber' is set but unconditional.
- */
-static void
-redraw_for_ligatures(wp)
-     win_T *wp;
-{
-	/* Only if ligatures are on but neither
-	 * 'cursorline' nor 'relativenumber'.
-	 */
-	if (p_macligatures
-	    && (wp->w_p_rnu == 0
-#ifdef FEAT_SYN_HL
-	        && wp->w_p_cul == 0
-#endif
-	    ))
-	redraw_win_later(wp, CLEAR);
-}
-#endif
 
 /*
  * Update curwin->w_topline and redraw if necessary.
@@ -809,9 +783,6 @@ curs_rows(win_T *wp)
     }
 
     redraw_for_cursorline(curwin);
-#ifdef FEAT_GUI_MACVIM
-    redraw_for_ligatures(curwin);
-#endif
     wp->w_valid |= VALID_CROW|VALID_CHEIGHT;
 
 }


### PR DESCRIPTION
This change replaces the current rendering paths in `MMCoreTextView` with one which draws from an array of structs that represent the state of each character cell. It applies draw commands to the array
and marks any touched cells as needing display instead of drawing to a view or image buffer.

In my own tests, this renderer seems to be roughly twice as fast of the current one. Because it seems to work for the use cases of all of the current renderers and reused a lot of code, this PR replaces the other paths instead of adding a preference.

Fixes #796.