### PR TITLE
Fix CI

### DIFF
--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -633,6 +633,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
     while (CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true)
             == kCFRunLoopRunHandledSource)
         ;   // do nothing
+    [self processInputQueue];
 }
 
 - (void)flushQueue:(BOOL)force
@@ -729,8 +730,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
 
     // The above calls may have placed messages on the input queue so process
     // it now.  This call may enter a blocking loop.
-    if ([inputQueue count] > 0)
-        [self processInputQueue];
+    [self processInputQueue];
 
     return inputReceived;
 }

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -347,9 +347,16 @@ gui_mch_update(void)
 
     CFAbsoluteTime nowTime = CFAbsoluteTimeGetCurrent();
     if (nowTime - lastTime > 1.0 / 30) {
-        [[MMBackend sharedInstance] update];
+        gui_macvim_update();
         lastTime = nowTime;
     }
+}
+
+
+    void
+gui_macvim_update(void)
+{
+    [[MMBackend sharedInstance] update];
 }
 
 

--- a/src/proto/gui_macvim.pro
+++ b/src/proto/gui_macvim.pro
@@ -17,6 +17,8 @@ gui_mch_open(void);
     void
 gui_mch_update(void);
     void
+gui_macvim_update(void);
+    void
 gui_mch_flush(void);
     void
 gui_macvim_flush(void);

--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -432,7 +432,7 @@ for g:testfunc in sort(s:tests)
           " tests pending for now before a more proper fix is implemented.
           call extend(s:messages, [
                 \ 'Flaky test failed too often, giving up',
-                \ 'MacVim marked ' . s:test . ' as pending',
+                \ 'MacVim marked ' . g:testfunc . ' as pending',
                 \ ])
           let v:errors = []
         endif

--- a/src/testdir/test_netbeans.vim
+++ b/src/testdir/test_netbeans.vim
@@ -609,7 +609,7 @@ func Nb_basic(port)
 
   " detach
   call appendbufline(cmdbufnr, '$', 'detach_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 6)')
+  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 8)')
   let l = readfile('Xnetbeans')
   call assert_equal('0:disconnect=91', l[-1])
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -707,7 +707,14 @@ ui_breakcheck_force(int force)
 
 #ifdef FEAT_GUI
     if (gui.in_use)
+    {
+# ifdef FEAT_GUI_MACVIM
+	if (force)
+	    gui_macvim_update();
+	else
+# endif
 	gui_mch_update();
+    }
     else
 #endif
 	mch_breakcheck(force);


### PR DESCRIPTION
Now CI fails caused by mainly `Test_writedelay` and netbeans tests.

**Test_writedelay**

By `RunVim()` added into `Test_opt_default_cdpath` the GUI events of window-focus (lost/gained) happen and they are queued into `inputQueue` of MMBackend, but they are not processd during tests.
Because of that, regarded as input are activated, 'writedelay' are ignored at doing `redraw`.

Solution: during `gui_mch_update()`, invoke `[MMBackend processInputQueue]` to flush events.

**netbeans tests**

Netbeans tests expect that the channel are processed during `:sleep 1m`, but, since currently updating rate is up to 30/second, cannot handle enough the messages from the test server.

Solution: define `gui_macvim_update()` in order to update surely in `:sleep`.

And merged a part of 8.2.0786 to fix `Test_nb_basic`.