### PR TITLE
Help menu search will now search Vim documentation

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -463,8 +463,7 @@ is not used.
 Hint: The |:macaction| command supports command-line completion so you can
 enter ":maca<Space><C-d>" to see a list of all available actions.
 
-Here is a random assortment of actions from Actions.plist which might be
-useful.  
+Here are some of the actions from Actions.plist which might be useful.  
 
 Action				Description ~
 fileOpen:			Show "File Open" dialog

--- a/src/MacVim/MMAppController.h
+++ b/src/MacVim/MMAppController.h
@@ -17,7 +17,7 @@
 @class SUUpdater;
 
 
-@interface MMAppController : NSObject <MMAppProtocol> {
+@interface MMAppController : NSObject <MMAppProtocol, NSUserInterfaceItemSearching> {
     NSConnection        *connection;
     NSMutableArray      *vimControllers;
     NSString            *openSelectionString;
@@ -62,11 +62,18 @@
 - (IBAction)selectPreviousWindow:(id)sender;
 - (IBAction)orderFrontPreferencePanel:(id)sender;
 - (IBAction)openWebsite:(id)sender;
+- (IBAction)showVimHelp:(id)sender withCmd:(NSString *)cmd;
 - (IBAction)showVimHelp:(id)sender;
 - (IBAction)checkForUpdates:(id)sender;
 - (IBAction)zoomAll:(id)sender;
 - (IBAction)stayInFront:(id)sender;
 - (IBAction)stayInBack:(id)sender;
 - (IBAction)stayLevelNormal:(id)sender;
+
+- (NSArray<NSString *> *)localizedTitlesForItem:(id)item;
+- (void)searchForItemsWithSearchString:(NSString *)searchString
+                           resultLimit:(NSInteger)resultLimit
+                    matchedItemHandler:(void (^)(NSArray *items))handleMatchedItems;
+- (void)performActionForItem:(id)item;
 
 @end

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -126,6 +126,7 @@ enum {
 - (NSMenu *)findApplicationMenu;
 - (NSMenu *)findServicesMenu;
 - (NSMenu *)findFileMenu;
+- (NSMenu *)findHelpMenu;
 @end
 
 

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -178,6 +178,11 @@ NSString *MMBufferedDrawingKey            = @"MMBufferedDrawing";
     return [self findMenuContainingItemWithAction:@selector(performClose:)];
 }
 
+- (NSMenu *)findHelpMenu
+{
+    return [self findMenuContainingItemWithAction:@selector(openWebsite:)];
+}
+
 @end // NSMenu (MMExtras)
 
 


### PR DESCRIPTION
Implement macOS Help menu's search functionality, so that it can be used to search Vim's documentation. For now, can use space-delimited search string to search Vim's doc tags. The search results will display something like "options.txt > 'termwinsize'" when searching for "term size".

Currently this only works with Vim's built-in documentation. Due to the asynchronous nature of the search, it's a little tricky to support plugins as different Vim instances could be loading different plugins.  For now, just the built-in Vim documentation should serve most of the needs.

Also, properly set the help menu on the app so that localized menus will still show the search box (previously it had to be called exactly 'Help').

