### PR TITLE
Fix MacVim GUI to hard-code sign icon to width of 2 to reduce dependency

### DIFF
--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -2369,8 +2369,7 @@ gui_mch_drawsign(int row, int col, int typenr)
     if (!imgName)
         return;
 
-    char_u *txt = sign_get_text(typenr);
-    int txtSize = txt ? strlen((char*)txt) : 2;
+    const int txtSize = 2; // This is specified in the docs, and is expected to always be the case.
 
     [[MMBackend sharedInstance] drawSign:imgName
                                    atRow:row


### PR DESCRIPTION
Prevoiusly the code uses strlen to get the sign icon width but it's always 2 (according to Vim's documentation, see ":h sign-define"), and the function it calls (`sign_get_text`) has been removed from Vim already. Just use the hard-coded 2 for simplicity and reduce dependency.