### PR TITLE
Bundle vimtutor with MacVim and provide Help menu item to open it

### DIFF
--- a/runtime/doc/usr_01.txt
+++ b/runtime/doc/usr_01.txt
@@ -118,6 +118,9 @@ On Unix, if Vim has been properly installed, you can start it from the shell:
 On MS-Windows you can find it in the Program/Vim menu.  Or execute
 vimtutor.bat in the $VIMRUNTIME directory.
 
+On MacVim, you can run `vimtutor` from the shell, or select "Vim Tutor" in the
+Help menu.
+
 This will make a copy of the tutor file, so that you can edit it without
 the risk of damaging the original.
    There are a few translated versions of the tutor.  To find out if yours is

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -99,8 +99,16 @@ endif
 " Help menu
 if has("gui_macvim")
   an 9999.1 &Help.MacVim\ Help		    :h gui_mac<CR>
+  tln 9999.1 &Help.MacVim\ Help		    <C-W>:h gui_mac<CR>
   an <silent> 9999.2 Help.MacVim\ Website   <Nop>
   an 9999.3 &Help.-sep0-		    <Nop>
+endif
+if has("gui_macvim")
+  " Run vimtutor in GUI mode. Need to make sure to override the PATH so we use
+  " this app instead of accidentally opening another installed Vim/MacVim.
+  an 9999.5 &Help.Vim\ Tutor       :silent !PATH="$VIM/../../bin":/usr/bin:/bin:/usr/sbin:/sbin $VIM/../../bin/vimtutor -g&<CR>
+  tln 9999.5 &Help.Vim\ Tutor      <C-W>:silent !PATH="$VIM/../../bin":/usr/bin:/bin:/usr/sbin:/sbin $VIM/../../bin/vimtutor -g&<CR>
+  an 9999.6 &Help.-sep-vim-tutor-  <Nop>
 endif
 an 9999.10 &Help.&Overview<Tab><F1>	:help<CR>
 an 9999.20 &Help.&User\ Manual		:help usr_toc<CR>
@@ -114,6 +122,19 @@ an 9999.70 &Help.O&rphans		:help kcc<CR>
 an 9999.75 &Help.-sep2-			<Nop>
 an 9999.80 &Help.&Version		:version<CR>
 an 9999.90 &Help.&About			:intro<CR>
+
+tln 9999.10 &Help.&Overview<Tab><F1>	<C-W>:help<CR>
+tln 9999.20 &Help.&User\ Manual		<C-W>:help usr_toc<CR>
+tln 9999.30 &Help.&How-To\ Links		<C-W>:help how-to<CR>
+tln <silent> 9999.40 &Help.&Find\.\.\.	<C-W>:call <SID>Helpfind()<CR>
+tln 9999.45 &Help.-sep1-			<Nop>
+tln 9999.50 &Help.&Credits		<C-W>:help credits<CR>
+tln 9999.60 &Help.Co&pying		<C-W>:help copying<CR>
+tln 9999.70 &Help.&Sponsor/Register	<C-W>:help sponsor<CR>
+tln 9999.70 &Help.O&rphans		<C-W>:help kcc<CR>
+tln 9999.75 &Help.-sep2-			<Nop>
+tln 9999.80 &Help.&Version		<C-W>:version<CR>
+tln 9999.90 &Help.&About			<C-W>:intro<CR>
 
 fun! s:Helpfind()
   if !exists("g:menutrans_help_dialog")

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -906,7 +906,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
     // of Screen" to the Window menu, and on repeated calls it will keep adding
     // the same item over and over again, without resolving for duplicates. Using
     // copies help keep the source menu clean.
-    NSMenu *mainMenu = [currentMainMenu copy];
+    NSMenu *mainMenu = [[currentMainMenu copy] autorelease];
 
     // If the new menu has a "Recent Files" dummy item, then swap the real item
     // for the dummy.  We are forced to do this since Cocoa initializes the

--- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
+++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -840,6 +840,7 @@
 				1D1C31F00EFFBFD6003FE9A5 /* Make Document Icons */,
 				528DA6671426D456003380F1 /* Copy Scripts */,
 				52283AB71EBA200C00A6F6B9 /* Copy mvim scripts */,
+				90C052E1251E889500E2D81E /* Copy vimtutor */,
 			);
 			buildRules = (
 			);
@@ -1001,6 +1002,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Copy all the locale translation files from the po folder to\n# runtime/lang/<lang>/LC_MESSAGES/vim.mo. Need to do this because unlike normal\n# Vim, MacVim is distributed as a standalone app package and therefore we don't\n# want to install these files to a global location (e.g.\n# /usr/local/share/locale/). This is similar to how Windows installation\n# (po/Make_mvc.mak) works.\ncd \"${SRCROOT}\"/..\nmake macvim-install-languages DEST_LANG=\"${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/vim/runtime/lang\"\n";
+			showEnvVarsInLog = 0;
+		};
+		90C052E1251E889500E2D81E /* Copy vimtutor */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy vimtutor";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "BINPATH=$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/bin\nmkdir -p \"${BINPATH}\"\ncp -a \"${SRCROOT}/../vimtutor\" \"${BINPATH}/vimtutor\"\ncp -a \"${SRCROOT}/../gvimtutor\" \"${BINPATH}/gvimtutor\"\nchmod 755 \"${BINPATH}/vimtutor\"\nchmod 755 \"${BINPATH}/gvimtutor\"\ncd \"${BINPATH}\"\nln -fs gvimtutor mvimtutor \n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -744,6 +744,7 @@ func Test_menu()
 
   " Check deleting menu doesn't cause trouble.
   aunmenu Help
+  tlunmenu Help
   call assert_fails('menu Help', 'E329:')
 endfunc
 


### PR DESCRIPTION
MacVim has previously not included vimtutor, meaning the user had to obtain it elsewhere. Change the build scripts to copy it over to the app bundle so that it's under MacVim.app/Contents/bin just like `mvim` etc.

Also, provide a Help menu item to open vimtutor. The menu action will also make sure to override the PATH first to prevent accidentally opening other installed MacVim/Vim versions since vimtutor works by searching PATH instead of explicitly passing in the Vim executable path.