### PR TITLE
Decouple Sparkle from MMAppController if DISABLE_SPARKLE is set

### DIFF
--- a/src/MacVim/MMAppController.h
+++ b/src/MacVim/MMAppController.h
@@ -14,7 +14,10 @@
 
 @class MMWindowController;
 @class MMVimController;
+
+#if !DISABLE_SPARKLE
 @class SUUpdater;
+#endif
 
 
 @interface MMAppController : NSObject <MMAppProtocol, NSUserInterfaceItemSearching> {
@@ -36,7 +39,9 @@
     NSMutableDictionary *inputQueues;
     int                 processingFlag;
     
+#if !DISABLE_SPARKLE
     SUUpdater           *updater;
+#endif
 
     FSEventStreamRef    fsEventStream;
 }

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -326,7 +326,9 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
     [defaultMainMenu release];  defaultMainMenu = nil;
     currentMainMenu = nil;
     [appMenuItemTemplate release];  appMenuItemTemplate = nil;
+#if !DISABLE_SPARKLE
     [updater release];  updater = nil;
+#endif
 
     [super dealloc];
 }


### PR DESCRIPTION
This makes the code buildable if DISABLE_SPARKLE is set, even if the Sparkle framework is removed. This doesn't mean there is a way to build without linking against Sparkle though as Xcode doesn't provide an easy way to control whether a framework is used or not via xcodebuild command line arguemnts, but for situations like Apple Silicon builds we can at least just remove the reference to Sparkle and it should build now.