### PR TITLE
Update binary release to target 10.9 (used to be 10.8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
     update: true
 
 env:
-  - MACOSX_DEPLOYMENT_TARGET=10.8
+  - MACOSX_DEPLOYMENT_TARGET=10.9
     VERSIONER_PERL_VERSION=5.18
     VERSIONER_PYTHON_VERSION=2.7
     vi_cv_path_python=/usr/bin/python


### PR DESCRIPTION
This is mostly to satisfy Apple's notarization requirements as 10.9 is the minium. Given how currently macOS is at 10.14, there should have been ample time for people to have upgraded. People can still manually build MacVim for 10.8 if they so wish.