### PR TITLE
Fix test_menu breaking at VimEnter autocommand

### DIFF
--- a/src/testdir/test_menu.vim
+++ b/src/testdir/test_menu.vim
@@ -12,7 +12,9 @@ func Test_load_menu()
   call assert_match('browse confirm w', execute(':menu File.Save'))
 
   let v:errmsg = ''
-  doautocmd LoadBufferMenu VimEnter
+  if !has("gui_macvim")
+    doautocmd LoadBufferMenu VimEnter
+  endif
   call assert_equal('', v:errmsg)
 
   source $VIMRUNTIME/delmenu.vim


### PR DESCRIPTION
This autocommand is turned off for MacVim menus, so don't invoke it in
test.