### PR TITLE
Fix build warnings and code format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ script:
   - NPROC=$(getconf _NPROCESSORS_ONLN)
   - make distclean
   - ./configure ${CONFOPT} ${LANGOPT} --enable-fail-if-missing
+  - sed -i.bak -f ci/config.mk.sed -f ci/config.mk.clang.sed src/auto/config.mk
   # Ruby is keg-only in Homebrew, so need to manually link in the path so Vim will know where to look for the binaries.
   - perl -p -i -e "s#(?<=-DDYNAMIC_RUBY_DLL=\\\\\").*?(?=\\\\\")#${vi_cv_dll_name_ruby}#" src/auto/config.mk
   - cat src/auto/config.mk

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Vim - the text editor - for Mac OS X
+Vim - the text editor - for macOS
 
 
 - MacVim homepage https://macvim-dev.github.io/macvim

--- a/ci/config.mk.clang.sed
+++ b/ci/config.mk.clang.sed
@@ -1,2 +1,2 @@
-/^CFLAGS[[:blank:]]*=/s/$/ -Wno-error=missing-field-initializers/
+/^CFLAGS[[:blank:]]*=/s/$/ -Wno-error=missing-field-initializers -Wno-error=deprecated-declarations -Wno-error=unused-function/
 /^RUBY_CFLAGS[[:blank:]]*=/s/$/ -Wno-error=unknown-attributes -Wno-error=ignored-attributes/

--- a/src/MacVim/MMBackend.h
+++ b/src/MacVim/MMBackend.h
@@ -140,6 +140,7 @@ extern NSTimeInterval MMBalloonEvalInternalDelay;
 - (void)setLigatures:(BOOL)ligatures;
 - (void)setThinStrokes:(BOOL)thinStrokes;
 - (void)setBlurRadius:(int)radius;
+- (void)setBackground:(int)dark;
 
 - (void)updateModifiedFlag;
 

--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -62,10 +62,10 @@ vimmenu_T *menu_for_descriptor(NSArray *desc);
 
 static id evalExprCocoa(NSString * expr, NSString ** errstr);
 
-extern void im_preedit_start_macvim();
-extern void im_preedit_end_macvim();
-extern void im_preedit_abandon_macvim();
-extern void im_preedit_changed_macvim(char *preedit_string, int cursor_index);
+void im_preedit_start_macvim();
+void im_preedit_end_macvim();
+void im_preedit_abandon_macvim();
+void im_preedit_changed_macvim(char *preedit_string, int cursor_index);
 
 enum {
     MMBlinkStateNone = 0,
@@ -636,7 +636,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
     [self processInputQueue];
 }
 
-- (void)flushQueue:(BOOL)force
+- (void)flushQueue:(BOOL UNUSED)force
 {
     // TODO: "force" is currently unused. When flushDisabled is set, it will
     // always disable flushing. Consider fixing it so that force will actually
@@ -1765,10 +1765,10 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
     // the shell (think ":grep" with thousands of matches).
 
     ++numWholeLineChanges;
-    if (numWholeLineChanges == gui.num_rows) {
+    if (numWholeLineChanges == (unsigned)gui.num_rows) {
         // Remember the offset to prune up to.
         offsetForDrawDataPrune = [drawData length];
-    } else if (numWholeLineChanges == 2*gui.num_rows) {
+    } else if (numWholeLineChanges == (unsigned)2*gui.num_rows) {
         // Delete all the unnecessary draw commands.
         NSMutableData *d = [[NSMutableData alloc]
                     initWithBytes:[drawData bytes] + offsetForDrawDataPrune
@@ -2200,7 +2200,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
         vim_free(conv_str);
 }
 
-- (BOOL)handleSpecialKey:(NSString *)key
+- (BOOL)handleSpecialKey:(NSString * UNUSED)key
                  keyCode:(unsigned)code
                modifiers:(int)mods
 {
@@ -2327,7 +2327,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
         [outputQueue addObject:[NSData data]];
 }
 
-- (void)connectionDidDie:(NSNotification *)notification
+- (void)connectionDidDie:(NSNotification * UNUSED)notification
 {
     // If the main connection to MacVim is lost this means that either MacVim
     // has crashed or this process did not receive its termination message
@@ -2340,7 +2340,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
     getout_preserve_modified(1);
 }
 
-- (void)blinkTimerFired:(NSTimer *)timer
+- (void)blinkTimerFired:(NSTimer * UNUSED)timer
 {
     NSTimeInterval timeInterval = 0;
 
@@ -2633,7 +2633,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
 #endif // FEAT_ODB_EDITOR
 }
 
-- (void)handleXcodeMod:(NSData *)data
+- (void)handleXcodeMod:(NSData * UNUSED)data
 {
 #if 0
     const void *bytes = [data bytes];
@@ -3349,7 +3349,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
 }
 
 #ifdef FEAT_BEVAL
-- (void)bevalCallback:(id)sender
+- (void)bevalCallback:(id UNUSED)sender
 {
     if (!(p_beval && balloonEval))
         return;
@@ -3373,7 +3373,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
 #endif
 
 #ifdef MESSAGE_QUEUE
-- (void)checkForProcessEvents:(NSTimer *)timer
+- (void)checkForProcessEvents:(NSTimer * UNUSED)timer
 {
 # ifdef FEAT_TIMERS
     did_add_timer = FALSE;
@@ -3464,7 +3464,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
 
     while ((conn = [e nextObject])) {
         // HACK! Assume connection uses mach ports.
-        if (port == [(NSMachPort*)[conn sendPort] machPort])
+        if ((uint32_t)port == [(NSMachPort*)[conn sendPort] machPort])
             return conn;
     }
 

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -849,9 +849,9 @@ gui_mch_destroy_menu(vimmenu_T *menu)
     void
 gui_mch_menu_grey(vimmenu_T *menu, int grey)
 {
-    /* Only update menu if the 'grey' state has changed to avoid having to pass
-     * lots of unnecessary data to MacVim.  (Skipping this test makes MacVim
-     * pause noticably on mode changes. */
+    // Only update menu if the 'grey' state has changed to avoid having to pass
+    // lots of unnecessary data to MacVim.  (Skipping this test makes MacVim
+    // pause noticably on mode changes.
     NSArray *desc = descriptor_for_menu(menu);
     if (menu->was_grey == grey)
         return;
@@ -923,7 +923,7 @@ gui_mch_draw_menubar(void)
 
 
     void
-gui_mch_enable_menu(int flag)
+gui_mch_enable_menu(int flag UNUSED)
 {
     // The (main) menu is always enabled in Mac OS X.
 }
@@ -1048,7 +1048,7 @@ gui_mch_init_font(char_u *font_name, int fontset)
  * Set the current text font.
  */
     void
-gui_mch_set_font(GuiFont font)
+gui_mch_set_font(GuiFont font UNUSED)
 {
     // Font selection is done inside MacVim...nothing here to do.
 }
@@ -1120,7 +1120,7 @@ gui_macvim_font_with_name(char_u *name)
     void
 gui_mch_create_scrollbar(
 	scrollbar_T *sb,
-	int orient)	/* SBAR_VERT or SBAR_HORIZ */
+	int orient UNUSED)	/* SBAR_VERT or SBAR_HORIZ */
 {
     [[MMBackend sharedInstance] 
             createScrollbarWithIdentifier:(int32_t)sb->ident type:sb->type];
@@ -1199,7 +1199,7 @@ gui_mch_draw_hollow_cursor(guicolor_T color)
  * Draw part of a cursor, only w pixels wide, and h pixels high.
  */
     void
-gui_mch_draw_part_cursor(int w, int h, guicolor_T color)
+gui_mch_draw_part_cursor(int w UNUSED, int h UNUSED, guicolor_T color)
 {
     // HACK!  'w' and 'h' are always 1 since we do not tell Vim about the exact
     // font dimensions.  Thus these parameters are useless.  Instead we look at
@@ -1286,14 +1286,14 @@ gui_mch_stop_blink(int may_call_gui_update_cursor)
  * Get current mouse coordinates in text window.
  */
     void
-gui_mch_getmouse(int *x, int *y)
+gui_mch_getmouse(int *x UNUSED, int *y UNUSED)
 {
     ASLogInfo(@"Not implemented!");
 }
 
 
     void
-gui_mch_setmouse(int x, int y)
+gui_mch_setmouse(int x UNUSED, int y UNUSED)
 {
     ASLogInfo(@"Not implemented!");
 }
@@ -1311,6 +1311,8 @@ mch_set_mouse_shape(int shape)
 // -- Input Method ----------------------------------------------------------
 
 #if defined(FEAT_EVAL)
+void call_imactivatefunc(int active);
+int call_imstatusfunc(void);
 # ifdef FEAT_GUI
 #  define USE_IMACTIVATEFUNC (!gui.in_use && *p_imaf != NUL)
 #  define USE_IMSTATUSFUNC (!gui.in_use && *p_imsf != NUL)
@@ -1345,13 +1347,10 @@ im_set_active(int active)
     if (USE_IMACTIVATEFUNC)
     {
         if (active != im_get_status())
-        {
             call_imactivatefunc(active);
-        }
         return;
     }
 #endif
-
     // Tell frontend to enable/disable IM (called e.g. when the mode changes).
     if (!p_imdisable) {
         int msgid = active ? ActivateKeyScriptMsgID : DeactivateKeyScriptMsgID;
@@ -1364,11 +1363,10 @@ im_set_active(int active)
     int
 im_get_status(void)
 {
-#ifdef FEAT_EVAL
+#if defined(FEAT_EVAL)
     if (USE_IMSTATUSFUNC)
         return call_imstatusfunc();
 #endif
-
     return [[MMBackend sharedInstance] imState];
 }
 
@@ -1380,7 +1378,7 @@ im_get_status(void)
 #ifdef FIND_REPLACE_DIALOG
 
     static void
-macvim_find_and_replace(char_u *arg, BOOL replace)
+macvim_find_and_replace(char_u *arg, BOOL replace UNUSED)
 {
     // TODO: Specialized dialog for find without replace?
     int wholeWord = FALSE;
@@ -1559,7 +1557,7 @@ gui_mch_dialog(
     char_u	*buttons,
     int		dfltbutton,
     char_u	*textfield,
-    int         ex_cmd)     // UNUSED
+    int		ex_cmd UNUSED)
 {
     ASLogDebug(@"type=%d title='%s' message='%s' buttons='%s' dfltbutton=%d "
                "textfield='%s'", type, title, message, buttons, dfltbutton,
@@ -1623,8 +1621,9 @@ gui_mch_dialog(
 
 
     void
-gui_mch_flash(int msec)
+gui_mch_flash(int msec UNUSED)
 {
+    // NOP
 }
 
 
@@ -1704,6 +1703,7 @@ gui_mch_haskey(char_u *name)
     void
 gui_mch_iconify(void)
 {
+    // NOP
 }
 
 
@@ -1772,8 +1772,9 @@ gui_mch_get_winpos(int *x, int *y)
 
 
     void
-gui_mch_set_text_area_pos(int x, int y, int w, int h)
+gui_mch_set_text_area_pos(int x UNUSED, int y UNUSED, int w UNUSED, int h UNUSED)
 {
+    // NOP
 }
 
 
@@ -1802,14 +1803,15 @@ gui_mch_settitle(char_u *title, char_u *icon)
 
 
     void
-gui_mch_toggle_tearoffs(int enable)
+gui_mch_toggle_tearoffs(int enable UNUSED)
 {
+    // NOP
 }
 
 
 
     void
-gui_mch_enter_fullscreen(int fuoptions_flags, guicolor_T bg)
+gui_mch_enter_fullscreen(guicolor_T bg)
 {
     [[MMBackend sharedInstance] enterFullScreen:fuoptions_flags background:bg];
 }
@@ -1977,8 +1979,14 @@ serverRegisterName(char_u *name)
  * Returns 0 for OK, negative for an error.
  */
     int
-serverSendToVim(char_u *name, char_u *cmd, char_u **result,
-        int *port, int asExpr, int timeout, int silent)
+serverSendToVim(
+    char_u	*name,
+    char_u	*cmd,
+    char_u	**result,
+    int		*port,
+    int		asExpr,
+    int		timeout UNUSED,
+    int		silent)
 {
     name = CONVERT_TO_UTF8(name);
     cmd = CONVERT_TO_UTF8(cmd);
@@ -2199,12 +2207,12 @@ odb_end(void)
 
 
     char_u *
-get_macaction_name(expand_T *xp, int idx)
+get_macaction_name(expand_T *xp UNUSED, int idx)
 {
     static char_u *str = NULL;
     NSDictionary *actionDict = [[MMBackend sharedInstance] actionDict];
 
-    if (nil == actionDict || idx < 0 || idx >= [actionDict count])
+    if (nil == actionDict || idx < 0 || (size_t)idx >= [actionDict count])
         return NULL;
 
     NSString *string = [[actionDict allKeys] objectAtIndex:idx];
@@ -2299,7 +2307,7 @@ specialKeyToNSKey(int key)
         { K_PAGEDOWN, NSPageDownFunctionKey }
     };
 
-    int i;
+    size_t i;
     for (i = 0; i < sizeof(sp2ns)/sizeof(sp2ns[0]); ++i) {
         if (sp2ns[i].special == key)
             return sp2ns[i].nskey;
@@ -2427,7 +2435,7 @@ gui_mch_destroy_sign(void *sign)
 
     BalloonEval *
 gui_mch_create_beval_area(
-    void	*target,
+    void	*target UNUSED,
     char_u	*mesg,
     void	(*mesgCB)(BalloonEval *, int),
     void	*clientData)
@@ -2446,7 +2454,7 @@ gui_mch_create_beval_area(
 }
 
     void
-gui_mch_enable_beval_area(BalloonEval *beval)
+gui_mch_enable_beval_area(BalloonEval *beval UNUSED)
 {
     // Set the balloon delay when enabling balloon eval.
     float delay = p_bdlay/1000.0f - MMBalloonEvalInternalDelay;
@@ -2457,7 +2465,7 @@ gui_mch_enable_beval_area(BalloonEval *beval)
 }
 
     void
-gui_mch_disable_beval_area(BalloonEval *beval)
+gui_mch_disable_beval_area(BalloonEval *beval UNUSED)
 {
     // NOTE: An empty tool tip indicates that the tool tip window should hide.
     [[MMBackend sharedInstance] queueMessage:SetTooltipMsgID properties:
@@ -2468,7 +2476,7 @@ gui_mch_disable_beval_area(BalloonEval *beval)
  * Show a balloon with "mesg".
  */
     void
-gui_mch_post_balloon(BalloonEval *beval, char_u *mesg)
+gui_mch_post_balloon(BalloonEval *beval UNUSED, char_u *mesg)
 {
     NSString *toolTip = [NSString stringWithVimString:mesg];
     [[MMBackend sharedInstance] setLastToolTip:toolTip];

--- a/src/channel.c
+++ b/src/channel.c
@@ -3966,7 +3966,7 @@ theend:
     free_job_options(&opt);
 }
 
-#ifdef FEAT_GUI_MACVIM
+#if defined(FEAT_GUI_MACVIM) || defined(PROTO)
 /*
  * Read from channel "channel" in dispatch event handler.
  * Channel may be already read out elsewhere before the handler invoked

--- a/src/gui.c
+++ b/src/gui.c
@@ -918,14 +918,14 @@ gui_init_font(char_u *font_list, int fontset UNUSED)
 		(void)copy_option_part(&font_list, font_name, FONTLEN, ",");
 
 #if defined(FEAT_GUI_MACVIM)
-                // The font dialog is modeless in Mac OS X, so when
-                // gui_mch_init_font() is called with "*" it brings up the
-                // dialog and returns immediately.  In this case we don't want
-                // it to be called again with NULL, so return here.
-                if (STRCMP(font_name, "*") == 0) {
-                    gui_mch_init_font(font_name, FALSE);
-                    return FALSE;
-                }
+		// The font dialog is modeless in Mac OS X, so when
+		// gui_mch_init_font() is called with "*" it brings up the
+		// dialog and returns immediately.  In this case we don't want
+		// it to be called again with NULL, so return here.
+		if (STRCMP(font_name, "*") == 0) {
+		    gui_mch_init_font(font_name, FALSE);
+		    return FALSE;
+		}
 #endif
 		// Careful!!!  The Win32 version of gui_mch_init_font(), when
 		// called with "*" will change p_guifont to the selected font

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4828,9 +4828,6 @@ call_imstatusfunc(void)
 #if defined(FEAT_XIM) || defined(PROTO)
 
 # ifdef FEAT_GUI_MACVIM
-   typedef int	 GtkIMContext;
-   typedef int * gpointer;
-   typedef char  gchar;
 #  define g_return_if_fail(x) if (!(x)) return;
 # endif
 
@@ -4856,8 +4853,8 @@ static int preedit_is_active   = FALSE;
 static int im_preedit_cursor   = 0;	// cursor offset in characters
 static int im_preedit_trailing = 0;	// number of characters after cursor
 
-static unsigned long im_commit_handler_id  = 0;
 # ifndef FEAT_GUI_MACVIM
+static unsigned long im_commit_handler_id  = 0;
 static unsigned int  im_activatekey_keyval = GDK_VoidSymbol;
 static unsigned int  im_activatekey_state  = 0;
 
@@ -4865,7 +4862,9 @@ static GtkWidget *preedit_window = NULL;
 static GtkWidget *preedit_label = NULL;
 
 static void im_preedit_window_set_position(void);
+# endif
 
+# if !defined(FEAT_GUI_MACVIM) || defined(PROTO)
     void
 im_set_active(int active)
 {
@@ -4880,7 +4879,7 @@ im_set_active(int active)
 # endif
 
     void
-xim_set_focus(int focus)
+xim_set_focus(int focus UNUSED)
 {
 # ifndef FEAT_GUI_MACVIM
     if (xic != NULL)
@@ -4893,7 +4892,7 @@ xim_set_focus(int focus)
 # endif
 }
 
-# ifndef FEAT_GUI_MACVIM
+# if !defined(FEAT_GUI_MACVIM) || defined(PROTO)
     void
 im_set_position(int row, int col)
 {
@@ -5545,7 +5544,7 @@ translate_pango_attributes(PangoAttrIterator *iter)
  * Return -1 if not in preediting mode or if col is out of range.
  */
     int
-im_get_feedback_attr(int col)
+im_get_feedback_attr(int col UNUSED)
 {
 # ifndef FEAT_GUI_MACVIM
     char	    *preedit_string = NULL;
@@ -5640,7 +5639,9 @@ im_shutdown(void)
     }
 # endif
     im_is_active = FALSE;
+# ifndef FEAT_GUI_MACVIM
     im_commit_handler_id = 0;
+# endif
     if (p_imst == IM_ON_THE_SPOT)
 	preedit_start_col = MAXCOL;
     xim_has_preediting = FALSE;
@@ -5790,7 +5791,7 @@ xim_reset(void)
     xim_has_preediting = FALSE;
 }
 
-# ifndef FEAT_GUI_MACVIM
+# if !defined(FEAT_GUI_MACVIM) || defined(PROTO)
     int
 xim_queue_key_press_event(GdkEventKey *event, int down)
 {
@@ -5929,7 +5930,7 @@ xim_queue_key_press_event(GdkEventKey *event, int down)
 }
 # endif
 
-# ifndef FEAT_GUI_MACVIM
+# if !defined(FEAT_GUI_MACVIM) || defined(PROTO)
     int
 im_get_status(void)
 {

--- a/src/menu.c
+++ b/src/menu.c
@@ -2863,8 +2863,8 @@ menu_translate_tab_and_shift(char_u *arg_start)
     return arg;
 }
 
-#ifdef FEAT_GUI_MACVIM
-    vimmenu_T *
+#if defined(FEAT_GUI_MACVIM) || defined(PROTO)
+    static vimmenu_T *
 menu_for_path(char_u *menu_path)
 {
     vimmenu_T	*menu;
@@ -2918,14 +2918,14 @@ menu_for_path(char_u *menu_path)
     return menu;
 }
 
-    void 
+    static void
 set_mac_menu_attrs(
-    vimmenu_T	*menu, 
-    char_u	*action, 
-    int		set_alt, 
-    int		mac_alternate, 
-    int		set_key, 
-    int		mac_key, 
+    vimmenu_T	*menu,
+    char_u	*action,
+    int		set_alt,
+    int		mac_alternate,
+    int		set_key,
+    int		mac_key,
     int		mac_mods)
 {
     if (action)
@@ -2943,8 +2943,7 @@ set_mac_menu_attrs(
  * Handle the ":macmenu" command.
  */
     void
-ex_macmenu(eap)
-    exarg_T	*eap;
+ex_macmenu(exarg_T *eap)
 {
     vimmenu_T	*menu = NULL;
     vimmenu_T	*popup_menu_for_mode = NULL;
@@ -2968,8 +2967,8 @@ ex_macmenu(eap)
     int		unmenu;
     char_u	*last_dash;
     int		bit;
-    int         set_key = FALSE;
-    int         set_alt = FALSE;
+    int		set_key = FALSE;
+    int		set_alt = FALSE;
 
     arg = eap->arg;
 
@@ -2983,7 +2982,8 @@ ex_macmenu(eap)
     keys = menu_translate_tab_and_shift(arg);
 
     menu = menu_for_path(menu_path);
-    if (!menu) return;
+    if (!menu)
+	return;
 
     /*
      * Parse all key=value arguments.
@@ -3180,7 +3180,8 @@ ex_macmenu(eap)
      */
     if (!error)
     {
-	set_mac_menu_attrs(menu, action, set_alt, mac_alternate, set_key, mac_key, mac_mods);
+	set_mac_menu_attrs(menu, action, set_alt, mac_alternate, set_key,
+							   mac_key, mac_mods);
 
 	modes = get_menu_cmd_modes(eap->cmd, eap->forceit, &noremap, &unmenu);
 	if (menu_is_popup(menu_path))
@@ -3192,7 +3193,9 @@ ex_macmenu(eap)
 		    if (p != NULL)
 		    {
 			popup_menu_for_mode = menu_for_path(p);
-			set_mac_menu_attrs(popup_menu_for_mode, action, set_alt, mac_alternate, set_key, mac_key, mac_mods);
+			set_mac_menu_attrs(popup_menu_for_mode, action,
+						  set_alt, mac_alternate,
+						  set_key, mac_key, mac_mods);
 			vim_free(p);
 		    }
 		}
@@ -3205,11 +3208,10 @@ ex_macmenu(eap)
 }
 
     char_u *
-lookup_toolbar_item(idx)
-    int idx;
+lookup_toolbar_item(int idx)
 {
-    if (idx >= 0 && idx < TOOLBAR_NAME_COUNT)
-        return (char_u*)toolbar_names[idx];
+    if (idx >= 0 && (size_t)idx < TOOLBAR_NAME_COUNT)
+	return (char_u*)toolbar_names[idx];
 
     return NULL;
 }

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -495,7 +495,7 @@ static struct vimoption options[] =
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)0L, (char_u *)0L} },
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"bomb",	    NULL,   P_BOOL|P_NO_MKRC|P_VI_DEF|P_RSTAT,
 			    (char_u *)&p_bomb, PV_BOMB,
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
@@ -1138,11 +1138,12 @@ static struct vimoption options[] =
     {"fullscreen",  "fu",   P_BOOL|P_NO_MKRC,
 #ifdef FEAT_FULLSCREEN
 			    (char_u *)&p_fullscreen, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
+			    {(char_u *)FALSE, (char_u *)0L}
 #else
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)NULL, (char_u *)0L} SCTX_INIT},
+			    {(char_u *)NULL, (char_u *)0L}
 #endif
+			    SCTX_INIT},
     {"fuoptions",  "fuopt", P_STRING|P_COMMA|P_NODUP|P_VI_DEF,
 #ifdef FEAT_FULLSCREEN
 			    (char_u *)&p_fuoptions, PV_NONE,
@@ -1677,27 +1678,30 @@ static struct vimoption options[] =
     {"macligatures", NULL,  P_BOOL|P_VI_DEF|P_RCLR,
 #ifdef FEAT_GUI_MACVIM
 			    (char_u *)&p_macligatures, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L}},
+			    {(char_u *)FALSE, (char_u *)0L}
 #else
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)NULL, (char_u *)0L}},
+			    {(char_u *)NULL, (char_u *)0L}
 #endif
+			    SCTX_INIT},
     {"macmeta",	    "mmta", P_BOOL|P_VI_DEF,
 #ifdef FEAT_GUI_MACVIM
 			    (char_u *)&p_mmta, PV_MMTA,
-			    {(char_u *)FALSE, (char_u *)0L}},
+			    {(char_u *)FALSE, (char_u *)0L}
 #else
 			    (char_u *)NULL, PV_MMTA,
-			    {(char_u *)NULL, (char_u *)0L}},
+			    {(char_u *)NULL, (char_u *)0L}
 #endif
+			    SCTX_INIT},
     {"macthinstrokes", NULL,  P_BOOL|P_VI_DEF|P_RCLR,
 #ifdef FEAT_GUI_MACVIM
 			    (char_u *)&p_macthinstrokes, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L}},
+			    {(char_u *)FALSE, (char_u *)0L}
 #else
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)NULL, (char_u *)0L}},
+			    {(char_u *)NULL, (char_u *)0L}
 #endif
+			    SCTX_INIT},
     {"magic",	    NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_magic, PV_NONE,
 			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
@@ -2732,7 +2736,7 @@ static struct vimoption options[] =
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)0L, (char_u *)0L} },
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"ttimeout",    NULL,   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_ttimeout, PV_NONE,
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4470,8 +4470,8 @@ mch_call_shell_system(
 
     out_flush();
 #ifdef FEAT_GUI_MACVIM
-    /* It is conceivable that the shell command will take a long time to finish
-     * so force a flush now. */
+    // It is conceivable that the shell command will take a long time to finish
+    // so force a flush now.
     if (gui.in_use)
 	gui_macvim_force_flush();
 #endif
@@ -4589,8 +4589,8 @@ mch_call_shell_fork(
 
     out_flush();
 #ifdef FEAT_GUI_MACVIM
-    /* It is conceivable that the shell command will take a long time to finish
-     * so force a flush now. */
+    // It is conceivable that the shell command will take a long time to finish
+    // so force a flush now.
     if (gui.in_use)
 	gui_macvim_force_flush();
 #endif

--- a/src/proto/gui_macvim.pro
+++ b/src/proto/gui_macvim.pro
@@ -210,7 +210,7 @@ int serverPeekReply(int port, char_u **str);
 int serverReadReply(int port, char_u **str);
 int serverSendReply(char_u *serverid, char_u *str);
 
-void gui_mch_enter_fullscreen(int fuoptions_flags, guicolor_T bg);
+void gui_mch_enter_fullscreen(guicolor_T bg);
 void gui_mch_leave_fullscreen(void);
 void gui_mch_fuopt_update(void);
 

--- a/src/proto/menu.pro
+++ b/src/proto/menu.pro
@@ -23,10 +23,7 @@ void ex_emenu(exarg_T *eap);
 void winbar_click(win_T *wp, int col);
 vimmenu_T *gui_find_menu(char_u *path_name);
 void ex_menutranslate(exarg_T *eap);
-#ifdef FEAT_GUI_MACVIM
 void ex_macmenu(exarg_T *eap);
-void ex_macmenukey(exarg_T *eap);
 char_u *lookup_toolbar_item(int idx);
-#endif
 void f_menu_info(typval_T *argvars, typval_T *rettv);
 /* vim: set ft=c : */

--- a/src/proto/option.pro
+++ b/src/proto/option.pro
@@ -14,7 +14,6 @@ void did_set_option(int opt_idx, int opt_flags, int new_value, int value_checked
 int string_to_key(char_u *arg, int multi_byte);
 void did_set_title(void);
 void set_options_bin(int oldval, int newval, int opt_flags);
-int check_fuoptions(char_u *p_fuoptions, unsigned *flags, int *bgcolor);
 void check_options(void);
 int get_term_opt_idx(char_u **p);
 int set_term_option_alloced(char_u **p);

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -11,4 +11,5 @@ void set_string_option_direct_in_buf(buf_T *buf, char_u *name, int opt_idx, char
 char *set_string_option(int opt_idx, char_u *value, int opt_flags);
 char *did_set_string_option(int opt_idx, char_u **varp, int new_value_alloced, char_u *oldval, char *errbuf, int opt_flags, int *value_checked);
 int check_ff_value(char_u *p);
+int check_fuoptions(void);
 /* vim: set ft=c : */

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1170,7 +1170,7 @@ write_to_term(buf_T *buffer, char_u *msg, channel_T *channel)
 	    if (buffer == curbuf && curbuf->b_term != NULL)
 		update_cursor(curbuf->b_term, TRUE);
 #ifdef FEAT_GUI_MACVIM
-            /* Force a flush now for better experience of interactive shell. */
+	    // Force a flush now for better experience of interactive shell.
 	    if (gui.in_use)
 		gui_macvim_force_flush();
 #endif

--- a/src/ui.c
+++ b/src/ui.c
@@ -535,12 +535,12 @@ ui_delay(long msec, int ignoreinput)
 #endif
     {
 #if defined(FEAT_GUI_MACVIM)
-        /* MacVim tries to be conservative with flushing, but when Vim takes a
-         * nap it really must flush (else timed error messages might not appear
-         * etc.).  Note that gui_mch_wait_for_chars() already does force a
-         * flush, so only do it here. */
-        if (gui.in_use)
-            gui_macvim_force_flush();
+	// MacVim tries to be conservative with flushing, but when Vim takes a
+	// nap it really must flush (else timed error messages might not appear
+	// etc.).  Note that gui_mch_wait_for_chars() already does force a
+	// flush, so only do it here.
+	if (gui.in_use)
+	    gui_macvim_force_flush();
 #endif
 	mch_delay(msec, ignoreinput);
     }
@@ -595,9 +595,9 @@ ui_get_shellsize(void)
 #ifdef FEAT_GUI
     if (gui.in_use
 # ifdef FEAT_GUI_MACVIM
-            /* Avoid using terminal dimensions for GUI window.  MacVim
-             * autosaves the dimensions of the first window. */
-            || gui.starting
+	    // Avoid using terminal dimensions for GUI window.  MacVim
+	    // autosaves the dimensions of the first window.
+	    || gui.starting
 # endif
             )
 	retval = gui_get_shellsize();


### PR DESCRIPTION
* Fix initialization of MacVim options
* Fix variable shadowing
* Organize and move check_fuoptions() to optionstr.c
* Mark unused variables