### PR TITLE
CI: Organize CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,38 +66,28 @@ script:
   - make -j${NPROC}
   - echo -en "travis_fold:end:build\\r\\033[0K"
   - ${VIMCMD} --version
+  # Disable errexit so flaky tests won't immediately exit to allow us to see all the errors.
+  - set +o errexit
 
-  - echo -e "\\033[33;1mSmoketest\\033[0m" && echo -en "travis_fold:start:smoketest\\r\\033[0K"
   # Smoketest scripting languages
+  - echo -e "\\033[33;1mSmoketest\\033[0m" && echo -en "travis_fold:start:smoketest\\r\\033[0K"
   - |
     macvim_excmd() {
-      if [[ -n "${LANGOPT}" ]]; then
-        ${VIMCMD} -u NONE -i NONE -g -f -X -V1 -es "$@" -c 'echo ""' -c quit 2>&1
-      fi
+      ${VIMCMD} -u NONE -i NONE -g -f -X -V1 -es "$@" -c 'echo ""' -c 'qall!' 2>&1
     }
-  - macvim_excmd -c 'lua print("Test")'
-  - macvim_excmd -c 'perl VIM::Msg("Test")'
-  - macvim_excmd -c 'py import sys; print("Test")'
-  - macvim_excmd -c 'py3 import sys; print("Test")'
-  - macvim_excmd -c 'ruby puts("Test")'
+  - if [[ -n "${LANGOPT}" ]]; then macvim_excmd -c 'lua print("Test")'; fi
+  - if [[ -n "${LANGOPT}" ]]; then macvim_excmd -c 'perl VIM::Msg("Test")'; fi
+  - if [[ -n "${LANGOPT}" ]]; then macvim_excmd -c 'py import sys; print("Test")'; fi
+  - if [[ -n "${LANGOPT}" ]]; then macvim_excmd -c 'py3 import sys; print("Test")'; fi
+  - if [[ -n "${LANGOPT}" ]]; then macvim_excmd -c 'ruby puts("Test")'; fi
   # Check that localized messages work by printing ':version' and checking against localized word
-  - |
-    if [[ -n "${HAS_GETTEXT}" ]]; then
-      ${VIMCMD} -es -c 'lang es_ES' -c 'redir @a' -c 'version' -c 'put a' -c 'print' -c 'qa!' | grep Enlazado
-    fi
+  - if [[ -n "${HAS_GETTEXT}" ]]; then macvim_excmd -c 'lang es_ES' -c 'version' | grep Enlazado; fi
   # Make sure there isn't any dynamic linkage to third-party dependencies in the built binary, as we should only use
-  # static linkage to avoid dependency hell. First, sanity check that we have some dylib linkage to make sure objdump is
-  # working properly, then test that all those dylib's are in /usr/lib which is bundled with macOS and not third-party.
-  - |
-    if (which objdump > /dev/null); then
-      objdump -p ${VIMCMD} | grep -q dylib &&
-      ! (objdump -p ${VIMCMD} | grep dylib | grep -v "name /usr/lib/")
-    fi
+  # static linkage to avoid dependency hell. Test that all those dylib's are in /usr/lib which is bundled with macOS and not third-party.
+  - (! otool -L ${VIMCMD} | grep '\.dylib\s' | grep -v '^\s*/usr/lib/')
   - echo -en "travis_fold:end:smoketest\\r\\033[0K"
 
   # Run standard test suites.
-  # Disable errexit so flaky tests won't immediately exit to allow us to see all the errors.
-  - set +o errexit
   - echo -e "\\033[33;1mTesting MacVim\\033[0m" && echo -en "travis_fold:start:test\\r\\033[0K"
   - make test
   - make -C runtime/doc vimtags VIMEXE=../../src/MacVim/build/Release/MacVim.app/Contents/bin/vim


### PR DESCRIPTION
* Modify `macvim_excmd()` function for all smoketests to use it
* Replace objdump by otool; since otool is included in devtools always 