### PR TITLE
Fix logic behind Mac theme variant inference

### DIFF
--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -163,6 +163,8 @@ static BOOL isUnsafeMessage(int msgid);
 - (void)handleShowDialog:(NSDictionary *)attr;
 - (void)handleDeleteSign:(NSDictionary *)attr;
 - (void)setToolTipDelay:(NSTimeInterval)seconds;
+- (void)themeChanged:(NSNotification *)notification;
+- (void)themeChangedOnMainThread;
 @end
 
 
@@ -201,6 +203,10 @@ static BOOL isUnsafeMessage(int msgid);
             selector:@selector(connectionDidDie:)
                 name:NSConnectionDidDieNotification object:connection];
 
+    [NSDistributedNotificationCenter.defaultCenter addObserver:self
+            selector:@selector(themeChanged:)
+                name:@"AppleInterfaceThemeChangedNotification" object:nil];
+
     // Set up a main menu with only a "MacVim" menu (copied from a template
     // which itself is set up in MainMenu.nib).  The main menu is populated
     // by Vim later on.
@@ -224,7 +230,7 @@ static BOOL isUnsafeMessage(int msgid);
 
     // After MMVimController's initialization is completed,
     // set up the variable `v:os_appearance`.
-    [self appearanceChanged:getCurrentAppearance([windowController vimView].effectiveAppearance)];
+    [self appearanceChanged:getCurrentAppearance(NSApp.effectiveAppearance)];
     
     return self;
 }
@@ -1908,6 +1914,14 @@ static BOOL isUnsafeMessage(int msgid);
     } else {
         ASLogNotice(@"Failed to get NSToolTipManager");
     }
+}
+
+- (void)themeChanged:(NSNotification *)notification {
+    [self performSelectorOnMainThread:@selector(themeChangedOnMainThread) withObject:nil waitUntilDone:false];
+}
+
+- (void)themeChangedOnMainThread {
+    [self appearanceChanged:getCurrentAppearance(NSApp.effectiveAppearance)];
 }
 
 @end // MMVimController (Private)

--- a/src/MacVim/MMVimView.m
+++ b/src/MacVim/MMVimView.m
@@ -664,10 +664,6 @@ enum {
     [self frameSizeMayHaveChanged:NO];
 }
 
-- (void)viewDidChangeEffectiveAppearance
-{
-    [vimController appearanceChanged:getCurrentAppearance(self.effectiveAppearance)];
-}
 @end // MMVimView
 
 


### PR DESCRIPTION
The previous implementation could never possibly work, because every ``set background=…`` changes ``effectiveAppearance`` of ``MMVimView`` and therefore overrides the global value as set in the Preferences.app. In short, it essentially becomes just a mirror of background variable. 😛

I'm none of a Cocoa expert, but this patch ([derived from an SO answer](https://stackoverflow.com/a/56817617)) works just right for me.