### PR TITLE
Fix Xcode project file to only require Xcode 6.3

### DIFF
--- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
+++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 47;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -884,7 +884,7 @@
 				LastUpgradeCheck = 0710;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "MacVim" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 6.3";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (


### PR DESCRIPTION
Previously the objectVersion in the pbxproj file was erroneously changed from 46 to 54 (in fcd579756) as the Xcode editor automatically changed that. Fix this by manually change it back to an older version, but change it to 47 instead as that covers all the way up to Xcode 6.3 which is definitely old enough to be backward compatible. In the future will need to look into ways to lock that in place to prevent accidental changes.

Fix #1100
