### PR TITLE
Fix gettext dynamic linkage breaking binary builds due to missing dylib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,12 +61,13 @@ script:
       grep -q -- "-DDYNAMIC_RUBY_DLL=\\\\\"${vi_cv_dll_name_ruby}\\\\\"" src/auto/config.mk
     fi
   - echo -en "travis_fold:end:configure\\r\\033[0K"
+
   - echo -e "\\033[33;1mBuilding MacVim\\033[0m" && echo -en "travis_fold:start:build\\r\\033[0K"
   - make -j${NPROC}
   - echo -en "travis_fold:end:build\\r\\033[0K"
-  - set +o errexit
   - ${VIMCMD} --version
-  - echo -e "\\033[33;1mTesting MacVim\\033[0m" && echo -en "travis_fold:start:test\\r\\033[0K"
+
+  - echo -e "\\033[33;1mSmoketest\\033[0m" && echo -en "travis_fold:start:smoketest\\r\\033[0K"
   # Smoketest scripting languages
   - |
     macvim_excmd() {
@@ -84,7 +85,20 @@ script:
     if [[ -n "${HAS_GETTEXT}" ]]; then
       ${VIMCMD} -es -c 'lang es_ES' -c 'redir @a' -c 'version' -c 'put a' -c 'print' -c 'qa!' | grep Enlazado
     fi
-  # Run standard test suites
+  # Make sure there isn't any dynamic linkage to third-party dependencies in the built binary, as we should only use
+  # static linkage to avoid dependency hell. First, sanity check that we have some dylib linkage to make sure objdump is
+  # working properly, then test that all those dylib's are in /usr/lib which is bundled with macOS and not third-party.
+  - |
+    if (which objdump > /dev/null); then
+      objdump -p ${VIMCMD} | grep -q dylib &&
+      ! (objdump -p ${VIMCMD} | grep dylib | grep -v "name /usr/lib/")
+    fi
+  - echo -en "travis_fold:end:smoketest\\r\\033[0K"
+
+  # Run standard test suites.
+  # Disable errexit so flaky tests won't immediately exit to allow us to see all the errors.
+  - set +o errexit
+  - echo -e "\\033[33;1mTesting MacVim\\033[0m" && echo -en "travis_fold:start:test\\r\\033[0K"
   - make test
   - make -C runtime/doc vimtags VIMEXE=../../src/MacVim/build/Release/MacVim.app/Contents/bin/vim
   - echo -en "travis_fold:end:test\\r\\033[0K"

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -14705,6 +14705,23 @@ $as_echo "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
+
+      # MacVim: Hack to statically link against libintl instead of dynamic link, as we can't distribute app bundles with
+      # external linkage dependencies. Clang doesn't support any way to specify static linkage as it prefers dynamic
+      # linkage if a dylib exists in the same folder, and as such we have to manually specify the library path instead
+      # of using -l<lib> syntax. This also means it won't work with AC_TRY_LINK as specifying full lib path only works
+      # if you have separate compile/link stages but AC_TRY_LINK just compiles/link in one command.
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libintl.a" >&5
+$as_echo_n "checking for libintl.a... " >&6; }
+      if test -f ${local_dir}/lib/libintl.a; then
+        LIBS="$olibs ${local_dir}/lib/libintl.a"
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: Using ${local_dir}/lib/libintl.a instead of -lintl" >&5
+$as_echo "Using ${local_dir}/lib/libintl.a instead of -lintl" >&6; };
+      else
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: libintl.a not found - keeping using -lintl" >&5
+$as_echo "libintl.a not found - keeping using -lintl" >&6; };
+      fi
+
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking if msgfmt supports --desktop" >&5
 $as_echo_n "checking if msgfmt supports --desktop... " >&6; }
       MSGFMT_DESKTOP=

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4425,6 +4425,20 @@ if test "$enable_nls" = "yes"; then
 		[++_nl_msg_cat_cntr;],
 		AC_MSG_RESULT([yes]); AC_DEFINE(HAVE_NL_MSG_CAT_CNTR),
 		AC_MSG_RESULT([no]))
+
+      # MacVim: Hack to statically link against libintl instead of dynamic link, as we can't distribute app bundles with
+      # external linkage dependencies. Clang doesn't support any way to specify static linkage as it prefers dynamic
+      # linkage if a dylib exists in the same folder, and as such we have to manually specify the library path instead
+      # of using -l<lib> syntax. This also means it won't work with AC_TRY_LINK as specifying full lib path only works
+      # if you have separate compile/link stages but AC_TRY_LINK just compiles/link in one command.
+      AC_MSG_CHECKING([for libintl.a])
+      if test -f ${local_dir}/lib/libintl.a; then
+        LIBS="$olibs ${local_dir}/lib/libintl.a"
+        AC_MSG_RESULT([Using ${local_dir}/lib/libintl.a instead of -lintl]);
+      else
+        AC_MSG_RESULT([libintl.a not found - keeping using -lintl]);
+      fi
+
       AC_MSG_CHECKING([if msgfmt supports --desktop])
       MSGFMT_DESKTOP=
       if "$MSGFMT" --help | grep -e '--desktop' >/dev/null; then


### PR DESCRIPTION
Currently, all the external libraries MacVim links against are dynamically linked, but so far they are all system libraries or bundled in /usr/lib, so all users have them installed. When gettext dependency was added to the Travis build to add localization support, it relied on an installed libintl.dylib library, usually in /usr/local/lib. This means users who don't have it installed and open the distributed binary will see MacVim immediately crash due to a missing dylib.

Instead, statically link against libintl.a instead. This is tricky because clang stubbornly prefers dynamic libs over static ones if both exist and you use the "-l" argument. Instead, you have to pass full path to the static lib for it to link against it. Modify configure.ac to do so, but because of the full path requirement, it's hard to get AC_TRY_LINK to work with it, so just manually check for the library's existence and use that. Hacky but works.

Also, add a check to Travis CI build to make sure we didn't accidentally introduce third-party dynacmic linkage to the build.
- Add a new test to use objdump to dump out the dependencies, and check that we don't have any external third-party linkage (basically any dynamic links other than the pre-installed /usr/lib). Have to also check for existence of objdump because xcode 7 / macOS 10.11 doesn't have it installed.
- Split the beginning sanity checks to a separate fold group called "smoketest". Also, don't unset errexit until that part is done, so that we will immediately fail out of the job if the smoketest fails.  Unsetting errexit is only useful in the later regular tests that could be a little flaky.

Fix #1073