### PR TITLE
Fix hardened runtime entitlement for scripting languages and add app signing scripts

### DIFF
--- a/src/MacVim/MacVim.entitlements
+++ b/src/MacVim/MacVim.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
+</dict>
+</plist>

--- a/src/MacVim/scripts/notarize-dmg
+++ b/src/MacVim/scripts/notarize-dmg
@@ -1,0 +1,74 @@
+#!/bin/zsh
+
+# Utility script to submit an app for notarization by Apple. It will wait for
+# the notarization to succeed, and then staple the results to the target DMG
+# file.
+
+if [[ $# == 0 ]]; then
+    echo "Usage: sign-developer-id <MacVim_dmg> <entitlements_file>"
+    exit -1
+fi
+
+set -e
+
+if [[ $ALTOOL_USERNAME == '' || $ALTOOL_PASSWORD == '' ]]; then
+    echo 'Need to set ALTOOL_USERNAME and ALTOOL_PASSWORD in environment variables'
+    exit -1
+fi
+
+set -e
+
+macvim_dmg=$1
+
+# Step 1: Submit app to Apple's servers for notarization
+set -x
+notarize_submit_uuid=$(xcrun altool --notarize-app --primary-bundle-id "org.vim.macvim" --file ${macvim_dmg} --username "${ALTOOL_USERNAME}" --password "${ALTOOL_PASSWORD}" | grep "RequestUUID" | sed -E "s/RequestUUID = (.*)/\1/")
+set +x
+
+if [[ ${notarize_submit_uuid} == "" ]]; then
+    echo "Failed to submit for notarization!"
+    exit -1
+fi
+if ! [[ ${notarize_submit_uuid} =~ "^[a-f0-9\-]*$" ]]; then
+    echo "Request UUID format error!"
+    exit -1
+fi
+
+# Step 2: Wait for notarization to success or fail by continuously querying
+# Apple's servers for status updates
+echo "Notarization request UUID: ${notarize_submit_uuid}"
+printf "Waiting for notarization results..."
+
+counter=0
+while sleep 30; do
+    notarize_results=$(xcrun altool --notarization-info ${notarize_submit_uuid} --username "${ALTOOL_USERNAME}" --password "${ALTOOL_PASSWORD}")
+    notarize_status=$(echo $notarize_results | grep "Status:" | sed -E "s/^.*Status: (.*)/\1/")
+
+    if ((++counter > 60)); then
+        echo "Notarization timeout!"
+        exit -1
+    fi
+
+    if [[ $notarize_status == "in progress" ]]; then
+        printf "."
+        continue
+    elif [[ $notarize_status == "success" ]]; then
+        printf "\n"
+        echo "Notarization Success!\n"
+        echo $notarize_results
+        break
+    else
+        printf "\n"
+        exit -1
+    fi
+done
+
+# Step 3: Staple the notarization info to the DMG so that an offline user can
+# verify that it is notarized.
+set -x
+xcrun stapler staple ${macvim_dmg}
+
+# Just print out extra info for reference
+echo "--------------------"
+codesign -d --verbose=2 ${macvim_dmg}
+spctl -a -t open --context context:primary-signature -v ${macvim_dmg}

--- a/src/MacVim/scripts/sign-developer-id
+++ b/src/MacVim/scripts/sign-developer-id
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# Utility script to sign MacVim with a valid Developer ID with hardened runtime
+# along with a provided entitlments file. This script requires a Developer ID
+# cert already installed on the computer.
+
+# Use the following to verify:
+#     codesign -d --verbose=4 --entitlements - <MacVim_app>
+
+if [[ $# == 0 || $# == 1 ]]; then
+    echo "Usage: sign-developer-id <MacVim_app> <entitlements_file>"
+    exit -1
+fi
+
+set -e
+
+macvim_path=$1
+entitlements=$2
+
+if [[ $macvim_path =~ dmg ]]; then
+    set -x
+    codesign -f -s "Developer ID Application" -o runtime --timestamp $macvim_path
+else
+    # Sign bottom-up to make sure everything is signed. Note: --deep doesn't
+    # catch certain edge cases like the files in Resources, hence the need to
+    # manually sign them before signing the main app.
+    set -x
+    codesign -f -s "Developer ID Application" -o runtime --deep --timestamp $macvim_path/Contents/Frameworks/Sparkle.framework/Versions/A/Resources/Autoupdate.app
+    codesign -f -s "Developer ID Application" -o runtime --deep --timestamp $macvim_path/Contents/Library/QuickLook/QLStephen.qlgenerator/Contents/MacOS/QLStephen
+    codesign -f -s "Developer ID Application" -o runtime --deep --timestamp --entitlements $entitlements $macvim_path
+fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -3620,16 +3620,21 @@ $(APPDIR)/Contents:
 
 ##############################################################################
 ### MacVim GUI
-.PHONY: macvim macvim-dmg macvimclean
+.PHONY: macvim macvim-dmg macvimclean macvim-signed macvim-dmg-release
 
 RELEASEDIR = MacVim/build/Release
 DMGDIR = MacVim/build/dmg
 DMGFILE = MacVim.dmg
+ENTITLEMENTS = MacVim/MacVim.entitlements
 
 macvim: $(VIMTARGET)
 	xcodebuild -project MacVim/MacVim.xcodeproj $(XCODEFLAGS)
 
+macvim-signed:
+	MacVim/scripts/sign-developer-id $(RELEASEDIR)/MacVim.app $(ENTITLEMENTS)
+
 macvim-dmg:
+	rm -rf $(DMGDIR)
 	mkdir -p $(DMGDIR)
 	cp -a $(RELEASEDIR)/MacVim.app $(DMGDIR)/
 	rm -rf $(RELEASEDIR)/$(DMGFILE)
@@ -3647,6 +3652,13 @@ macvimclean:
 	if test -d MacVim; then \
 		rm -rf MacVim/build MacVim/qlstephen/build xxd/xxd.dSYM; \
 	fi
+
+# Create a release DMG image that is signed and notaraized
+macvim-dmg-release: macvim-signed macvim-dmg
+	MacVim/scripts/sign-developer-id $(RELEASEDIR)/MacVim.dmg $(ENTITLEMENTS)
+	MacVim/scripts/notarize-dmg $(RELEASEDIR)/MacVim.dmg
+	echo "--------------------"
+	echo "Release MacVim built!"
 
 
 ###############################################################################


### PR DESCRIPTION
### Hardened runtime entitlements

Add hardened runtime entitlements to allow AppleScript + scripting languages to work.

Add `get-task-allow` entitlement which seems to be necessary to get scripting languages like Python to work. It's discouraged in docs, and Apple may not allow it from [January 2020 onwards](https://developer.apple.com/news/?id=09032019a) so this is not a safe long term solution and we need to find out how to get Python and other scripting languages to work without setting `get-task-allow`.

Fix #978 
Also see #979

### App signing / notarization scripts

Add scripts to sign and notarize MacVim

Add two scripts. First one signs the MacVim app bundle and dmg files with developer certificate. Second one submits the dmg file to Apple for app notarization, and waits for the results to come back.

Also added Makefile target `macvim-dmg-release` that will use these scripts to create a signed and notarized dmg file that can be distributed and will be play nice with macOS Gatekeeper.


