### PR TITLE
Fix flaky test_suspend script test

### DIFF
--- a/src/testdir/test_suspend.vim
+++ b/src/testdir/test_suspend.vim
@@ -54,6 +54,7 @@ func Test_suspend()
   " Quit gracefully to dump coverage information.
   call term_sendkeys(buf, ":qall!\<CR>")
   call term_wait(buf)
+  call WaitForAssert({-> assert_match('[$#] $', term_getline(buf, '.'))})
   call StopShellInTerminal(buf)
 
   exe buf . 'bwipe!'


### PR DESCRIPTION
Make sure to wait for shell prompt to come up when quitting Vim before sending the "exit" command to shell. This seems to help in certain situations where it appears to have a race condition where `term_wait(buf)` isn't enough to wait for Vim to have fully quitted and returning contorl back to the shell.