### PR TITLE
Fix mvim:// protocol double-encoding behavior handling properly

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -604,6 +604,15 @@ For example, the link >
 	mvim://open?url=file:///etc/profile&line=20
 will open the file /etc/profile on line 20 when clicked in a web browser.
 
+Note: A caveat in MacVim's implementation is that it expects special
+characters to be encoded twice. For example, a space should be encoded into
+"%2520" instead of "%20". A file "/tmp/file name?.txt" would need the
+following link: >
+	mvim://open?url=file:///tmp/file%2520name%253F.txt
+
+MacVim will try to be smart and detect cases where a user has erroneously only
+encoded once, but for best results use double-encoding as described above.
+
 Note that url has to be a file:// url pointing to an existing local file.
 
 ==============================================================================


### PR DESCRIPTION
Change mvim:// protocol behavior back to previous state to double-encode the file path, since we are encapsulating a file:// protocol (which has encoded path) within another URL as a query, which itself should be encoded. This means a file path "/tmp/file name.txt" should be properly encoded as mvim://open?url=file:///tmp/file%2520name.txt, as the space is encoded twice (first to %20, then to %2520).

Previously we tried to fix the protocol handler to only do a single encoding (see #1021 and #1043) but it's really an incorrect usage of URL. The reason for that fix was that tools like iTerm2 was passing in single-encoded URLs. As such, also add a compatibility feature here where we will optimiscally try to re-encode characters that we detect to be erroneously encoded. For example, if we see mvim://open?url=file:///tmp/file%20name.txt, MacVim will intelligently realize that the space needs to be encoded again. The only character where that won't work is the "%" character because of the ambiguity involved, so a file path "/tmp/file%.txt" will only work with this: mvim://open?url=file:///tmp/file%2525.txt

Close #1020 (also see the issue for discussions).