### PR TITLE
Add basic localized MacVim messages for some languages

### DIFF
--- a/src/po/es.po
+++ b/src/po/es.po
@@ -5792,6 +5792,10 @@ msgstr "con GUI Carbon."
 msgid "with Cocoa GUI."
 msgstr "con interfaz gráfica para Cocoa."
 
+# MacVim only
+msgid "with MacVim GUI."
+msgstr "con interfaz gráfica para MacVim."
+
 msgid "with (classic) GUI."
 msgstr "con interfaz gráfica (clásica)."
 
@@ -5872,6 +5876,10 @@ msgstr "escriba  «:q<Intro>»            para salir             "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "escriba  «:help<Intro>» o <F1>  para obtener ayuda     "
+
+# MacVim only
+msgid "type  :help macvim<Enter>     for MacVim help "
+msgstr "       escriba  «:help macvim<Enter>»  para obtener ayuda para MacVim"
 
 msgid "type  :help version8<Enter>   for version info"
 msgstr "escriba «:help version8<Intro>» para información de la versión"

--- a/src/po/ja.euc-jp.po
+++ b/src/po/ja.euc-jp.po
@@ -6236,6 +6236,10 @@ msgstr "with Carbon GUI."
 msgid "with Cocoa GUI."
 msgstr "with Cocoa GUI."
 
+# MacVim only
+msgid "with MacVim GUI."
+msgstr "with MacVim GUI."
+
 msgid "  Features included (+) or not (-):\n"
 msgstr "  機能の一覧 有効(+)/無効(-)\n"
 
@@ -6316,6 +6320,10 @@ msgstr "終了するには           :q<Enter>              "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "オンラインヘルプは     :help<Enter> か <F1>   "
+
+# MacVim only
+msgid "type  :help macvim<Enter>     for MacVim help "
+msgstr "MacVim のオンラインヘルプは     :help macvim<Enter>             "
 
 msgid "type  :help version8<Enter>   for version info"
 msgstr "バージョン情報は       :help version8<Enter>  "

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -6236,6 +6236,10 @@ msgstr "with Carbon GUI."
 msgid "with Cocoa GUI."
 msgstr "with Cocoa GUI."
 
+# MacVim only
+msgid "with MacVim GUI."
+msgstr "with MacVim GUI."
+
 msgid "  Features included (+) or not (-):\n"
 msgstr "  機能の一覧 有効(+)/無効(-)\n"
 
@@ -6316,6 +6320,10 @@ msgstr "終了するには           :q<Enter>              "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "オンラインヘルプは     :help<Enter> か <F1>   "
+
+# MacVim only
+msgid "type  :help macvim<Enter>     for MacVim help "
+msgstr "MacVim のオンラインヘルプは     :help macvim<Enter>             "
 
 msgid "type  :help version8<Enter>   for version info"
 msgstr "バージョン情報は       :help version8<Enter>  "

--- a/src/po/ja.sjis.po
+++ b/src/po/ja.sjis.po
@@ -3178,7 +3178,7 @@ msgstr ""
 "gvimによって解釈される引数(GTK+バージョン):\n"
 
 msgid "-display <display>\tRun Vim on <display> (also: --display)"
-msgstr "-display <display>\t<display> でvimを実行する(同義: --display)"
+msgstr "-display <display>\t<display> でVimを実行する(同義: --display)"
 
 msgid "--role <role>\tSet a unique role to identify the main window"
 msgstr "--role <role>\tメインウィンドウを識別する一意な役割(role)を設定する"
@@ -6236,6 +6236,10 @@ msgstr "with Carbon GUI."
 msgid "with Cocoa GUI."
 msgstr "with Cocoa GUI."
 
+# MacVim only
+msgid "with MacVim GUI."
+msgstr "with MacVim GUI."
+
 msgid "  Features included (+) or not (-):\n"
 msgstr "  機能\の一覧 有効(+)/無効(-)\n"
 
@@ -6316,6 +6320,10 @@ msgstr "終了するには           :q<Enter>              "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "オンラインヘルプは     :help<Enter> か <F1>   "
+
+# MacVim only
+msgid "type  :help macvim<Enter>     for MacVim help "
+msgstr "MacVim のオンラインヘルプは     :help macvim<Enter>             "
 
 msgid "type  :help version8<Enter>   for version info"
 msgstr "バージョン情報は       :help version8<Enter>  "

--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -5468,6 +5468,10 @@ msgstr "带 Carbon 图形界面。"
 msgid "with Cocoa GUI."
 msgstr "带 Cocoa 图形界面。"
 
+# MacVim only
+msgid "with MacVim GUI."
+msgstr "带 MacVim 图形界面。"
+
 msgid "with (classic) GUI."
 msgstr "带(传统)图形界面。"
 
@@ -5548,6 +5552,10 @@ msgstr "输入  :q<Enter>               退出            "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "输入  :help<Enter>  或  <F1>  查看在线帮助    "
+
+# MacVim only
+msgid "type  :help macvim<Enter>     for MacVim help "
+msgstr "     输入  :help macvim<Enter>     查看 MacVim 的在线帮助"
 
 msgid "type  :help version8<Enter>   for version info"
 msgstr "输入  :help version8<Enter>   查看版本信息    "

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -5468,6 +5468,10 @@ msgstr "带 Carbon 图形界面。"
 msgid "with Cocoa GUI."
 msgstr "带 Cocoa 图形界面。"
 
+# MacVim only
+msgid "with MacVim GUI."
+msgstr "带 MacVim 图形界面。"
+
 msgid "with (classic) GUI."
 msgstr "带(传统)图形界面。"
 
@@ -5548,6 +5552,10 @@ msgstr "输入  :q<Enter>               退出            "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "输入  :help<Enter>  或  <F1>  查看在线帮助    "
+
+# MacVim only
+msgid "type  :help macvim<Enter>     for MacVim help "
+msgstr "     输入  :help macvim<Enter>     查看 MacVim 的在线帮助"
 
 msgid "type  :help version8<Enter>   for version info"
 msgstr "输入  :help version8<Enter>   查看版本信息    "

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -5468,6 +5468,10 @@ msgstr "带 Carbon 图形界面。"
 msgid "with Cocoa GUI."
 msgstr "带 Cocoa 图形界面。"
 
+# MacVim only
+msgid "with MacVim GUI."
+msgstr "带 MacVim 图形界面。"
+
 msgid "with (classic) GUI."
 msgstr "带(传统)图形界面。"
 
@@ -5548,6 +5552,10 @@ msgstr "输入  :q<Enter>               退出            "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "输入  :help<Enter>  或  <F1>  查看在线帮助    "
+
+# MacVim only
+msgid "type  :help macvim<Enter>     for MacVim help "
+msgstr "     输入  :help macvim<Enter>     查看 MacVim 的在线帮助"
 
 msgid "type  :help version8<Enter>   for version info"
 msgstr "输入  :help version8<Enter>   查看版本信息    "

--- a/src/po/zh_TW.UTF-8.po
+++ b/src/po/zh_TW.UTF-8.po
@@ -4642,6 +4642,10 @@ msgstr "使用 Carbon 圖型界面。"
 msgid "with Cocoa GUI."
 msgstr "使用 Cocoa 圖型界面。"
 
+# MacVim only
+msgid "with MacVim GUI."
+msgstr "使用 MacVim 圖型界面。"
+
 msgid "with (classic) GUI."
 msgstr "使用 (傳統) 圖型界面。"
 
@@ -4722,6 +4726,10 @@ msgstr "要離開請輸入                  :q<Enter>            "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "線上說明請輸入                :help<Enter>         "
+
+# MacVim only
+msgid "type  :help macvim<Enter>     for MacVim help "
+msgstr "MacVim 線上說明請輸入                :help<Enter>               "
 
 msgid "type  :help version8<Enter>   for version info"
 msgstr "新版本資訊請輸入              :help version8<Enter>"

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -4635,6 +4635,10 @@ msgstr "使用 Carbon 圖型界面。"
 msgid "with Cocoa GUI."
 msgstr "使用 Cocoa 圖型界面。"
 
+# MacVim only
+msgid "with MacVim GUI."
+msgstr "使用 MacVim 圖型界面。"
+
 msgid "with (classic) GUI."
 msgstr "使用 (傳統) 圖型界面。"
 
@@ -4715,6 +4719,10 @@ msgstr "要離開請輸入                  :q<Enter>            "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "線上說明請輸入                :help<Enter>         "
+
+# MacVim only
+msgid "type  :help macvim<Enter>     for MacVim help "
+msgstr "MacVim 線上說明請輸入                :help<Enter>               "
 
 msgid "type  :help version8<Enter>   for version info"
 msgstr "新版本資訊請輸入              :help version8<Enter>"


### PR DESCRIPTION
Since #1070 added support for localized messages for MacVim, add some
translations for some MacVim-specific messages (only add intro text
and :version output for now) for some languages (es, ja, zh) to make the
intro screen look less like an odd mix.