### PR TITLE
Switch Travis CI release to use Github release drafts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ os:
   - osx
 
 osx_image:
+  - xcode11.2
+  - xcode10.3
   - xcode7.3
   - xcode9.4
-  - xcode10.3
-  - xcode11.2
 
 compiler:
   - clang
@@ -74,8 +74,9 @@ deploy:
     secure: ukjm+qbuNiTli25Ut2BoVpeBCV+JyVbRUwPqjTKrJxfHz34bpr38eSbryIB8BgKBItgzE876Yoqa3CD0k8mqGClis1+98MtrYFpAkO97juJmHpcZZZB7ausbHGf7Z7VdMT4jBjjVGcBeaNj0mio0hwem0/S4WyJK3M/3Fym995CltCUtJKRfMvRiGkWZqUs8K7EZf53DFR6CXUn38rq/3B88SeK51OZuCkMsiDWLGYCdayH19vJfFrTF8MYMQYDYxz16Q/Kf21PVhwia7HEhOzqnXS8RXS+vLkZw8mzIxowX+w6NT90q7Sj0ENdR7YaS27QPfDdhZEnOgpgqj+za63lpiyIdRcgSBkGxNYrM6B5KhiwC1VocBxCBdCxT5WXlx9rA9+k4CASdsxAW/MtQOK6PRMfZEnAB+ShFvshM2H/iE5Jch+o/SIjCXhdkeASD5qov2x6eXcsEVu8PIxvEUptCpHeqJTN5/26nfKsvOdrsqbwJbDluwISOKfEPhohb8Hn7JqOJNTS2aJr3jfvU+egE1NS0eLqKPXecu7MOOsOq1CQL6WxblphG2JCCmAOuNMYrJx9+w28ekMDRDAbI9r5nWcPLZtBqjFUyuBXXM7UknMar0FZ2fd7YTi/Gki3n56UN0lKaSAKaJB9EXlneDSKp/1ogsETr9/b7jz0s6lI=
   file: src/MacVim/build/Release/MacVim.dmg
   skip_cleanup: true
+  draft: true
   on:
-    condition: $TRAVIS_OSX_IMAGE = xcode10.2
+    condition: $TRAVIS_OSX_IMAGE = xcode11.2
     all_branches: true
     tags: true
     repo: macvim-dev/macvim


### PR DESCRIPTION
This is necessary because with the new macOS requirements to use code signing and app notarization, there's a set of additional steps after Travis CI has built the app to be done. Using drafts would upload the built app to a non-release location to give time to finish the remaining signing and notarization steps without creating an incomplete Github release.