### PR TITLE
Fix drag-and-drop with swap file enabled causing MacVim to freeze

### DIFF
--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -636,10 +636,12 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
 
 - (void)flushQueue:(BOOL)force
 {
-    // NOTE: This variable allows for better control over when the queue is
-    // flushed.  It can be set to YES at the beginning of a sequence of calls
-    // that may potentially add items to the queue, and then restored back to
-    // NO.
+    // TODO: "force" is currently unused. When flushDisabled is set, it will
+    // always disable flushing. Consider fixing it so that force will actually
+    // forcefully flush (i.e. ignore flushDisabled), and change
+    // gui_macvim_flush() to call flushQueue with
+    // force set to NO.
+
     if (flushDisabled) return;
 
     if ([drawData length] > 0) {
@@ -1793,7 +1795,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
         if (count%2 == 0) {
             for (i = count-2; i >= 0; i -= 2) {
                 int msgid = [[inputQueue objectAtIndex:i] intValue];
-                if (SetTextDimensionsMsgID == msgid) {
+                if (SetTextDimensionsMsgID == msgid || SetTextDimensionsNoResizeWindowMsgID == msgid) {
                     textDimData = [[inputQueue objectAtIndex:i+1] retain];
                     break;
                 }
@@ -2716,10 +2718,6 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
                 bufHasFilename = curbuf->b_ffname != NULL;
             }
 
-            // Temporarily disable flushing since the following code may
-            // potentially cause multiple redraws.
-            flushDisabled = YES;
-
             // Make sure we're in normal mode first.
             // TODO: The mixing of addInput and Ex commands is a little
             // problematic because addInput is asynchronous and will therefore
@@ -2959,8 +2957,6 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
             out_flush();
             gui_update_cursor(FALSE, FALSE);
             maketitle();
-
-            flushDisabled = NO;
         }
     }
 


### PR DESCRIPTION
MMBackend's `handleOpenWithArguments` previously set a "flushDisabled" flag to disable all flushing during handling the files. This was unsafe, because under the new code that handles editing immediately (instead of building a deferred set of Ex commands) MacVim tries to immediately pop up a dialog box but that message doesn't get properly flushed because it's disabled. Just remove the setting of that disabled flag as it doesn't seem like it's gaining anything.

If we want to have a way to disable flushing for performance reasons in the future , we should make sure the "force" flag in flushQueue: actually gets respected and used properly (only when we want to force it). Right now the "force" flag isn't actually used.

Also, make sure the dialog handling code handles the "no GUI resize" resize message (which gets set when we have `guioptions+=k`) as well and don't drop the message. Otherwise if drag-and-drop opens a new tab (since there are multiple files dropped) and the user has guioptions+=k, it won't get redrawn properly because the SetTextDimensionsNoResizeWindowMsgID message would get dropped. It's unfortunate it's a hardcoded hack like this and this should be revisited in the future.

Fix #913