### PR TITLE
Fix switching to fullscreen loses keyboard focus if titlebar is hidden

### DIFF
--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1419,6 +1419,11 @@
         // full-screen using :fullscreen option (including Ctrl-Cmd-f).
         [vimController sendMessage:BackingPropertiesChangedMsgID data:nil];
     }
+
+    // Sometimes full screen will de-focus the text view. This seems to happen
+    // when titlebar is configured as hidden. Simply re-assert it to make sure
+    // text is still focused.
+    [decoratedWindow makeFirstResponder:[vimView textView]];
 }
 
 - (void)windowDidFailToEnterFullScreen:(NSWindow *)window
@@ -1436,6 +1441,11 @@
     [[vimView tabBarControl] setStyleNamed:tabBarStyle];
     [self updateTablineSeparator];
     [window setFrame:preFullScreenFrame display:YES];
+
+    // Sometimes full screen will de-focus the text view. This seems to happen
+    // when titlebar is configured as hidden. Simply re-assert it to make sure
+    // text is still focused.
+    [decoratedWindow makeFirstResponder:[vimView textView]];
 }
 
 - (NSArray *)customWindowsToExitFullScreenForWindow:(NSWindow *)window
@@ -1500,6 +1510,11 @@
     }
 
     [self updateTablineSeparator];
+
+    // Sometimes full screen will de-focus the text view. This seems to happen
+    // when titlebar is configured as hidden. Simply re-assert it to make sure
+    // text is still focused.
+    [decoratedWindow makeFirstResponder:[vimView textView]];
 }
 
 - (void)windowDidFailToExitFullScreen:(NSWindow *)window
@@ -1515,6 +1530,11 @@
     [[vimView tabBarControl] setStyleNamed:tabBarStyle];
     [self updateTablineSeparator];
     [self maximizeWindow:fullScreenOptions];
+
+    // Sometimes full screen will de-focus the text view. This seems to happen
+    // when titlebar is configured as hidden. Simply re-assert it to make sure
+    // text is still focused.
+    [decoratedWindow makeFirstResponder:[vimView textView]];
 }
 
 #endif // (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)


### PR DESCRIPTION
For some reason, when the titlebar is hidden, if we use `set fullscreen` in native full screen mode, the focus will be lost and the user needs to manually click on the screen to be able to type in MacVim. Current theory is that because fullscreen window always has a title bar, sometime that resulted in the window being defocused when the OS is fixing it up.

For an easy fix, simply assert the focus by using `makeFirstResponder` on the text view. This may not work well if the program is more complicated but for MacVim the text view should always be where the focus goes.

Fix #1078