### PR TITLE
Fix Travis CI Python issues by manually linking Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ anchors:
           - python
           - ruby
         update: true
+    before_install:
+      # Homebrew has issues linking Python due to conflicts with Python2. Manually link in Python3.
+      - brew link --overwrite python3
   - &lang_env
     env: "LANGOPT='--enable-perlinterp=dynamic --enable-pythoninterp=dynamic --enable-python3interp=dynamic --enable-rubyinterp=dynamic --enable-luainterp=dynamic --with-lua-prefix=/usr/local'"
   - &caches


### PR DESCRIPTION
For some reason Homebrew started getting Python conflict issues with Python linked to `python@2`. Add a manual force linking to python3 as a before_install step.