### PR TITLE
Touch Bar add submenu/title/emoji picker support

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -514,10 +514,17 @@ icon can be found a warning triangle is displayed instead.
 ==============================================================================
 8. Touch Bar						*macvim-touchbar*
 
-Touch Bar in MacVim works similar to the toolbar (see |macvim-toolbar|).  The
-difference is that you use the special menu "TouchBar" instead of "ToolBar": >
+Touch Bar in MacVim is configurable, and works similar to the toolbar (see
+|macvim-toolbar|).  The difference is that you use the special menu "TouchBar"
+instead of "ToolBar": >
 	:an TouchBar.Hello          :echo "Hello"<CR>
-
+<
+You can also create submenus. Due to macOS restrictions, submenus can only be
+one level deep: >
+	:an TouchBar.Navigate.Next  :next<CR>
+	:an TouchBar.Navigate.Prev  :prev<CR>
+<
+						*macvim-touchbar-separator*
 The separators work similar to how toolbars work: >
 	:an TouchBar.-Sep-          <Nop>
 	:an TouchBar.-space1-       <Nop>
@@ -530,24 +537,45 @@ separator and are specified by names that begin with "-space" and ends with
 that items after it will be right-aligned, and is specified by names that
 begin with "-flexspace" and ends with "-".
 
+						*macvim-touchbar-icon*
 You can specify icons for Touch Bar buttons the same way for toolbar icons.
 Touch Bar icons should ideally be 36x36 pixels, and no larger than 44x44
 pixels. You can also use default template icons provided by Apple by using
 their template names. An example: >
-	:an icon=NSTouchBarListViewTemplate TouchBar.ShowList <Nop>
+	:an icon=NSTouchBarListViewTemplate TouchBar.ShowList :ls<CR>
+<
+						*macvim-touchbar-title*
+By default, the TouchBar buttons will use the menu names as the title. If an
+icon is specified, the title will not be shown. You can override this by using
+|tmenu| to set a tooltip. The tooltip will be displayed as the title of the
+button. If an icon is specified, the tooltip override will be shown alongside
+the icion. Example: >
+	:an icon=NSTouchBarAddTemplate TouchBar.AddItem <Nop>
+	:tmenu TouchBar.AddItem Add an Item
+<
+			*macvim-touchbar-characterpicker* *macvim-touchbar-emoji*
+You can also insert emojis by adding a character picker button (specified by
+using a name that begin wtih "-characterpicker" and ends with "-"): >
+	:inoremenu TouchBar.-characterpicker-	<Nop>
 
 This feature only works on Mac devices that come with Touch Bars. On the ones
 that don't, nothing will show up.
 
-						    *macvim-touchbar-defaults*
+						*macvim-touchbar-defaults*
 Here is a list of default Touch Bar buttons that MacVim sets up:
 
-					*macvim-touchbar-fullscreen*
+						*macvim-touchbar-fullscreen*
 					*g:macvim_default_touchbar_fullscreen*
 EnterFullScreen		Touch Bar buttons that allow you to toggle
-ExitFullScreen		|'fullscreen'| mode. To disable the button, add the
-			following to your vimrc file: >
+ExitFullScreen		|'fullscreen'| mode. To disable, add the following to
+			your vimrc file: >
 			  let g:macvim_default_touchbar_fullscreen=0
+<
+				*g:macvim_default_touchbar_characterpicker*
+-characterpicker-	Character picker that lets you add special characters
+			and emojis in insert and terminal modes. To disable,
+			add the following to your vimrc file: >
+			  let g:macvim_default_touchbar_characterpicker=0
 
 ==============================================================================
 9. Dialogs						*macvim-dialogs*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -6801,6 +6801,7 @@ g:html_use_encoding	syntax.txt	/*g:html_use_encoding*
 g:html_use_input_for_pc	syntax.txt	/*g:html_use_input_for_pc*
 g:html_use_xhtml	syntax.txt	/*g:html_use_xhtml*
 g:html_whole_filler	syntax.txt	/*g:html_whole_filler*
+g:macvim_default_touchbar_characterpicker	gui_mac.txt	/*g:macvim_default_touchbar_characterpicker*
 g:macvim_default_touchbar_fullscreen	gui_mac.txt	/*g:macvim_default_touchbar_fullscreen*
 g:netrw_altfile	pi_netrw.txt	/*g:netrw_altfile*
 g:netrw_alto	pi_netrw.txt	/*g:netrw_alto*
@@ -7803,8 +7804,13 @@ macvim-tablabel	gui_mac.txt	/*macvim-tablabel*
 macvim-todo	gui_mac.txt	/*macvim-todo*
 macvim-toolbar	gui_mac.txt	/*macvim-toolbar*
 macvim-touchbar	gui_mac.txt	/*macvim-touchbar*
+macvim-touchbar-characterpicker	gui_mac.txt	/*macvim-touchbar-characterpicker*
 macvim-touchbar-defaults	gui_mac.txt	/*macvim-touchbar-defaults*
+macvim-touchbar-emoji	gui_mac.txt	/*macvim-touchbar-emoji*
 macvim-touchbar-fullscreen	gui_mac.txt	/*macvim-touchbar-fullscreen*
+macvim-touchbar-icon	gui_mac.txt	/*macvim-touchbar-icon*
+macvim-touchbar-separator	gui_mac.txt	/*macvim-touchbar-separator*
+macvim-touchbar-title	gui_mac.txt	/*macvim-touchbar-title*
 macvim-url-handler	gui_mac.txt	/*macvim-url-handler*
 macvim-user-defaults	gui_mac.txt	/*macvim-user-defaults*
 macvim-window-title	gui_mac.txt	/*macvim-window-title*
@@ -8618,6 +8624,7 @@ progname-variable	eval.txt	/*progname-variable*
 progpath-variable	eval.txt	/*progpath-variable*
 progress.vim	syntax.txt	/*progress.vim*
 prompt-buffer	channel.txt	/*prompt-buffer*
+prompt_getprompt()	eval.txt	/*prompt_getprompt()*
 prompt_setcallback()	eval.txt	/*prompt_setcallback()*
 prompt_setinterrupt()	eval.txt	/*prompt_setinterrupt()*
 prompt_setprompt()	eval.txt	/*prompt_setprompt()*

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -1332,8 +1332,8 @@ if has("touchbar")
   " 1. Smart fullscreen icon that toggles between going full screen or not.
 
   if !exists("g:macvim_default_touchbar_fullscreen") || g:macvim_default_touchbar_fullscreen
-    an icon=NSTouchBarEnterFullScreenTemplate 1.10 TouchBar.EnterFullScreen :set fullscreen<CR>
-    tln icon=NSTouchBarEnterFullScreenTemplate 1.10 TouchBar.EnterFullScreen <C-W>:set fullscreen<CR>
+    an icon=NSTouchBarEnterFullScreenTemplate 1.20 TouchBar.EnterFullScreen :set fullscreen<CR>
+    tln icon=NSTouchBarEnterFullScreenTemplate 1.20 TouchBar.EnterFullScreen <C-W>:set fullscreen<CR>
   endif
 
   let s:touchbar_fullscreen=0
@@ -1342,16 +1342,16 @@ if has("touchbar")
       silent! aun TouchBar.EnterFullScreen
       silent! tlun TouchBar.EnterFullScreen
       if !exists("g:macvim_default_touchbar_fullscreen") || g:macvim_default_touchbar_fullscreen
-        an icon=NSTouchBarExitFullScreenTemplate 1.10 TouchBar.ExitFullScreen :set nofullscreen<CR>
-        tln icon=NSTouchBarExitFullScreenTemplate 1.10 TouchBar.ExitFullScreen <C-W>:set nofullscreen<CR>
+        an icon=NSTouchBarExitFullScreenTemplate 1.20 TouchBar.ExitFullScreen :set nofullscreen<CR>
+        tln icon=NSTouchBarExitFullScreenTemplate 1.20 TouchBar.ExitFullScreen <C-W>:set nofullscreen<CR>
       endif
       let s:touchbar_fullscreen = 1
     elseif !&fullscreen && s:touchbar_fullscreen != 0
       silent! aun TouchBar.ExitFullScreen
       silent! tlun TouchBar.ExitFullScreen
       if !exists("g:macvim_default_touchbar_fullscreen") || g:macvim_default_touchbar_fullscreen
-        an icon=NSTouchBarEnterFullScreenTemplate 1.10 TouchBar.EnterFullScreen :set fullscreen<CR>
-        tln icon=NSTouchBarEnterFullScreenTemplate 1.10 TouchBar.EnterFullScreen <C-W>:set fullscreen<CR>
+        an icon=NSTouchBarEnterFullScreenTemplate 1.20 TouchBar.EnterFullScreen :set fullscreen<CR>
+        tln icon=NSTouchBarEnterFullScreenTemplate 1.20 TouchBar.EnterFullScreen <C-W>:set fullscreen<CR>
       endif
       let s:touchbar_fullscreen = 0
     endif
@@ -1360,6 +1360,14 @@ if has("touchbar")
     au!
     au VimEnter,VimResized * call <SID>SetupFullScreenTouchBar()
   aug END
+
+  " 2. Character (i.e. emojis) picker. Only in modes where user is actively
+  " entering text.
+  if !exists("g:macvim_default_touchbar_characterpicker") || g:macvim_default_touchbar_characterpicker
+    inoremenu 1.40 TouchBar.-characterpicker- <Nop>
+    cnoremenu 1.40 TouchBar.-characterpicker- <Nop>
+    tlnoremenu 1.40 TouchBar.-characterpicker- <Nop>
+  endif
 endif
 
 " vim: set sw=2 :

--- a/src/MacVim/MMVimController.h
+++ b/src/MacVim/MMVimController.h
@@ -12,6 +12,7 @@
 
 
 @class MMWindowController;
+@class MMTouchBarInfo;
 
 
 
@@ -34,10 +35,7 @@
     NSToolbar           *toolbar;
     NSMutableDictionary *toolbarItemDict;
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
-    NSTouchBar          *touchbar;
-    NSMutableDictionary *touchbarItemDict;
-    NSMutableArray      *touchbarItemOrder;
-    NSMutableSet        *touchbarDisabledItems;
+    MMTouchBarInfo      *touchbarInfo;
 #endif
 
     int                 pid;

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1083,7 +1083,7 @@
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
 - (IBAction)vimTouchbarItemAction:(id)sender
 {
-    NSArray *desc = [NSArray arrayWithObjects:@"TouchBar", [sender title], nil];
+    NSArray *desc = [sender desc];
     NSDictionary *attrs = [NSDictionary dictionaryWithObject:desc
                                                       forKey:@"descriptor"];
     [vimController sendMessage:ExecuteMenuMsgID data:[attrs dictionaryAsData]];

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -788,7 +788,15 @@ gui_mch_add_menu_item(vimmenu_T *menu, int idx)
     int modifierMask = vimModMaskToEventModifierFlags(menu->mac_mods);
     char_u *icon = NULL;
 
-    if (menu_is_toolbar(menu->parent->name)) {
+    vimmenu_T *rootMenu = menu;
+    while (rootMenu->parent) {
+        rootMenu = rootMenu->parent;
+    }
+    if (menu_is_toolbar(rootMenu->name)) {
+        //
+        // Find out what file to load for the icon. This is only relevant for the
+        // toolbar and TouchBar.
+        //
         char_u fname[MAXPATHL];
 
         // Try to use the icon=.. argument


### PR DESCRIPTION
Touch Bar add submenu/title/emoji picker support

Can now specify submenus. E.g. TouchBar.Debugger.Run. When trying to create a submenu it will first create a popover item and then only create the NSButton at the leaf.

- Unfortunatley macOS currently can't do multiple levels of submenus (the API will allow it, but it doesn't really work), presumably for usability concerns. Limit it to only one level of nesting for now.

Add ability to set a title on a Touch Bar button, using `tmenu`. This allows us to override the displayed button name, and when an icon is specified the override name will still be shown alongside the icon.

Add emoji picker support, and add it to the list of default Touch Bar menus. Only enable it in modes where the user is typing (insert, command, terminal, etc).

Fixed up the internal implementation of Touch Bar management so it's easier to add metadata to it now.

Also, add documentation.

TODO:

- Using `tmenu` after `amenu` doesn't really work (unless it's specified in vimrc and loaded on initialization). This is because MacVim hasn't implemented `gui_mch_menu_set_tip`. Should fix it by adding support for it. For now, the user can just call `tmenu` before `amenu`.
- Disabling menus currently just hides the menu. Since the user can already do `aunmenu` to hide, should change the disable behavior to show the button but disabled instead, similar to how toolbars and normal menus work.

