### PR TITLE
Fix configure not parsing Vim version correctly

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -14903,10 +14903,16 @@ $as_echo "using default" >&6; }
 fi
 
 
-    vim_short_version_string=`grep 'define.*VIM_VERSION_SHORT' $srcdir/version.h|sed -E -e 's/.*"([0-9.]*)".*/\1/'`
+    vim_major_version_string=`grep -m 1 'define.*VIM_VERSION_MAJOR' $srcdir/version.h|sed -E -e 's/^.*([0-9]+).*/\1/'`
+  vim_minor_version_string=`grep -m 1 'define.*VIM_VERSION_MINOR' $srcdir/version.h|sed -E -e 's/^.*([0-9]+).*/\1/'`
   snapshot=`grep -C2 "Add new patch number below this line" $srcdir/version.c|tail -1|sed -E -e 's/^ *([0-9]+),.*/\1/'`
-  vim_short_version_string="$vim_short_version_string.$snapshot"
-  XCODEFLAGS="$XCODEFLAGS VIM_SHORT_VERSION_STRING=$vim_short_version_string"
+  vim_short_version_string="$vim_major_version_string.$vim_minor_version_string.$snapshot"
+
+  if echo "$vim_short_version_string" | grep -q "^\d\+\.\d\+\.\d\+$"; then
+    XCODEFLAGS="$XCODEFLAGS VIM_SHORT_VERSION_STRING=$vim_short_version_string"
+  else
+    as_fn_error $? "could not parse Vim version: $vim_short_version_string" "$LINENO" 5
+  fi
 
 
 fi

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4543,10 +4543,16 @@ if test "x$MACOS_X" = "xyes"; then
     [ AC_MSG_RESULT(using default) ])
 
   dnl Set CFBundleShortVersionString of Info.plist
-  vim_short_version_string=`grep 'define.*VIM_VERSION_SHORT' $srcdir/version.h|sed -E -e 's/.*"([[0-9.]]*)".*/\1/'`
+  vim_major_version_string=`grep -m 1 'define.*VIM_VERSION_MAJOR' $srcdir/version.h|sed -E -e 's/^.*([[0-9]]+).*/\1/'`
+  vim_minor_version_string=`grep -m 1 'define.*VIM_VERSION_MINOR' $srcdir/version.h|sed -E -e 's/^.*([[0-9]]+).*/\1/'`
   snapshot=`grep -C2 "Add new patch number below this line" $srcdir/version.c|tail -1|sed -E -e 's/^ *([[0-9]]+),.*/\1/'`
-  vim_short_version_string="$vim_short_version_string.$snapshot"
-  XCODEFLAGS="$XCODEFLAGS VIM_SHORT_VERSION_STRING=$vim_short_version_string"
+  vim_short_version_string="$vim_major_version_string.$vim_minor_version_string.$snapshot"
+
+  if echo "$vim_short_version_string" | grep -q "^\d\+\.\d\+\.\d\+$"; then
+    XCODEFLAGS="$XCODEFLAGS VIM_SHORT_VERSION_STRING=$vim_short_version_string"
+  else
+    AC_MSG_ERROR(could not parse Vim version: $vim_short_version_string)
+  fi
 
   AC_SUBST(XCODEFLAGS)
 fi


### PR DESCRIPTION
Fix the script to parse Vim version correct as version.h had a refactor. Also, make sure if the output version string doesn't look right, we will fail the configure script so we know something is wrong after merging from Vim upstream.

Fix #1011