### PR TITLE
Update README to point to new Travis CI URL instead of the legacy one

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Vim - the text editor - for Mac OS X
 
 - Vim README: [README_vim.md](README_vim.md)
 
-- Travis CI <a href="https://travis-ci.org/macvim-dev/macvim"><img src="https://travis-ci.org/macvim-dev/macvim.svg?branch=master" alt="Build Status"></a><a href="https://travis-ci.org/macvim-dev/homebrew-macvim"><img src="https://travis-ci.org/macvim-dev/homebrew-macvim.svg?branch=master" alt="Build Status"></a>
+- Travis CI <a href="https://travis-ci.com/macvim-dev/macvim"><img src="https://travis-ci.com/macvim-dev/macvim.svg?branch=master" alt="Build Status"></a>
 
 - Packaged in [![Homebrew package](https://repology.org/badge/version-for-repo/homebrew/macvim.svg)](https://repology.org/metapackage/macvim/versions) [![MacPorts package](https://repology.org/badge/version-for-repo/macports/macvim.svg)](https://repology.org/metapackage/macvim/versions)
 


### PR DESCRIPTION
Also remove Homebrew build status as the MacVim Homebrew formula can be considered deprecated and un-maintained.