### PR TITLE
CI: Add xcode12 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
       vi_cv_dll_name_ruby=/usr/local/opt/ruby/lib/libruby.dylib
       VIMCMD=src/MacVim/build/Release/MacVim.app/Contents/MacOS/Vim
       CONFOPT="--with-features=huge --enable-netbeans --with-tlib=ncurses --enable-cscope --enable-gui=macvim"
+      BASH_SILENCE_DEPRECATION_WARNING=1
 
 _anchors:
   - &lang_env
@@ -84,11 +85,11 @@ script:
 
 jobs:
   include:
+    - osx_image: xcode12
     - osx_image: xcode11.3
       <<: *lang_env
       <<: *homebrew
       <<: *caches
-    - osx_image: xcode10.3
     - osx_image: xcode9.4
     - osx_image: xcode7.3
     - stage: deploy


### PR DESCRIPTION
I think we can drop xcode10.3 (macOS 10.14.4) since OS version is duplicated with xcode11.3 (10.14.6).

On macOS 10.15 when login shell is set not to zsh, the notification message is shown on launching the shell so causes some tests of test_terminal fail (hang up).
Thus must set `BASH_SILENCE_DEPRECATION_WARNING=1` to suppress the message.