### PR TITLE
Fix configure not working with custom grep

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -14903,12 +14903,12 @@ $as_echo "using default" >&6; }
 fi
 
 
-    vim_major_version_string=`grep -m 1 'define.*VIM_VERSION_MAJOR' $srcdir/version.h|sed -E -e 's/^.*([0-9]+).*/\1/'`
-  vim_minor_version_string=`grep -m 1 'define.*VIM_VERSION_MINOR' $srcdir/version.h|sed -E -e 's/^.*([0-9]+).*/\1/'`
-  snapshot=`grep -C2 "Add new patch number below this line" $srcdir/version.c|tail -1|sed -E -e 's/^ *([0-9]+),.*/\1/'`
+    vim_major_version_string=`/usr/bin/grep -m 1 'define.*VIM_VERSION_MAJOR' $srcdir/version.h|sed -E -e 's/^.*([0-9]+).*/\1/'`
+  vim_minor_version_string=`/usr/bin/grep -m 1 'define.*VIM_VERSION_MINOR' $srcdir/version.h|sed -E -e 's/^.*([0-9]+).*/\1/'`
+  snapshot=`/usr/bin/grep -C2 "Add new patch number below this line" $srcdir/version.c|tail -1|sed -E -e 's/^ *([0-9]+),.*/\1/'`
   vim_short_version_string="$vim_major_version_string.$vim_minor_version_string.$snapshot"
 
-  if echo "$vim_short_version_string" | grep -q "^\d\+\.\d\+\.\d\+$"; then
+  if echo "$vim_short_version_string" | /usr/bin/grep -q "^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+$"; then
     XCODEFLAGS="$XCODEFLAGS VIM_SHORT_VERSION_STRING=$vim_short_version_string"
   else
     as_fn_error $? "could not parse Vim version: $vim_short_version_string" "$LINENO" 5

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4543,12 +4543,12 @@ if test "x$MACOS_X" = "xyes"; then
     [ AC_MSG_RESULT(using default) ])
 
   dnl Set CFBundleShortVersionString of Info.plist
-  vim_major_version_string=`grep -m 1 'define.*VIM_VERSION_MAJOR' $srcdir/version.h|sed -E -e 's/^.*([[0-9]]+).*/\1/'`
-  vim_minor_version_string=`grep -m 1 'define.*VIM_VERSION_MINOR' $srcdir/version.h|sed -E -e 's/^.*([[0-9]]+).*/\1/'`
-  snapshot=`grep -C2 "Add new patch number below this line" $srcdir/version.c|tail -1|sed -E -e 's/^ *([[0-9]]+),.*/\1/'`
+  vim_major_version_string=`/usr/bin/grep -m 1 'define.*VIM_VERSION_MAJOR' $srcdir/version.h|sed -E -e 's/^.*([[0-9]]+).*/\1/'`
+  vim_minor_version_string=`/usr/bin/grep -m 1 'define.*VIM_VERSION_MINOR' $srcdir/version.h|sed -E -e 's/^.*([[0-9]]+).*/\1/'`
+  snapshot=`/usr/bin/grep -C2 "Add new patch number below this line" $srcdir/version.c|tail -1|sed -E -e 's/^ *([[0-9]]+),.*/\1/'`
   vim_short_version_string="$vim_major_version_string.$vim_minor_version_string.$snapshot"
 
-  if echo "$vim_short_version_string" | grep -q "^\d\+\.\d\+\.\d\+$"; then
+  if echo "$vim_short_version_string" | /usr/bin/grep -q "^[[[:digit:]]]\+\.[[[:digit:]]]\+\.[[[:digit:]]]\+$"; then
     XCODEFLAGS="$XCODEFLAGS VIM_SHORT_VERSION_STRING=$vim_short_version_string"
   else
     AC_MSG_ERROR(could not parse Vim version: $vim_short_version_string)


### PR DESCRIPTION
5e199f497ee189e83b435956f4cb358ee9bf0f12 added a check to make sure configure is properly parsing the Vim version string, but it doesn't work if user has installed GNU grep instead of the system one. Fix it to use the more common `[[:digit:]]` (instead of `\d`), and also hardcode the path for grep.

Fix #1017