### PR TITLE
Add missing message ID string, then refactor to make that harder to repeat

### DIFF
--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -1322,7 +1322,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
         for (i = 1; i < count; i += 2) {
             if ([[inputQueue objectAtIndex:i-1] intValue] == msgid) {
                 ASLogDebug(@"Input queue filling up, remove message: %s",
-                                                        MessageStrings[msgid]);
+                                                        MMVimMsgIDStrings[msgid]);
                 [inputQueue removeObjectAtIndex:i];
                 [inputQueue removeObjectAtIndex:i-1];
                 break;
@@ -1860,7 +1860,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
         if ([data isEqual:[NSNull null]])
             data = nil;
 
-        ASLogDebug(@"(%d) %s", i, MessageStrings[msgid]);
+        ASLogDebug(@"(%d) %s", i, MMVimMsgIDStrings[msgid]);
         [self handleInputEvent:msgid data:data];
     }
 

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -351,7 +351,7 @@ static BOOL isUnsafeMessage(int msgid);
 - (void)sendMessage:(int)msgid data:(NSData *)data
 {
     ASLogDebug(@"msg=%s (isInitialized=%d)",
-               MessageStrings[msgid], isInitialized);
+               MMVimMsgIDStrings[msgid], isInitialized);
 
     if (!isInitialized) return;
 
@@ -360,7 +360,7 @@ static BOOL isUnsafeMessage(int msgid);
     }
     @catch (NSException *ex) {
         ASLogDebug(@"processInput:data: failed: pid=%d id=%d msg=%s reason=%@",
-                pid, identifier, MessageStrings[msgid], ex);
+                pid, identifier, MMVimMsgIDStrings[msgid], ex);
     }
 }
 
@@ -373,7 +373,7 @@ static BOOL isUnsafeMessage(int msgid);
     // used instead.
 
     ASLogDebug(@"msg=%s (isInitialized=%d)",
-               MessageStrings[msgid], isInitialized);
+               MMVimMsgIDStrings[msgid], isInitialized);
 
     if (!isInitialized)
         return NO;
@@ -392,7 +392,7 @@ static BOOL isUnsafeMessage(int msgid);
     @catch (NSException *ex) {
         sendOk = NO;
         ASLogDebug(@"processInput:data: failed: pid=%d id=%d msg=%s reason=%@",
-                pid, identifier, MessageStrings[msgid], ex);
+                pid, identifier, MMVimMsgIDStrings[msgid], ex);
     }
     @finally {
         [conn setRequestTimeout:oldTimeout];
@@ -587,7 +587,7 @@ static BOOL isUnsafeMessage(int msgid);
                 delayQueue = [NSMutableArray array];
 
             ASLogDebug(@"Adding unsafe message '%s' to delay queue (mode=%@)",
-                       MessageStrings[msgid],
+                       MMVimMsgIDStrings[msgid],
                        [[NSRunLoop currentRunLoop] currentMode]);
             [delayQueue addObject:value];
             [delayQueue addObject:data];

--- a/src/MacVim/MMVimView.m
+++ b/src/MacVim/MMVimView.m
@@ -968,7 +968,7 @@ enum {
 
         ASLogDebug(@"Notify Vim that text dimensions changed from %dx%d to "
                    "%dx%d (%s)", cols, rows, constrained[1], constrained[0],
-                   MessageStrings[msgid]);
+                   MMVimMsgIDStrings[msgid]);
 
         if (msgid != LiveResizeMsgID || !self.pendingLiveResize) {
             // Live resize messages can be sent really rapidly, especailly if

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1764,7 +1764,7 @@
         }
         NSParameterAssert(data != nil && msgid != 0);
 
-        ASLogDebug(@"%s: %dx%d", MessageStrings[msgid], fuRows, fuColumns);
+        ASLogDebug(@"%s: %dx%d", MMVimMsgIDStrings[msgid], fuRows, fuColumns);
         MMVimController *vc = [self vimController];
         [vc sendMessage:msgid data:data];
         [[vimView textView] setMaxRows:fuRows columns:fuColumns];

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -168,102 +168,107 @@
 // Vim.  These can be sent in processInput:data: and in processCommandQueue:.
 //
 
-// NOTE! This array must be updated whenever the enum below changes!
-extern char *MessageStrings[];
+extern const char * const MMVimMsgIDStrings[];
+
+#define FOREACH_MMVimMsgID(MSG) \
+    MSG(NullMsgID) \
+    MSG(OpenWindowMsgID) \
+    MSG(KeyDownMsgID) \
+    MSG(BatchDrawMsgID) \
+    MSG(SelectTabMsgID) \
+    MSG(CloseTabMsgID) \
+    MSG(AddNewTabMsgID) \
+    MSG(DraggedTabMsgID) \
+    MSG(UpdateTabBarMsgID) \
+    MSG(ShowTabBarMsgID) \
+    MSG(HideTabBarMsgID) \
+    MSG(SetTextRowsMsgID) \
+    MSG(SetTextColumnsMsgID) \
+    MSG(SetTextDimensionsMsgID) \
+    MSG(SetTextDimensionsNoResizeWindowMsgID) \
+    MSG(LiveResizeMsgID) \
+    MSG(SetTextDimensionsReplyMsgID) \
+    MSG(ResizeViewMsgID) \
+    MSG(SetWindowTitleMsgID) \
+    MSG(ScrollWheelMsgID) \
+    MSG(MouseDownMsgID) \
+    MSG(MouseUpMsgID) \
+    MSG(MouseDraggedMsgID) \
+    MSG(FlushQueueMsgID) \
+    MSG(AddMenuMsgID) \
+    MSG(AddMenuItemMsgID) \
+    MSG(RemoveMenuItemMsgID) \
+    MSG(EnableMenuItemMsgID) \
+    MSG(ExecuteMenuMsgID) \
+    MSG(ShowToolbarMsgID) \
+    MSG(ToggleToolbarMsgID) \
+    MSG(CreateScrollbarMsgID) \
+    MSG(DestroyScrollbarMsgID) \
+    MSG(ShowScrollbarMsgID) \
+    MSG(SetScrollbarPositionMsgID) \
+    MSG(SetScrollbarThumbMsgID) \
+    MSG(ScrollbarEventMsgID) \
+    MSG(SetFontMsgID) \
+    MSG(SetWideFontMsgID) \
+    MSG(VimShouldCloseMsgID) \
+    MSG(SetDefaultColorsMsgID) \
+    MSG(ExecuteActionMsgID) \
+    MSG(DropFilesMsgID) \
+    MSG(DropStringMsgID) \
+    MSG(ShowPopupMenuMsgID) \
+    MSG(GotFocusMsgID) \
+    MSG(LostFocusMsgID) \
+    MSG(MouseMovedMsgID) \
+    MSG(SetMouseShapeMsgID) \
+    MSG(AdjustLinespaceMsgID) \
+    MSG(AdjustColumnspaceMsgID) \
+    MSG(ActivateMsgID) \
+    MSG(SetServerNameMsgID) \
+    MSG(EnterFullScreenMsgID) \
+    MSG(LeaveFullScreenMsgID) \
+    MSG(SetBuffersModifiedMsgID) \
+    MSG(AddInputMsgID) \
+    MSG(SetPreEditPositionMsgID) \
+    MSG(TerminateNowMsgID) \
+    MSG(XcodeModMsgID) \
+    MSG(EnableAntialiasMsgID) \
+    MSG(DisableAntialiasMsgID) \
+    MSG(SetVimStateMsgID) \
+    MSG(SetDocumentFilenameMsgID) \
+    MSG(OpenWithArgumentsMsgID) \
+    MSG(CloseWindowMsgID) \
+    MSG(SetFullScreenColorMsgID) \
+    MSG(ShowFindReplaceDialogMsgID) \
+    MSG(FindReplaceMsgID) \
+    MSG(UseSelectionForFindMsgID) \
+    MSG(ActivateKeyScriptMsgID) \
+    MSG(DeactivateKeyScriptMsgID) \
+    MSG(EnableImControlMsgID) \
+    MSG(DisableImControlMsgID) \
+    MSG(ActivatedImMsgID) \
+    MSG(DeactivatedImMsgID) \
+    MSG(BrowseForFileMsgID) \
+    MSG(ShowDialogMsgID) \
+    MSG(SetMarkedTextMsgID) \
+    MSG(ZoomMsgID) \
+    MSG(SetWindowPositionMsgID) \
+    MSG(DeleteSignMsgID) \
+    MSG(SetTooltipMsgID) \
+    MSG(SetTooltipDelayMsgID) \
+    MSG(GestureMsgID) \
+    MSG(AddToMRUMsgID) \
+    MSG(BackingPropertiesChangedMsgID) \
+    MSG(SetBlurRadiusMsgID) \
+    MSG(EnableLigaturesMsgID) \
+    MSG(DisableLigaturesMsgID) \
+    MSG(EnableThinStrokesMsgID) \
+    MSG(DisableThinStrokesMsgID) \
+    MSG(LastMsgID) \
 
 enum {
-    OpenWindowMsgID = 1,    // NOTE: FIRST IN ENUM MUST BE 1
-    KeyDownMsgID,
-    BatchDrawMsgID,
-    SelectTabMsgID,
-    CloseTabMsgID,
-    AddNewTabMsgID,
-    DraggedTabMsgID,
-    UpdateTabBarMsgID,
-    ShowTabBarMsgID,
-    HideTabBarMsgID,
-    SetTextRowsMsgID,
-    SetTextColumnsMsgID,
-    SetTextDimensionsMsgID,
-    SetTextDimensionsNoResizeWindowMsgID,
-    LiveResizeMsgID,
-    SetTextDimensionsReplyMsgID,
-    ResizeViewMsgID,
-    SetWindowTitleMsgID,
-    ScrollWheelMsgID,
-    MouseDownMsgID,
-    MouseUpMsgID,
-    MouseDraggedMsgID,
-    FlushQueueMsgID,
-    AddMenuMsgID,
-    AddMenuItemMsgID,
-    RemoveMenuItemMsgID,
-    EnableMenuItemMsgID,
-    ExecuteMenuMsgID,
-    ShowToolbarMsgID,
-    ToggleToolbarMsgID,
-    CreateScrollbarMsgID,
-    DestroyScrollbarMsgID,
-    ShowScrollbarMsgID,
-    SetScrollbarPositionMsgID,
-    SetScrollbarThumbMsgID,
-    ScrollbarEventMsgID,
-    SetFontMsgID,
-    SetWideFontMsgID,
-    VimShouldCloseMsgID,
-    SetDefaultColorsMsgID,
-    ExecuteActionMsgID,
-    DropFilesMsgID,
-    DropStringMsgID,
-    ShowPopupMenuMsgID,
-    GotFocusMsgID,
-    LostFocusMsgID,
-    MouseMovedMsgID,
-    SetMouseShapeMsgID,
-    AdjustLinespaceMsgID,
-    AdjustColumnspaceMsgID,
-    ActivateMsgID,
-    SetServerNameMsgID,
-    EnterFullScreenMsgID,
-    LeaveFullScreenMsgID,
-    SetBuffersModifiedMsgID,
-    AddInputMsgID,
-    SetPreEditPositionMsgID,
-    TerminateNowMsgID,
-    XcodeModMsgID,
-    EnableAntialiasMsgID,
-    DisableAntialiasMsgID,
-    SetVimStateMsgID,
-    SetDocumentFilenameMsgID,
-    OpenWithArgumentsMsgID,
-    CloseWindowMsgID,
-    SetFullScreenColorMsgID,
-    ShowFindReplaceDialogMsgID,
-    FindReplaceMsgID,
-    UseSelectionForFindMsgID,
-    ActivateKeyScriptMsgID,
-    DeactivateKeyScriptMsgID,
-    EnableImControlMsgID,
-    DisableImControlMsgID,
-    ActivatedImMsgID,
-    DeactivatedImMsgID,
-    BrowseForFileMsgID,
-    ShowDialogMsgID,
-    SetMarkedTextMsgID,
-    ZoomMsgID,
-    SetWindowPositionMsgID,
-    DeleteSignMsgID,
-    SetTooltipMsgID,
-    SetTooltipDelayMsgID,
-    GestureMsgID,
-    AddToMRUMsgID,
-    BackingPropertiesChangedMsgID,
-    SetBlurRadiusMsgID,
-    EnableLigaturesMsgID,
-    DisableLigaturesMsgID,
-    EnableThinStrokesMsgID,
-    DisableThinStrokesMsgID,
-    LastMsgID   // NOTE: MUST BE LAST MESSAGE IN ENUM!
+#define ENUM_ENTRY(X) X,
+    FOREACH_MMVimMsgID(ENUM_ENTRY)
+#undef ENUM_ENTRY
 };
 
 

--- a/src/MacVim/MacVim.m
+++ b/src/MacVim/MacVim.m
@@ -14,100 +14,11 @@
 #import "MacVim.h"
 
 
-char *MessageStrings[] = 
+const char * const MMVimMsgIDStrings[] =
 {
-    "INVALID MESSAGE ID",
-    "OpenWindowMsgID",
-    "KeyDownMsgID",
-    "BatchDrawMsgID",
-    "SelectTabMsgID",
-    "CloseTabMsgID",
-    "AddNewTabMsgID",
-    "DraggedTabMsgID",
-    "UpdateTabBarMsgID",
-    "ShowTabBarMsgID",
-    "HideTabBarMsgID",
-    "SetTextRowsMsgID",
-    "SetTextColumnsMsgID",
-    "SetTextDimensionsMsgID",
-    "SetTextDimensionsNoResizeWindowMsgID",
-    "LiveResizeMsgID",
-    "SetTextDimensionsReplyMsgID",
-    "ResizeViewMsgID",
-    "SetWindowTitleMsgID",
-    "ScrollWheelMsgID",
-    "MouseDownMsgID",
-    "MouseUpMsgID",
-    "MouseDraggedMsgID",
-    "FlushQueueMsgID",
-    "AddMenuMsgID",
-    "AddMenuItemMsgID",
-    "RemoveMenuItemMsgID",
-    "EnableMenuItemMsgID",
-    "ExecuteMenuMsgID",
-    "ShowToolbarMsgID",
-    "ToggleToolbarMsgID",
-    "CreateScrollbarMsgID",
-    "DestroyScrollbarMsgID",
-    "ShowScrollbarMsgID",
-    "SetScrollbarPositionMsgID",
-    "SetScrollbarThumbMsgID",
-    "ScrollbarEventMsgID",
-    "SetFontMsgID",
-    "SetWideFontMsgID",
-    "VimShouldCloseMsgID",
-    "SetDefaultColorsMsgID",
-    "ExecuteActionMsgID",
-    "DropFilesMsgID",
-    "DropStringMsgID",
-    "ShowPopupMenuMsgID",
-    "GotFocusMsgID",
-    "LostFocusMsgID",
-    "MouseMovedMsgID",
-    "SetMouseShapeMsgID",
-    "AdjustLinespaceMsgID",
-    "AdjustColumnspaceMsgID",
-    "ActivateMsgID",
-    "SetServerNameMsgID",
-    "EnterFullScreenMsgID",
-    "LeaveFullScreenMsgID",
-    "SetBuffersModifiedMsgID",
-    "AddInputMsgID",
-    "SetPreEditPositionMsgID",
-    "TerminateNowMsgID",
-    "XcodeModMsgID",
-    "EnableAntialiasMsgID",
-    "DisableAntialiasMsgID",
-    "SetVimStateMsgID",
-    "SetDocumentFilenameMsgID",
-    "OpenWithArgumentsMsgID",
-    "CloseWindowMsgID",
-    "SetFullScreenColorMsgID",
-    "ShowFindReplaceDialogMsgID",
-    "FindReplaceMsgID",
-    "ActivateKeyScriptMsgID",
-    "DeactivateKeyScriptMsgID",
-    "EnableImControlMsgID",
-    "DisableImControlMsgID",
-    "ActivatedImMsgID",
-    "DeactivatedImMsgID",
-    "BrowseForFileMsgID",
-    "ShowDialogMsgID",
-    "SetMarkedTextMsgID",
-    "ZoomMsgID",
-    "SetWindowPositionMsgID",
-    "DeleteSignMsgID",
-    "SetTooltipMsgID",
-    "SetTooltipDelayMsgID",
-    "GestureMsgID",
-    "AddToMRUMsgID",
-    "BackingPropertiesChangedMsgID",
-    "SetBlurRadiusMsgID",
-    "EnableLigaturesMsgID",
-    "DisableLigaturesMsgID",
-    "EnableThinStrokesMsgID",
-    "DisableThinStrokesMsgID",
-    "END OF MESSAGE IDs"     // NOTE: Must be last!
+#define STRING_ARRAY_ENTRY(X) #X,
+    FOREACH_MMVimMsgID(STRING_ARRAY_ENTRY)
+#undef STRING_ARRAY_ENTRY
 };
 
 
@@ -157,7 +68,7 @@ debugStringForMessageQueue(NSArray *queue)
         else if (msgid == ShowScrollbarMsgID) ++shows;
         else if (msgid == CreateScrollbarMsgID) ++cres;
         else if (msgid == DestroyScrollbarMsgID) ++dess;
-        else [s appendFormat:@"%s ", MessageStrings[msgid]];
+        else [s appendFormat:@"%s ", MMVimMsgIDStrings[msgid]];
     }
     if (item > 0) [s appendFormat:@"AddMenuItemMsgID(%d) ", item];
     if (menu > 0) [s appendFormat:@"AddMenuMsgID(%d) ", menu];


### PR DESCRIPTION
This PR contains a few commits:

1. Adds `"UseSelectionForFindMsgID"` to `MessageStrings`: it was missing and the following strings were out of sync with the enum.
2. Adds a macro to both declare the enum and create `MessageStrings`, to stop them from getting out of sync again. I don't have strong feelings about the details of how that's done; feel free to change it or suggest changes!
3. Renames `MessageStrings` to `MMVimMsgIDStrings`, and makes it const, for clarity.