### PR TITLE
Fix tmenu in MacVim and submenu handling in TouchBar

### DIFF
--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -203,6 +203,7 @@ extern const char * const MMVimMsgIDStrings[];
     MSG(RemoveMenuItemMsgID) \
     MSG(EnableMenuItemMsgID) \
     MSG(ExecuteMenuMsgID) \
+    MSG(UpdateMenuItemTooltipMsgID) \
     MSG(ShowToolbarMsgID) \
     MSG(ToggleToolbarMsgID) \
     MSG(CreateScrollbarMsgID) \

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -895,6 +895,22 @@ gui_mch_show_popupmenu(vimmenu_T *menu)
 
 
 /*
+ * Update a menu's tooltip.
+ */
+    void
+gui_mch_menu_set_tip(vimmenu_T *menu)
+{
+    char_u *tip = menu->strings[MENU_INDEX_TIP];
+    NSArray *desc = descriptor_for_menu(menu);
+    [[MMBackend sharedInstance] queueMessage:UpdateMenuItemTooltipMsgID properties:
+        [NSDictionary dictionaryWithObjectsAndKeys:
+            desc, @"descriptor",
+            [NSString stringWithVimString:tip], @"tip",
+            nil]];
+}
+
+
+/*
  * This is called when a :popup command is executed.
  */
     void

--- a/src/menu.c
+++ b/src/menu.c
@@ -814,8 +814,7 @@ add_menu_path(
 	    }
 	}
 #if defined(FEAT_TOOLBAR) && !defined(FEAT_GUI_MSWIN) \
-	&& !defined(FEAT_GUI_MACVIM) \
-	&& (defined(FEAT_BEVAL_GUI) || defined(FEAT_GUI_GTK))
+	&& (defined(FEAT_BEVAL_GUI) || defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MACVIM))
 	// Need to update the menu tip.
 	if (modes & MENU_TIP_MODE)
 	    gui_mch_menu_set_tip(menu);
@@ -1010,8 +1009,7 @@ remove_menu(
 	{
 	    free_menu_string(menu, MENU_INDEX_TIP);
 #if defined(FEAT_TOOLBAR) && !defined(FEAT_GUI_MSWIN) \
-	    && !defined(FEAT_GUI_MACVIM) \
-	    && (defined(FEAT_BEVAL_GUI) || defined(FEAT_GUI_GTK))
+	    && (defined(FEAT_BEVAL_GUI) || defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MACVIM))
 	    // Need to update the menu tip.
 	    if (gui.in_use)
 		gui_mch_menu_set_tip(menu);


### PR DESCRIPTION
Fix `tmenu` to work when it's called after the menu has already been created, by implementing `gui_mch_menu_set_tip`. This works for menus, tool bar, and Touch Bar (see #1084 which added tmenu support for TouchBar).

Also, fix Touch Bar's submenu handling to reuse more common shared function. Previously enabling/disabling/removing Touch Bar submenu items didn't work as it had a hard-coded length check.