### PR TITLE
Set App Category to Productivity

### DIFF
--- a/src/MacVim/Info.plist
+++ b/src/MacVim/Info.plist
@@ -1256,6 +1256,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>162</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.productivity</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
I noticed that MacVim is categorised as Other in Screen Time. I think Productivity would be a better fit.