### PR TITLE
Add MacVim test scripts for basic testing

### DIFF
--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -172,6 +172,7 @@ NEW_TESTS = \
 	test_listlbr \
 	test_listlbr_utf8 \
 	test_lua \
+	test_macvim \
 	test_makeencoding \
 	test_man \
 	test_maparg \
@@ -372,6 +373,7 @@ NEW_TESTS_RES = \
 	test_listener.res \
 	test_listlbr.res \
 	test_lua.res \
+	test_macvim.res \
 	test_makeencoding.res \
 	test_man.res \
 	test_maparg.res \

--- a/src/testdir/test_macvim.vim
+++ b/src/testdir/test_macvim.vim
@@ -1,0 +1,48 @@
+" Test for MacVim behaviors and regressions
+
+source check.vim
+CheckFeature gui_macvim
+
+" Tests for basic existence of commands and options to make sure no
+" regressions have accidentally removed them
+func Test_macvim_options_commands()
+    call assert_true(exists('+antialias'), 'Missing option "antialias"')
+    call assert_true(exists('+blurradius'), 'Missing option "blurradius"')
+    call assert_true(exists('+fullscreen'), 'Missing option "fullscreen"')
+    call assert_true(exists('+fuoptions'), 'Missing option "fuoptions"')
+    call assert_true(exists('+macligatures'), 'Missing option "macligatures"')
+    call assert_true(exists('+macmeta'), 'Missing option "macmeta"')
+    call assert_true(exists('+macthinstrokes'), 'Missing option "macthinstrokes"')
+    call assert_true(exists('+toolbariconsize'), 'Missing option "toolbariconsize"')
+    call assert_true(exists('+transparency'), 'Missing option "transparency"')
+
+    call assert_true(exists(':macaction'), 'Missing command "macaction"')
+    call assert_true(exists(':macmenu'), 'Missing command "macmenu"')
+endfunc
+
+" Test that Cmd-key and touch pad mappings are working (this doesn't actually
+" test that the full mapping work properly as it's difficult to inject keys in
+" Vimscript)
+func Test_macvim_mappings()
+    let g:marker_value=0
+
+    nnoremap <D-1> :let g:marker_value=1<CR>
+    call feedkeys("\<D-1>", "xt")
+    call assert_equal(1, g:marker_value)
+
+    nnoremap <SwipeLeft> :let g:marker_value=1<CR>
+    call feedkeys("\<SwipeLeft>", "xt")
+    call assert_equal(1, g:marker_value)
+    nnoremap <SwipeRight> :let g:marker_value=2<CR>
+    call feedkeys("\<SwipeRight>", "xt")
+    call assert_equal(2, g:marker_value)
+    nnoremap <SwipeUp> :let g:marker_value=3<CR>
+    call feedkeys("\<SwipeUp>", "xt")
+    call assert_equal(3, g:marker_value)
+    nnoremap <SwipeDown> :let g:marker_value=4<CR>
+    call feedkeys("\<SwipeDown>", "xt")
+    call assert_equal(4, g:marker_value)
+    nnoremap <ForceClick> :let g:marker_value=5<CR>
+    call feedkeys("\<ForceClick>", "xt")
+    call assert_equal(5, g:marker_value)
+endfunc


### PR DESCRIPTION
Just initial commit to do very basic regression testing including checking options/commands exists and that we can map keys. May add more later. Some more complicated tests probably need Objective-C tests but for simple things we should be able to rely on VimScript tests to be consistent with how Vim does things.