### PR TITLE
Add option to enable a transparent titlebar #884

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -250,6 +250,7 @@ KEY				VALUE ~
 *MMLoginShellCommand*		which shell to use to launch Vim [string]
 *MMNoFontSubstitution*		disable automatic font substitution [bool]
 *MMNoTitleBarWindow*		hide title bar [bool]
+*MMTitlebarAppearsTransparent*	enable a transparent titlebar [bool]
 *MMShareFindPboard*		share search text to Find Pasteboard [bool]
 *MMShowAddTabButton*		enable "add tab" button on tabline [bool]
 *MMTabMaxWidth*			maximum width of a tab [int]

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4853,6 +4853,7 @@ MMLoginShellArgument	gui_mac.txt	/*MMLoginShellArgument*
 MMLoginShellCommand	gui_mac.txt	/*MMLoginShellCommand*
 MMNoFontSubstitution	gui_mac.txt	/*MMNoFontSubstitution*
 MMNoTitleBarWindow	gui_mac.txt	/*MMNoTitleBarWindow*
+MMTitlebarAppearsTransparent	gui_mac.txt	/*MMTitlebarAppearsTransparent*
 MMShareFindPboard	gui_mac.txt	/*MMShareFindPboard*
 MMShowAddTabButton	gui_mac.txt	/*MMShowAddTabButton*
 MMTabMaxWidth	gui_mac.txt	/*MMTabMaxWidth*

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -148,6 +148,12 @@
                         backing:NSBackingStoreBuffered
                           defer:YES];
     [win autorelease];
+    
+    if ([[NSUserDefaults standardUserDefaults]
+         boolForKey:MMTitlebarAppearsTransparentKey]) {
+        // Transparent title bar setting
+        win.titlebarAppearsTransparent = true;
+    }
 
     self = [super initWithWindow:win];
     if (!self) return nil;

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -34,6 +34,7 @@ extern NSString *MMTopLeftPointKey;
 extern NSString *MMOpenInCurrentWindowKey;
 extern NSString *MMNoFontSubstitutionKey;
 extern NSString *MMNoTitleBarWindowKey;
+extern NSString *MMTitlebarAppearsTransparentKey;
 extern NSString *MMLoginShellKey;
 extern NSString *MMUntitledWindowKey;
 extern NSString *MMZoomBothKey;

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -14,42 +14,43 @@
 
 
 // NSUserDefaults keys
-NSString *MMTabMinWidthKey              = @"MMTabMinWidth";
-NSString *MMTabMaxWidthKey              = @"MMTabMaxWidth";
-NSString *MMTabOptimumWidthKey          = @"MMTabOptimumWidth";
-NSString *MMShowAddTabButtonKey         = @"MMShowAddTabButton";
-NSString *MMTextInsetLeftKey            = @"MMTextInsetLeft";
-NSString *MMTextInsetRightKey           = @"MMTextInsetRight";
-NSString *MMTextInsetTopKey             = @"MMTextInsetTop";
-NSString *MMTextInsetBottomKey          = @"MMTextInsetBottom";
-NSString *MMTypesetterKey               = @"MMTypesetter";
-NSString *MMCellWidthMultiplierKey      = @"MMCellWidthMultiplier";
-NSString *MMBaselineOffsetKey           = @"MMBaselineOffset";
-NSString *MMTranslateCtrlClickKey       = @"MMTranslateCtrlClick";
-NSString *MMTopLeftPointKey             = @"MMTopLeftPoint";
-NSString *MMOpenInCurrentWindowKey      = @"MMOpenInCurrentWindow";
-NSString *MMNoFontSubstitutionKey       = @"MMNoFontSubstitution";
-NSString *MMNoTitleBarWindowKey         = @"MMNoTitleBarWindow";
-NSString *MMLoginShellKey               = @"MMLoginShell";
-NSString *MMUntitledWindowKey           = @"MMUntitledWindow";
-NSString *MMZoomBothKey                 = @"MMZoomBoth";
-NSString *MMCurrentPreferencePaneKey    = @"MMCurrentPreferencePane";
-NSString *MMLoginShellCommandKey        = @"MMLoginShellCommand";
-NSString *MMLoginShellArgumentKey       = @"MMLoginShellArgument";
-NSString *MMDialogsTrackPwdKey          = @"MMDialogsTrackPwd";
-NSString *MMOpenLayoutKey               = @"MMOpenLayout";
-NSString *MMVerticalSplitKey            = @"MMVerticalSplit";
-NSString *MMPreloadCacheSizeKey         = @"MMPreloadCacheSize";
-NSString *MMLastWindowClosedBehaviorKey = @"MMLastWindowClosedBehavior";
+NSString *MMTabMinWidthKey                = @"MMTabMinWidth";
+NSString *MMTabMaxWidthKey                = @"MMTabMaxWidth";
+NSString *MMTabOptimumWidthKey            = @"MMTabOptimumWidth";
+NSString *MMShowAddTabButtonKey           = @"MMShowAddTabButton";
+NSString *MMTextInsetLeftKey              = @"MMTextInsetLeft";
+NSString *MMTextInsetRightKey             = @"MMTextInsetRight";
+NSString *MMTextInsetTopKey               = @"MMTextInsetTop";
+NSString *MMTextInsetBottomKey            = @"MMTextInsetBottom";
+NSString *MMTypesetterKey                 = @"MMTypesetter";
+NSString *MMCellWidthMultiplierKey        = @"MMCellWidthMultiplier";
+NSString *MMBaselineOffsetKey             = @"MMBaselineOffset";
+NSString *MMTranslateCtrlClickKey         = @"MMTranslateCtrlClick";
+NSString *MMTopLeftPointKey               = @"MMTopLeftPoint";
+NSString *MMOpenInCurrentWindowKey        = @"MMOpenInCurrentWindow";
+NSString *MMNoFontSubstitutionKey         = @"MMNoFontSubstitution";
+NSString *MMNoTitleBarWindowKey           = @"MMNoTitleBarWindow";
+NSString *MMTitlebarAppearsTransparentKey = @"MMTitlebarAppearsTransparent";
+NSString *MMLoginShellKey                 = @"MMLoginShell";
+NSString *MMUntitledWindowKey             = @"MMUntitledWindow";
+NSString *MMZoomBothKey                   = @"MMZoomBoth";
+NSString *MMCurrentPreferencePaneKey      = @"MMCurrentPreferencePane";
+NSString *MMLoginShellCommandKey          = @"MMLoginShellCommand";
+NSString *MMLoginShellArgumentKey         = @"MMLoginShellArgument";
+NSString *MMDialogsTrackPwdKey            = @"MMDialogsTrackPwd";
+NSString *MMOpenLayoutKey                 = @"MMOpenLayout";
+NSString *MMVerticalSplitKey              = @"MMVerticalSplit";
+NSString *MMPreloadCacheSizeKey           = @"MMPreloadCacheSize";
+NSString *MMLastWindowClosedBehaviorKey   = @"MMLastWindowClosedBehavior";
 #ifdef INCLUDE_OLD_IM_CODE
-NSString *MMUseInlineImKey              = @"MMUseInlineIm";
+NSString *MMUseInlineImKey                = @"MMUseInlineIm";
 #endif // INCLUDE_OLD_IM_CODE
-NSString *MMSuppressTerminationAlertKey = @"MMSuppressTerminationAlert";
-NSString *MMNativeFullScreenKey         = @"MMNativeFullScreen";
-NSString *MMUseMouseTimeKey             = @"MMUseMouseTime";
-NSString *MMFullScreenFadeTimeKey       = @"MMFullScreenFadeTime";
-NSString *MMUseCGLayerAlwaysKey         = @"MMUseCGLayerAlways";
-NSString *MMBufferedDrawingKey          = @"MMBufferedDrawing";
+NSString *MMSuppressTerminationAlertKey   = @"MMSuppressTerminationAlert";
+NSString *MMNativeFullScreenKey           = @"MMNativeFullScreen";
+NSString *MMUseMouseTimeKey               = @"MMUseMouseTime";
+NSString *MMFullScreenFadeTimeKey         = @"MMFullScreenFadeTime";
+NSString *MMUseCGLayerAlwaysKey           = @"MMUseCGLayerAlways";
+NSString *MMBufferedDrawingKey            = @"MMBufferedDrawing";
 
 
 


### PR DESCRIPTION
Adds an option `MMTitlebarAppearsTransparent` that makes the titlebar appear transparent.

<img width="690" alt="Screenshot 2019-04-27 at 22 05 27" src="https://user-images.githubusercontent.com/519188/56854549-bfe43580-6938-11e9-84f8-e958938be4cb.png">
<img width="690" alt="Screenshot 2019-04-27 at 22 05 47" src="https://user-images.githubusercontent.com/519188/56854550-bfe43580-6938-11e9-8dbe-f23effd698c7.png">

One thing to consider is that the text colour in the titlebar is decided by the system appearance setting, so if you use a dark theme in vim and have the system appearance set to Light the titlebar text will be hard to see. I'm assuming people using this setting will recognise that.