### PR TITLE
Changes for titlebar

### DIFF
--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -149,10 +149,12 @@
                           defer:YES];
     [win autorelease];
     
-    if ([[NSUserDefaults standardUserDefaults]
-         boolForKey:MMTitlebarAppearsTransparentKey]) {
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:MMTitlebarAppearsTransparentKey]) {
         // Transparent title bar setting
         win.titlebarAppearsTransparent = true;
+        if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_10) {
+            win.appearance = [NSAppearance appearanceNamed: NSAppearanceNameDarkAqua];
+        }
     }
 
     self = [super initWithWindow:win];
@@ -504,6 +506,12 @@
 
     [decoratedWindow setRepresentedFilename:filename];
     [fullScreenWindow setRepresentedFilename:filename];
+    
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:MMTitlebarDisableDocumentIconKey]) {
+        // Transparent title bar setting
+        [[decoratedWindow standardWindowButton:NSWindowDocumentIconButton] setImage: nil];
+        [[fullScreenWindow standardWindowButton:NSWindowDocumentIconButton] setImage: nil];
+    }
 }
 
 - (void)setToolbar:(NSToolbar *)theToolbar

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -35,6 +35,7 @@ extern NSString *MMOpenInCurrentWindowKey;
 extern NSString *MMNoFontSubstitutionKey;
 extern NSString *MMNoTitleBarWindowKey;
 extern NSString *MMTitlebarAppearsTransparentKey;
+extern NSString *MMTitlebarDisableDocumentIconKey;
 extern NSString *MMDisableLaunchAnimation;
 extern NSString *MMLoginShellKey;
 extern NSString *MMUntitledWindowKey;

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -14,44 +14,45 @@
 
 
 // NSUserDefaults keys
-NSString *MMTabMinWidthKey                = @"MMTabMinWidth";
-NSString *MMTabMaxWidthKey                = @"MMTabMaxWidth";
-NSString *MMTabOptimumWidthKey            = @"MMTabOptimumWidth";
-NSString *MMShowAddTabButtonKey           = @"MMShowAddTabButton";
-NSString *MMTextInsetLeftKey              = @"MMTextInsetLeft";
-NSString *MMTextInsetRightKey             = @"MMTextInsetRight";
-NSString *MMTextInsetTopKey               = @"MMTextInsetTop";
-NSString *MMTextInsetBottomKey            = @"MMTextInsetBottom";
-NSString *MMTypesetterKey                 = @"MMTypesetter";
-NSString *MMCellWidthMultiplierKey        = @"MMCellWidthMultiplier";
-NSString *MMBaselineOffsetKey             = @"MMBaselineOffset";
-NSString *MMTranslateCtrlClickKey         = @"MMTranslateCtrlClick";
-NSString *MMTopLeftPointKey               = @"MMTopLeftPoint";
-NSString *MMOpenInCurrentWindowKey        = @"MMOpenInCurrentWindow";
-NSString *MMNoFontSubstitutionKey         = @"MMNoFontSubstitution";
-NSString *MMNoTitleBarWindowKey           = @"MMNoTitleBarWindow";
-NSString *MMTitlebarAppearsTransparentKey = @"MMTitlebarAppearsTransparent";
-NSString *MMDisableLaunchAnimation        = @"MMDisableLaunchAnimation";
-NSString *MMLoginShellKey                 = @"MMLoginShell";
-NSString *MMUntitledWindowKey             = @"MMUntitledWindow";
-NSString *MMZoomBothKey                   = @"MMZoomBoth";
-NSString *MMCurrentPreferencePaneKey      = @"MMCurrentPreferencePane";
-NSString *MMLoginShellCommandKey          = @"MMLoginShellCommand";
-NSString *MMLoginShellArgumentKey         = @"MMLoginShellArgument";
-NSString *MMDialogsTrackPwdKey            = @"MMDialogsTrackPwd";
-NSString *MMOpenLayoutKey                 = @"MMOpenLayout";
-NSString *MMVerticalSplitKey              = @"MMVerticalSplit";
-NSString *MMPreloadCacheSizeKey           = @"MMPreloadCacheSize";
-NSString *MMLastWindowClosedBehaviorKey   = @"MMLastWindowClosedBehavior";
+NSString *MMTabMinWidthKey                 = @"MMTabMinWidth";
+NSString *MMTabMaxWidthKey                 = @"MMTabMaxWidth";
+NSString *MMTabOptimumWidthKey             = @"MMTabOptimumWidth";
+NSString *MMShowAddTabButtonKey            = @"MMShowAddTabButton";
+NSString *MMTextInsetLeftKey               = @"MMTextInsetLeft";
+NSString *MMTextInsetRightKey              = @"MMTextInsetRight";
+NSString *MMTextInsetTopKey                = @"MMTextInsetTop";
+NSString *MMTextInsetBottomKey             = @"MMTextInsetBottom";
+NSString *MMTypesetterKey                  = @"MMTypesetter";
+NSString *MMCellWidthMultiplierKey         = @"MMCellWidthMultiplier";
+NSString *MMBaselineOffsetKey              = @"MMBaselineOffset";
+NSString *MMTranslateCtrlClickKey          = @"MMTranslateCtrlClick";
+NSString *MMTopLeftPointKey                = @"MMTopLeftPoint";
+NSString *MMOpenInCurrentWindowKey         = @"MMOpenInCurrentWindow";
+NSString *MMNoFontSubstitutionKey          = @"MMNoFontSubstitution";
+NSString *MMNoTitleBarWindowKey            = @"MMNoTitleBarWindow";
+NSString *MMTitlebarAppearsTransparentKey  = @"MMTitlebarAppearsTransparent";
+NSString *MMTitlebarDisableDocumentIconKey = @"MMTitlebarDisableDocumentIcon";
+NSString *MMDisableLaunchAnimation         = @"MMDisableLaunchAnimation";
+NSString *MMLoginShellKey                  = @"MMLoginShell";
+NSString *MMUntitledWindowKey              = @"MMUntitledWindow";
+NSString *MMZoomBothKey                    = @"MMZoomBoth";
+NSString *MMCurrentPreferencePaneKey       = @"MMCurrentPreferencePane";
+NSString *MMLoginShellCommandKey           = @"MMLoginShellCommand";
+NSString *MMLoginShellArgumentKey          = @"MMLoginShellArgument";
+NSString *MMDialogsTrackPwdKey             = @"MMDialogsTrackPwd";
+NSString *MMOpenLayoutKey                  = @"MMOpenLayout";
+NSString *MMVerticalSplitKey               = @"MMVerticalSplit";
+NSString *MMPreloadCacheSizeKey            = @"MMPreloadCacheSize";
+NSString *MMLastWindowClosedBehaviorKey    = @"MMLastWindowClosedBehavior";
 #ifdef INCLUDE_OLD_IM_CODE
-NSString *MMUseInlineImKey                = @"MMUseInlineIm";
+NSString *MMUseInlineImKey                 = @"MMUseInlineIm";
 #endif // INCLUDE_OLD_IM_CODE
-NSString *MMSuppressTerminationAlertKey   = @"MMSuppressTerminationAlert";
-NSString *MMNativeFullScreenKey           = @"MMNativeFullScreen";
-NSString *MMUseMouseTimeKey               = @"MMUseMouseTime";
-NSString *MMFullScreenFadeTimeKey         = @"MMFullScreenFadeTime";
-NSString *MMUseCGLayerAlwaysKey           = @"MMUseCGLayerAlways";
-NSString *MMBufferedDrawingKey            = @"MMBufferedDrawing";
+NSString *MMSuppressTerminationAlertKey    = @"MMSuppressTerminationAlert";
+NSString *MMNativeFullScreenKey            = @"MMNativeFullScreen";
+NSString *MMUseMouseTimeKey                = @"MMUseMouseTime";
+NSString *MMFullScreenFadeTimeKey          = @"MMFullScreenFadeTime";
+NSString *MMUseCGLayerAlwaysKey            = @"MMUseCGLayerAlways";
+NSString *MMBufferedDrawingKey             = @"MMBufferedDrawing";
 
 
 


### PR DESCRIPTION
- When MMTitlebarAppearsTransparent is enabled, using window appearance (NSAppearanceNameDarkAqua, 10.10 and higher version is required) to avoid title bar font color fusion with background.
- Add MMTitlebarDisableDocumentIconKey to disable file icon from titlebar

![image](https://user-images.githubusercontent.com/1335935/75884131-3f973680-5e5f-11ea-800a-78af766e89ea.png)
