### PR TITLE
Add option to disable Touch Bar default fullscreen toggle button

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -525,6 +525,16 @@ their template names. An example: >
 This feature only works on Mac devices that come with Touch Bars. On the ones
 that don't, nothing will show up.
 
+						    *macvim-touchbar-defaults*
+Here is a list of default Touch Bar buttons that MacVim sets up:
+
+					*macvim-touchbar-fullscreen*
+					*g:macvim_default_touchbar_fullscreen*
+EnterFullScreen		Touch Bar buttons that allow you to toggle
+ExitFullScreen		|'fullscreen'| mode. To disable the button, add the
+			following to your vimrc file: >
+			  let g:macvim_default_touchbar_fullscreen=0
+
 ==============================================================================
 8. Dialogs						*macvim-dialogs*
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -6760,6 +6760,7 @@ g:html_use_encoding	syntax.txt	/*g:html_use_encoding*
 g:html_use_input_for_pc	syntax.txt	/*g:html_use_input_for_pc*
 g:html_use_xhtml	syntax.txt	/*g:html_use_xhtml*
 g:html_whole_filler	syntax.txt	/*g:html_whole_filler*
+g:macvim_default_touchbar_fullscreen	gui_mac.txt	/*g:macvim_default_touchbar_fullscreen*
 g:netrw_altfile	pi_netrw.txt	/*g:netrw_altfile*
 g:netrw_alto	pi_netrw.txt	/*g:netrw_alto*
 g:netrw_altv	pi_netrw.txt	/*g:netrw_altv*
@@ -7737,6 +7738,8 @@ macvim-tablabel	gui_mac.txt	/*macvim-tablabel*
 macvim-todo	gui_mac.txt	/*macvim-todo*
 macvim-toolbar	gui_mac.txt	/*macvim-toolbar*
 macvim-touchbar	gui_mac.txt	/*macvim-touchbar*
+macvim-touchbar-defaults	gui_mac.txt	/*macvim-touchbar-defaults*
+macvim-touchbar-fullscreen	gui_mac.txt	/*macvim-touchbar-fullscreen*
 macvim-url-handler	gui_mac.txt	/*macvim-url-handler*
 macvim-user-defaults	gui_mac.txt	/*macvim-user-defaults*
 macvim-window-title	gui_mac.txt	/*macvim-window-title*

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -1300,23 +1300,30 @@ endif
 if has("touchbar")
   " Set up default Touch Bar buttons.
   " 1. Smart fullscreen icon that toggles between going full screen or not.
-  an icon=NSTouchBarEnterFullScreenTemplate 1.10 TouchBar.EnterFullScreen :set fullscreen<CR>
+
+  if !exists("g:macvim_default_touchbar_fullscreen") || g:macvim_default_touchbar_fullscreen
+    an icon=NSTouchBarEnterFullScreenTemplate 1.10 TouchBar.EnterFullScreen :set fullscreen<CR>
+  endif
 
   let s:touchbar_fullscreen=0
   func! s:SetupFullScreenTouchBar()
-    if &fullscreen && s:touchbar_fullscreen == 0
-      aun TouchBar.EnterFullScreen
-      an icon=NSTouchBarExitFullScreenTemplate 1.10 TouchBar.ExitFullScreen :set nofullscreen<CR>
+    if &fullscreen && s:touchbar_fullscreen != 1
+      silent! aun TouchBar.EnterFullScreen
+      if !exists("g:macvim_default_touchbar_fullscreen") || g:macvim_default_touchbar_fullscreen
+        an icon=NSTouchBarExitFullScreenTemplate 1.10 TouchBar.ExitFullScreen :set nofullscreen<CR>
+      endif
       let s:touchbar_fullscreen = 1
-    elseif !&fullscreen && s:touchbar_fullscreen == 1
-      aun TouchBar.ExitFullScreen
-      an icon=NSTouchBarEnterFullScreenTemplate 1.10 TouchBar.EnterFullScreen :set fullscreen<CR>
+    elseif !&fullscreen && s:touchbar_fullscreen != 0
+      silent! aun TouchBar.ExitFullScreen
+      if !exists("g:macvim_default_touchbar_fullscreen") || g:macvim_default_touchbar_fullscreen
+        an icon=NSTouchBarEnterFullScreenTemplate 1.10 TouchBar.EnterFullScreen :set fullscreen<CR>
+      endif
       let s:touchbar_fullscreen = 0
     endif
   endfunc
   aug FullScreenTouchBar
     au!
-    au VimResized * call <SID>SetupFullScreenTouchBar()
+    au VimEnter,VimResized * call <SID>SetupFullScreenTouchBar()
   aug END
 endif
 


### PR DESCRIPTION
Add new global var `g:macvim_default_touchbar_fullscreen` that can disable the fullscreen Touch Bar button. Add documentation as well.

Fix #997.