### PR TITLE
Make MMTitlebarAppearsTransparent option work on pre-Mojave

### DIFF
--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -591,7 +591,26 @@
             }
         }
     }
+    else
 #endif
+    {
+        // 10.13 or below. As noted above, the window flag
+        // NSWindowStyleMaskTexturedBackground doesn't play well with window color,
+        // but if we are toggling the titlebar transparent option, we need to set
+        // the window background color in order the title bar to be tinted correctly.
+        if ([[NSUserDefaults standardUserDefaults]
+             boolForKey:MMTitlebarAppearsTransparentKey]) {
+            if ([back alphaComponent] != 0) {
+                [decoratedWindow setBackgroundColor:back];
+            } else {
+                // See above HACK for more details. Basically we cannot set a
+                // color with 0 alpha or the window manager will give it a
+                // different treatment.
+                NSColor *clearColor = [back colorWithAlphaComponent:0.001];
+                [decoratedWindow setBackgroundColor:clearColor];
+            }
+        }
+    }
 
     [vimView setDefaultColorsBackground:back foreground:fore];
 }


### PR DESCRIPTION
Added the special path to make tranparent titlebars work on pre-Mojave builds as well. It's annoying we have to two maintain separate code paths for how windows / titlebars work but this wasn't too hard to add. We just need to make sure to to set the background color on the window *only* when we have transparent titlebar set. Otherwise we don't want to do it because of weird interactions with textured window flag.

This addresses comments made in #888.