### PR TITLE
Update Travis to build in Xcode 12.2, disable old builds to save billing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,15 +99,16 @@ script:
 
 jobs:
   include:
-    - osx_image: xcode12
-    - osx_image: xcode11.3
+    - osx_image: xcode12.2
       <<: *lang_env
       <<: *homebrew
       <<: *caches
-    - osx_image: xcode9.4
-    - osx_image: xcode7.3
+    # Disable unnecessary builds to cut down on Travis usage due to billing changes for open-source projects.
+    #- osx_image: xcode11.6
+    #- osx_image: xcode9.4
+    #- osx_image: xcode7.3
     - stage: deploy
-      osx_image: xcode11.3
+      osx_image: xcode12.2
       <<: *lang_env
       <<: *caches
       script: skip


### PR DESCRIPTION
Use Xcode 12.2 to build releases, which fixes misc Big Sur issues when using a binary release built using Xcode 11.

Also, because Travis CI is moving away from being free for open-source projects, and instead uses a credit-based billing system, disable all other macOS/Xcode versions in the permutations to avoid running out of credits. This will be revisited later.