### PR TITLE
Remove setting default pythonhome and pythonthreehome

### DIFF
--- a/src/MacVim/vimrc
+++ b/src/MacVim/vimrc
@@ -22,15 +22,12 @@ if exists("&pythondll") && exists("&pythonhome")
   if filereadable("/usr/local/Frameworks/Python.framework/Versions/2.7/Python")
     " Homebrew python 2.7
     set pythondll=/usr/local/Frameworks/Python.framework/Versions/2.7/Python
-    set pythonhome=/usr/local/Frameworks/Python.framework/Versions/2.7
   elseif filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python")
     " MacPorts python 2.7
     set pythondll=/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python
-    set pythonhome=/opt/local/Library/Frameworks/Python.framework/Versions/2.7
   elseif filereadable("/Library/Frameworks/Python.framework/Versions/2.7/Python")
     " https://www.python.org/downloads/mac-osx/
     set pythondll=/Library/Frameworks/Python.framework/Versions/2.7/Python
-    set pythonhome=/Library/Frameworks/Python.framework/Versions/2.7
   endif
 endif
 
@@ -43,11 +40,9 @@ if exists("&pythonthreedll") && exists("&pythonthreehome") &&
   if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.7/Python")
     " MacPorts python 3.7
     set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.7/Python
-    set pythonthreehome=/opt/local/Library/Frameworks/Python.framework/Versions/3.7
   elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.7/Python")
     " https://www.python.org/downloads/mac-osx/
     set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.7/Python
-    set pythonthreehome=/Library/Frameworks/Python.framework/Versions/3.7
   endif
 endif
 


### PR DESCRIPTION
It's enough to set pythondll/pythonthreedll if you want defaults as per vim/vim@0424958. Before it was a requirement to set both.

Probably, closes #562 forever.

@ychin please verify if  compile flags doesn't specify pythonhome/pythonthreehome explicitly 