### PR TITLE
Fix duplicate menu items in Window menu

### DIFF
--- a/src/MacVim/MMAppController.h
+++ b/src/MacVim/MMAppController.h
@@ -22,7 +22,11 @@
     NSMutableArray      *vimControllers;
     NSString            *openSelectionString;
     NSMutableDictionary *pidArguments;
+
     NSMenu              *defaultMainMenu;
+    NSMenu              *currentMainMenu;
+    BOOL                mainMenuDirty;
+
     NSMenuItem          *appMenuItemTemplate;
     NSMenuItem          *recentFilesMenuItem;
     NSMutableArray      *cachedVimControllers;
@@ -44,6 +48,8 @@
 - (void)removeVimController:(id)controller;
 - (void)windowControllerWillOpen:(MMWindowController *)windowController;
 - (void)setMainMenu:(NSMenu *)mainMenu;
+- (void)markMainMenuDirty:(NSMenu *)mainMenu;
+- (void)refreshMainMenu;
 - (NSArray *)filterOpenFiles:(NSArray *)filenames;
 - (BOOL)openFiles:(NSArray *)filenames withArguments:(NSDictionary *)args;
 

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -1251,7 +1251,8 @@ static BOOL isUnsafeMessage(int msgid);
     [item setSubmenu:menu];
 
     NSMenu *parent = [self parentMenuForDescriptor:desc];
-    if (!parent && [MMVimController hasPopupPrefix:rootName]) {
+    const BOOL isPopup = [MMVimController hasPopupPrefix:rootName];
+    if (!parent && isPopup) {
         if ([popupMenuItems count] <= idx) {
             [popupMenuItems addObject:item];
         } else {
@@ -1271,6 +1272,8 @@ static BOOL isUnsafeMessage(int msgid);
 
     [item release];
     [menu release];
+    if (!isPopup)
+        [[MMAppController sharedInstance] markMainMenuDirty:mainMenu];
 }
 
 - (void)addMenuItemWithDescriptor:(NSArray *)desc
@@ -1350,6 +1353,9 @@ static BOOL isUnsafeMessage(int msgid);
     } else {
         [parent insertItem:item atIndex:idx];
     }
+    const BOOL isPopup = [MMVimController hasPopupPrefix:rootName];
+    if (!isPopup)
+        [[MMAppController sharedInstance] markMainMenuDirty:mainMenu];
 }
 
 - (void)removeMenuItemWithDescriptor:(NSArray *)desc
@@ -1405,6 +1411,10 @@ static BOOL isUnsafeMessage(int msgid);
         [[item menu] removeItem:item];
 
     [item release];
+
+    const BOOL isPopup = [MMVimController hasPopupPrefix:rootName];
+    if (!isPopup)
+        [[MMAppController sharedInstance] markMainMenuDirty:mainMenu];
 }
 
 - (void)enableMenuItemWithDescriptor:(NSArray *)desc state:(BOOL)on
@@ -1439,6 +1449,10 @@ static BOOL isUnsafeMessage(int msgid);
     // but at the same time Vim can set if a menu is enabled whenever it
     // wants to.
     [[self menuItemForDescriptor:desc] setTag:on];
+
+    const BOOL isPopup = [MMVimController hasPopupPrefix:rootName];
+    if (!isPopup)
+        [[MMAppController sharedInstance] markMainMenuDirty:mainMenu];
 }
     
 - (void)updateMenuItemTooltipWithDescriptor:(NSArray *)desc
@@ -1471,6 +1485,10 @@ static BOOL isUnsafeMessage(int msgid);
     }
 
     [[self menuItemForDescriptor:desc] setToolTip:tip];
+
+    const BOOL isPopup = [MMVimController hasPopupPrefix:rootName];
+    if (!isPopup)
+        [[MMAppController sharedInstance] markMainMenuDirty:mainMenu];
 }
 
 - (void)addToolbarItemToDictionaryWithLabel:(NSString *)title


### PR DESCRIPTION
Previously MacVim would see a lot of duplicate window menu items like "Enter Full Screen" or "Tile Window to Left of Screen" when the user toggles between two windows. This is because the `setWindowsMenu:` call was injecting these items, but AppKit isn't smart enough to de-duplicate them (unlike the window list at the bottom). Just fix this by making a copy of the main menu before passing it in. This way every time we try to set a main menu (which happens whenever we jump among Vim windows as each Vim can have different menu items), it will be set with a fresh copy of main menu that doesn't have the injected menu items in it.

- This also requires adding a refresh functionality because adding/removing items to the original menu no longer get automatically reflected to the app since it only knows about the copied version.

Also, set NSFullScreenMenuItemEverywhere to prevent AppKit from injecting "Enter Full Screen" items. MacVim already has similar menu items to handle that.

Also, remove old private API call to `setAppleMenu:`. As far as I could tell this is not useful anymore in recent macOS versions and that line of code was written in 2008.

Fix #566, Fix #992
