### PR TITLE
Fix font initialization pulling in extra metadata

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -301,9 +301,14 @@ defaultAdvanceForFont(NSFont *font)
         return;
 
     double em = round(defaultAdvanceForFont(newFont));
+    double pt = round([newFont pointSize]);
+
+    CTFontDescriptorRef desc = CTFontDescriptorCreateWithNameAndSize((CFStringRef)[newFont fontName], pt);
+    CTFontRef fontRef = CTFontCreateWithFontDescriptor(desc, pt, NULL);
+    CFRelease(desc);
 
     [font release];
-    font = [newFont retain];
+    font = (NSFont*)fontRef;
 
     float cellWidthMultiplier = [[NSUserDefaults standardUserDefaults]
             floatForKey:MMCellWidthMultiplierKey];
@@ -315,7 +320,7 @@ defaultAdvanceForFont(NSFont *font)
     cellSize.width = columnspace + ceil(em * cellWidthMultiplier);
     cellSize.height = linespace + defaultLineHeightForFont(font);
 
-    fontDescent = ceil(CTFontGetDescent((CTFontRef)newFont));
+    fontDescent = ceil(CTFontGetDescent(fontRef));
 
     [fontCache removeAllObjects];
 }


### PR DESCRIPTION
Recent fix to font initialization (#927) seems to have caused issues with other fonts. Keep the fix but revert to the old way of font initialization by manually creating a new one with point size to not use the other aspects of the font to keep the behavior consistent with previous behavior

Fix #928