### PR TITLE
Fix opening files that have special chars like '$' in filename

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -976,21 +976,11 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
             //
             // NOTE: Raise window before passing arguments, otherwise the
             // selection will be lost when selectionRange is set.
-            firstFile = [firstFile stringByEscapingSpecialFilenameCharacters];
-
-            NSString *bufCmd = @"tab sb";
-            switch (layout) {
-                case MMLayoutHorizontalSplit: bufCmd = @"sb"; break;
-                case MMLayoutVerticalSplit:   bufCmd = @"vert sb"; break;
-                case MMLayoutArglist:         bufCmd = @"b"; break;
-            }
-
-            NSString *input = [NSString stringWithFormat:@"<C-\\><C-N>"
-                    ":let oldswb=&swb|let &swb=\"useopen,usetab\"|"
-                    "%@ %@|let &swb=oldswb|unl oldswb|"
-                    "cal foreground()<CR>", bufCmd, firstFile];
-
-            [vc addVimInput:input];
+            NSDictionary *args = [NSDictionary dictionaryWithObjectsAndKeys:
+                                  firstFile, @"filename",
+                                  [NSNumber numberWithInt:layout], @"layout",
+                                  nil];
+            [vc sendMessage:SelectAndFocusOpenedFileMsgID data:[args dictionaryAsData]];
         }
 
         [vc passArguments:arguments];
@@ -1465,16 +1455,15 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
     if (!dirIndicator)
         path = [path stringByDeletingLastPathComponent];
 
-    path = [path stringByEscapingSpecialFilenameCharacters];
-
     NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
     BOOL openInCurrentWindow = [ud boolForKey:MMOpenInCurrentWindowKey];
     MMVimController *vc;
 
     if (openInCurrentWindow && (vc = [self topmostVimController])) {
-        NSString *input = [NSString stringWithFormat:@"<C-\\><C-N>"
-                ":tabe|cd %@<CR>", path];
-        [vc addVimInput:input];
+        NSDictionary *args = [NSDictionary dictionaryWithObjectsAndKeys:
+                              path, @"path",
+                              nil];
+        [vc sendMessage:NewFileHereMsgID data:[args dictionaryAsData]];
     } else {
         [self launchVimProcessWithArguments:nil workingDirectory:path];
     }

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -236,6 +236,8 @@ extern const char * const MMVimMsgIDStrings[];
     MSG(SetVimStateMsgID) \
     MSG(SetDocumentFilenameMsgID) \
     MSG(OpenWithArgumentsMsgID) \
+    MSG(SelectAndFocusOpenedFileMsgID) \
+    MSG(NewFileHereMsgID) \
     MSG(CloseWindowMsgID) \
     MSG(SetFullScreenColorMsgID) \
     MSG(ShowFindReplaceDialogMsgID) \
@@ -353,7 +355,6 @@ extern NSString *VimFindPboardType;
 
 
 @interface NSString (MMExtras)
-- (NSString *)stringByEscapingSpecialFilenameCharacters;
 - (NSString *)stringByRemovingFindPatterns;
 - (NSString *)stringBySanitizingSpotlightSearch;
 @end

--- a/src/MacVim/MacVim.m
+++ b/src/MacVim/MacVim.m
@@ -88,43 +88,6 @@ debugStringForMessageQueue(NSArray *queue)
 
 @implementation NSString (MMExtras)
 
-- (NSString *)stringByEscapingSpecialFilenameCharacters
-{
-    // NOTE: This code assumes that no characters already have been escaped.
-    NSMutableString *string = [self mutableCopy];
-
-    [string replaceOccurrencesOfString:@"\\"
-                            withString:@"\\\\"
-                               options:NSLiteralSearch
-                                 range:NSMakeRange(0, [string length])];
-    [string replaceOccurrencesOfString:@" "
-                            withString:@"\\ "
-                               options:NSLiteralSearch
-                                 range:NSMakeRange(0, [string length])];
-    [string replaceOccurrencesOfString:@"\t"
-                            withString:@"\\\t "
-                               options:NSLiteralSearch
-                                 range:NSMakeRange(0, [string length])];
-    [string replaceOccurrencesOfString:@"%"
-                            withString:@"\\%"
-                               options:NSLiteralSearch
-                                 range:NSMakeRange(0, [string length])];
-    [string replaceOccurrencesOfString:@"#"
-                            withString:@"\\#"
-                               options:NSLiteralSearch
-                                 range:NSMakeRange(0, [string length])];
-    [string replaceOccurrencesOfString:@"|"
-                            withString:@"\\|"
-                               options:NSLiteralSearch
-                                 range:NSMakeRange(0, [string length])];
-    [string replaceOccurrencesOfString:@"\""
-                            withString:@"\\\""
-                               options:NSLiteralSearch
-                                 range:NSMakeRange(0, [string length])];
-
-    return [string autorelease];
-}
-
 - (NSString *)stringByRemovingFindPatterns
 {
     // Remove some common patterns added to search strings that other apps are

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -131,7 +131,6 @@ static void	ex_mode(exarg_T *eap);
 static void	ex_wrongmodifier(exarg_T *eap);
 static void	ex_find(exarg_T *eap);
 static void	ex_open(exarg_T *eap);
-static void	ex_edit(exarg_T *eap);
 #ifndef FEAT_GUI
 # define ex_gui			ex_nogui
 static void	ex_nogui(exarg_T *eap);
@@ -7138,7 +7137,7 @@ ex_open(exarg_T *eap)
 /*
  * ":edit", ":badd", ":visual".
  */
-    static void
+    void
 ex_edit(exarg_T *eap)
 {
     do_exedit(eap, NULL);

--- a/src/proto/ex_docmd.pro
+++ b/src/proto/ex_docmd.pro
@@ -33,6 +33,7 @@ void alist_expand(int *fnum_list, int fnum_len);
 void alist_set(alist_T *al, int count, char_u **files, int use_curbuf, int *fnum_list, int fnum_len);
 void alist_add(alist_T *al, char_u *fname, int set_fnum);
 void alist_slash_adjust(void);
+void ex_edit(exarg_T *eap);
 void ex_splitview(exarg_T *eap);
 void tabpage_new(void);
 void do_exedit(exarg_T *eap, win_T *old_curwin);


### PR DESCRIPTION
Fix opening files that have special chars like '$' in filename

This fixes a whole host of related issues in MacVim that fails to properly sanitize filenames when opening files using the GUI (e.g.  drag-and-drop, file type associations, etc). The core issue came from the fact that the code used to rely on constructing Vimscript commands to send to code Vim to parse using `addInput` (e.g. `:tabe <filename>`).  This was convenient and fast to add new feature but requires properly sanitizing filenames (since that's an arbitrary user input). It used a bespoke function `stringByEscapingSpecialFilenameCharacters` but it didn't fully work ('$' would not be escaped so it would be interpreted as a Vim variable) for all filenames.

One solution should be to use Vim's fnameescape() utility, but it doesn't fully solve all edge cases. For example, if we hae a newline in a filename (which is admittedly weird) it will still break the Vimscript parsing.

Better solution is to simply construct the raw Ex commands in C manually. It forces more tie-in to Vim's internals but is the most robust way to arbitary filenames. Replace all usage of stringByEscapingSpecialFilenameCharacters with this method:

* `handleOpenWithArguments:` is used by drag-and-drop and opening files from GUI, so fix that to construct Vim function calls. Also fixes some weird bugs in existing behavior (e.g. if you drag multiple files in but one of them is opened alrady, it used to choose the wrong tab to do the `sall` split in. Now just make sure to make a new tab).

* Dragging files to tab bars. MacVim has a special behavior where dragging files to tab bars will open files in that particular tab.  Consolidate the behavior to use `handleOpenWithArguments` as well. Also fix an issue where previously it would forcefully stomp whatever buffer you had in that tab even if it had unsaved changes.

* Misc cases: New File Here macOS service and a "open first file if exists already" functionality also need to be fixed. For these two cases, make new MMBackend handlers just for simplicity as they aren't doing anything complicated.

For future TODO:
- Implement tests for this when new testing infrastructure is up for testing MacVim-specific functionality.

Fix #863.
