### PR TITLE
Add option to remove the launch animation of MacVim windows

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -247,6 +247,8 @@ Here is a list of relevant dictionary entries:
 KEY				VALUE ~
 *MMCellWidthMultiplier*		width of a normal glyph in em units [float]
 *MMDialogsTrackPwd*		open/save dialogs track the Vim pwd [bool]
+*MMDisableLaunchAnimation*	disable launch animation when opening a new
+				MacVim window [bool]
 *MMFullScreenFadeTime*		fade delay for non-native fullscreen [float]
 *MMLoginShellArgument*		login shell parameter [string]
 *MMLoginShellCommand*		which shell to use to launch Vim [string]

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4827,7 +4827,7 @@ E993	popup.txt	/*E993*
 E994	eval.txt	/*E994*
 E995	eval.txt	/*E995*
 E996	eval.txt	/*E996*
-E996	popup.txt	/*E996*
+E997	popup.txt	/*E997*
 E999	repeat.txt	/*E999*
 EX	intro.txt	/*EX*
 EXINIT	starting.txt	/*EXINIT*
@@ -4910,6 +4910,7 @@ M	motion.txt	/*M*
 MDI	starting.txt	/*MDI*
 MMCellWidthMultiplier	gui_mac.txt	/*MMCellWidthMultiplier*
 MMDialogsTrackPwd	gui_mac.txt	/*MMDialogsTrackPwd*
+MMDisableLaunchAnimation	gui_mac.txt	/*MMDisableLaunchAnimation*
 MMFullScreenFadeTime	gui_mac.txt	/*MMFullScreenFadeTime*
 MMLoginShellArgument	gui_mac.txt	/*MMLoginShellArgument*
 MMLoginShellCommand	gui_mac.txt	/*MMLoginShellCommand*
@@ -8348,10 +8349,12 @@ popup-examples	popup.txt	/*popup-examples*
 popup-filter	popup.txt	/*popup-filter*
 popup-functions	popup.txt	/*popup-functions*
 popup-intro	popup.txt	/*popup-intro*
+popup-mask	popup.txt	/*popup-mask*
 popup-menu	gui.txt	/*popup-menu*
 popup-menu-added	version5.txt	/*popup-menu-added*
 popup-position	popup.txt	/*popup-position*
 popup-props	popup.txt	/*popup-props*
+popup-scrollbar	popup.txt	/*popup-scrollbar*
 popup-window	popup.txt	/*popup-window*
 popup.txt	popup.txt	/*popup.txt*
 popup_atcursor()	popup.txt	/*popup_atcursor()*

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -224,8 +224,12 @@
         [win setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
 
     // This makes windows animate when opened
-    if ([win respondsToSelector:@selector(setAnimationBehavior:)])
-        [win setAnimationBehavior:NSWindowAnimationBehaviorDocumentWindow];
+    if ([win respondsToSelector:@selector(setAnimationBehavior:)]) {
+        if (![[NSUserDefaults standardUserDefaults]
+              boolForKey:MMDisableLaunchAnimation]) {
+            [win setAnimationBehavior:NSWindowAnimationBehaviorDocumentWindow];
+        }
+    }
 #endif
 
     [[NSNotificationCenter defaultCenter]

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -35,6 +35,7 @@ extern NSString *MMOpenInCurrentWindowKey;
 extern NSString *MMNoFontSubstitutionKey;
 extern NSString *MMNoTitleBarWindowKey;
 extern NSString *MMTitlebarAppearsTransparentKey;
+extern NSString *MMDisableLaunchAnimation;
 extern NSString *MMLoginShellKey;
 extern NSString *MMUntitledWindowKey;
 extern NSString *MMZoomBothKey;

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -31,6 +31,7 @@ NSString *MMOpenInCurrentWindowKey        = @"MMOpenInCurrentWindow";
 NSString *MMNoFontSubstitutionKey         = @"MMNoFontSubstitution";
 NSString *MMNoTitleBarWindowKey           = @"MMNoTitleBarWindow";
 NSString *MMTitlebarAppearsTransparentKey = @"MMTitlebarAppearsTransparent";
+NSString *MMDisableLaunchAnimation        = @"MMDisableLaunchAnimation";
 NSString *MMLoginShellKey                 = @"MMLoginShell";
 NSString *MMUntitledWindowKey             = @"MMUntitledWindow";
 NSString *MMZoomBothKey                   = @"MMZoomBoth";


### PR DESCRIPTION
Add a new option called "MMDisableLaunchAnimation" to disable the "pop" launch animation that gets assigned to document windows. The animation will still be the default behavior as that's native to macOS's treatment of document windows.

Fix #915