### PR TITLE
Fix macvim-askpass to send event to MacVim itself instead of Finder

### DIFF
--- a/src/MacVim/macvim-askpass
+++ b/src/MacVim/macvim-askpass
@@ -3,9 +3,10 @@
 #
 # An SSH_ASKPASS command for MacOS X
 #
-# Author: Joseph Mocker, Sun Microsystems
+# Original script from:
+#   http://blog.retep.org/2009/04/09/ssh-askpass-on-osx-10-5/
+#   Author: Joseph Mocker, Sun Microsystems
 #
-# http://blog.retep.org/2009/04/09/ssh-askpass-on-osx-10-5/
 
 #
 # To use this script:
@@ -18,8 +19,7 @@ TITLE=${MACOS_ASKPASS_TITLE:-"SSH"}
 DIALOG="display dialog \"$@\" default answer \"\" with title \"$TITLE\""
 DIALOG="$DIALOG with icon caution with hidden answer"
 
-result=`osascript -e 'tell application "Finder"' -e "activate"  -e "$DIALOG" -e "text returned of result" -e 'end tell'`
-osascript -e 'tell application "MacVim"' -e "activate" -e 'end tell'
+result=`osascript -e 'tell application "MacVim"' -e "activate"  -e "$DIALOG" -e "text returned of result" -e 'end tell'`
 
 if [ "$result" = "" ]; then
     exit 1


### PR DESCRIPTION
This fixes the focus issues with it and also makes the permission dialog
box a little less sketchy (previously it would appear MacVim is trying
to control Finder).

See #1091 for code contribution.

Close #1091.