### PR TITLE
Add support for localized message transalations in MacVim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,14 @@ env:
 
 _anchors:
   - &lang_env
-    env: LANGOPT="--enable-perlinterp=dynamic --enable-pythoninterp=dynamic --enable-python3interp=dynamic --enable-rubyinterp=dynamic --enable-luainterp=dynamic --with-lua-prefix=/usr/local"
+    env:
+      - LANGOPT="--enable-perlinterp=dynamic --enable-pythoninterp=dynamic --enable-python3interp=dynamic --enable-rubyinterp=dynamic --enable-luainterp=dynamic --with-lua-prefix=/usr/local"
+        HAS_GETTEXT=1
   - &homebrew
     addons:
       homebrew:
         packages:
+          - gettext
           - lua
           - python
           - ruby
@@ -64,6 +67,7 @@ script:
   - set +o errexit
   - ${VIMCMD} --version
   - echo -e "\\033[33;1mTesting MacVim\\033[0m" && echo -en "travis_fold:start:test\\r\\033[0K"
+  # Smoketest scripting languages
   - |
     macvim_excmd() {
       if [[ -n "${LANGOPT}" ]]; then
@@ -75,6 +79,12 @@ script:
   - macvim_excmd -c 'py import sys; print("Test")'
   - macvim_excmd -c 'py3 import sys; print("Test")'
   - macvim_excmd -c 'ruby puts("Test")'
+  # Check that localized messages work by printing ':version' and checking against localized word
+  - |
+    if [[ -n "${HAS_GETTEXT}" ]]; then
+      ${VIMCMD} -es -c 'lang es_ES' -c 'redir @a' -c 'version' -c 'put a' -c 'print' -c 'qa!' | grep Enlazado
+    fi
+  # Run standard test suites
   - make test
   - make -C runtime/doc vimtags VIMEXE=../../src/MacVim/build/Release/MacVim.app/Contents/bin/vim
   - echo -en "travis_fold:end:test\\r\\033[0K"

--- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
+++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
@@ -836,6 +836,7 @@
 				1D9EB2840C366D7B0074B739 /* Copy Frameworks */,
 				52818B021C1C088000F59085 /* Copy QuickLookPlugin */,
 				1DE608B80C58807F0055263D /* Copy Vim Runtime Files */,
+				90BD4EF224E0E8B700BF29F2 /* Copy locale message translation files */,
 				1D1C31F00EFFBFD6003FE9A5 /* Make Document Icons */,
 				528DA6671426D456003380F1 /* Copy Scripts */,
 				52283AB71EBA200C00A6F6B9 /* Copy mvim scripts */,
@@ -981,6 +982,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "BINPATH=$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/bin\nmkdir -p \"${BINPATH}\"\ncp -a \"${SRCROOT}/mvim\" \"${BINPATH}/mvim\"\nchmod 755 \"${BINPATH}/mvim\"\n(cd \"${BINPATH}\"; for f in vim vimdiff view gvim gvimdiff gview mvimdiff mview; do ln -fs mvim $f; done)\n";
+			showEnvVarsInLog = 0;
+		};
+		90BD4EF224E0E8B700BF29F2 /* Copy locale message translation files */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy locale message translation files";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Copy all the locale translation files from the po folder to\n# runtime/lang/<lang>/LC_MESSAGES/vim.mo. Need to do this because unlike normal\n# Vim, MacVim is distributed as a standalone app package and therefore we don't\n# want to install these files to a global location (e.g.\n# /usr/local/share/locale/). This is similar to how Windows installation\n# (po/Make_mvc.mak) works.\ncd \"${SRCROOT}\"/..\nmake macvim-install-languages DEST_LANG=\"${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/vim/runtime/lang\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/src/Makefile
+++ b/src/Makefile
@@ -3745,7 +3745,7 @@ $(APPDIR)/Contents:
 
 ##############################################################################
 ### MacVim GUI
-.PHONY: macvim macvim-dmg macvimclean macvim-signed macvim-dmg-release
+.PHONY: macvim macvim-dmg macvimclean macvim-signed macvim-dmg-release macvim-install-languages
 
 RELEASEDIR = MacVim/build/Release
 DMGDIR = MacVim/build/dmg
@@ -3785,6 +3785,12 @@ macvim-dmg-release: macvim-signed macvim-dmg
 	echo "--------------------"
 	echo "Release MacVim built!"
 
+# Install only language files to a dest folder. Subset of "install-languages".
+macvim-install-languages:
+	@if test -n "$(MAKEMO)" -a -f $(PODIR)/Makefile; then \
+	   cd $(PODIR); $(MAKE) prefix=$(DESTDIR)$(prefix) LOCALEDIR=$(DEST_LANG) \
+	   INSTALL_DATA=$(INSTALL_DATA) FILEMOD=$(FILEMOD) install; \
+	fi
 
 # Dependencies that "make depend" doesn't find
 objects/gui_gtk_x11.o: version.h

--- a/src/vim.h
+++ b/src/vim.h
@@ -551,6 +551,11 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 # define _(x) ((char *)(x))
 # define NGETTEXT(x, xs, n) (((n) == 1) ? (char *)(x) : (char *)(xs))
 # define N_(x) x
+#ifdef FEAT_GUI_MACVIM
+    // In MacVim, we want bindtextdomain to work because we bundle the locale
+    // files in runtime dir instead of a global install loation. This is
+    // similar to Windows (which has DYNAMIC_GETTEXT set).
+#else
 # ifdef bindtextdomain
 #  undef bindtextdomain
 # endif
@@ -563,6 +568,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #  undef textdomain
 # endif
 # define textdomain(x) // empty
+#endif // MacVim
 #endif
 
 /*


### PR DESCRIPTION
This enables localized translated messages in MacVim, instead of only using English.

- Get Travis to compile MacVim with gettext dependencies which is a pre-requisite for multilang localized messages. Also add a quick regression test to make sure localized messages will keep working.
- Add a post-build phase to copy all locale .mo files to `VIMRUNTIME/lang` so they will be bundled along with the rest in the app package. Normal Vim usually installs the localized files to a global location like /usr/local/share/locale/ but macOS applications are all self-contained bundles we don't want to do this. Use `VIMRUNTIME/lang` as the destination because that's also what the Windows build uses and existing code already knows to use it by using `bindtextdomain`.
- Fix vim.h header to not unbind `bindtextdomain` for MacVim. There is previously a little bit of hack there where it would only use `bindtextdomain` when `DYNAMIC_GETTEXT` is set because that's only set for Windows. Just add a special case for MacVim for now to get similar behavior to Windows.

Note: This does not add translations for menus. It only adds translations for Vim messages (e.g. "Press Enter" prompts, dialog box messages, or the intro screen).

Close #991
