### PR TITLE
Make MacVim default to 3.8 DLL paths for MacPort and python.org installs

### DIFF
--- a/src/MacVim/vimrc
+++ b/src/MacVim/vimrc
@@ -37,12 +37,12 @@ endif
 " or an installation from python.org:
 if exists("&pythonthreedll") && exists("&pythonthreehome") &&
       \ !filereadable(&pythonthreedll)
-  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.7/Python")
-    " MacPorts python 3.7
-    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.7/Python
-  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.7/Python")
+  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.8/Python")
+    " MacPorts python 3.8
+    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.8/Python
+  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.8/Python")
     " https://www.python.org/downloads/mac-osx/
-    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.7/Python
+    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.8/Python
   endif
 endif
 


### PR DESCRIPTION
Part of #1012