### PR TITLE
Fix #1020

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -1752,7 +1752,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_11
                 f = [f stringByRemovingPercentEncoding];
 #else
-		f = [f stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+                f = [f stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 #endif
 
                 // parse value
@@ -1763,20 +1763,20 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
                 if (decode)
                 {
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_11
-                    v = [f stringByRemovingPercentEncoding];
+                    v = [v stringByRemovingPercentEncoding];
 #else
-                    v = [f stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+                    v = [v stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 #endif
                 }
 
-		[dict setValue:v forKey:f];
+                [dict setValue:v forKey:f];
             }
         }
 
         // Actually open the file.
         NSString *file = [dict objectForKey:@"url"];
         if (file != nil) {
-            NSURL *fileUrl= [NSURL URLWithString:file];
+            NSURL *fileUrl = [NSURL URLWithString:file];
             // TextMate only opens files that already exist.
             if ([fileUrl isFileURL]
                     && [[NSFileManager defaultManager] fileExistsAtPath:


### PR DESCRIPTION
PR #1002 removed decoding of the mvim:// url query.
Every query goes through decoding now, no exceptions.

This should make it work the way it was.

We can use this PR to generate regression tests as well, as pointed here https://github.com/macvim-dev/macvim/issues/1020#issuecomment-597348522