### PR TITLE
Add macaction to maximize the window.

### DIFF
--- a/src/MacVim/Actions.plist
+++ b/src/MacVim/Actions.plist
@@ -50,6 +50,8 @@
 	<string></string>
 	<key>performMiniaturize:</key>
 	<string></string>
+	<key>performMaximize:</key>
+	<string></string>
 	<key>performZoom:</key>
 	<string></string>
 	<key>recentFilesDummy:</key>

--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -109,5 +109,6 @@
 - (IBAction)fontSizeDown:(id)sender;
 - (IBAction)findAndReplace:(id)sender;
 - (IBAction)zoom:(id)sender;
+- (IBAction)performMaximize:(id)sender;
 
 @end

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1191,6 +1191,22 @@
     [vimController sendMessage:ZoomMsgID data:data];
 }
 
+- (IBAction)performMaximize:(id)sender
+{
+    NSWindow *win = [self window];
+    NSRect maxFrame = [[win screen] frame];
+    int maxRows, maxColumns;
+    NSData *data;
+
+    [vimView constrainRows:&maxRows columns:&maxColumns toSize:maxFrame.size];
+    data = [NSData dataWithBytes:(int [2]){maxRows, maxColumns} length:(2 * sizeof(int))];
+    [[self vimController] sendMessage:SetTextDimensionsMsgID data:data];
+    [[vimView textView] setMaxRows:maxRows columns:maxColumns];
+
+    [win setFrameOrigin:maxFrame.origin];
+    [win setIsZoomed:YES];
+}
+
 
 
 // -- Services menu delegate -------------------------------------------------


### PR DESCRIPTION
Many Vim users, myself included, prefer to start Vim in a maximized window state.  For this, I have added the performMaximize: macaction.  This allows the following to be added to a vimrc:

`autocmd GUIEnter * macaction performMaximize:`