### PR TITLE
Fix docs and preferences to indicate non-CoreText renderer is deprecated

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -257,6 +257,7 @@ KEY				VALUE ~
 *MMLoginShellArgument*		login shell parameter [string]
 *MMLoginShellCommand*		which shell to use to launch Vim [string]
 *MMNoFontSubstitution*		disable automatic font substitution [bool]
+				(Deprecated: Non-CoreText renderer only)
 *MMNoTitleBarWindow*		hide title bar [bool]
 *MMTitlebarAppearsTransparent*	enable a transparent titlebar [bool]
 *MMAppearanceModeSelection*	dark mode selection (|macvim-dark-mode|)[bool]
@@ -793,9 +794,6 @@ if you would like to see certain messages localized.
 This list is by no means exhaustive, it only enumerates some of the more
 prominent bugs/missing features.
 
-- Under macOS Mojave (10.14), the default renderer (Core Text renderer) has
-  some performance issues and scrolling is not as smooth as previous macOS
-  versions (10.13 or below).
 - Sound.  MacVim does not currently support |+sound| yet.
 - |modifyOtherKeys| support.  This feature allows for more granular key
   mapping (e.g. differentiating <C-I> and <Tab>) and isn't supported by the

--- a/src/MacVim/Base.lproj/Preferences.xib
+++ b/src/MacVim/Base.lproj/Preferences.xib
@@ -367,9 +367,8 @@
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" id="815">
                     <rect key="frame" x="17" y="252" width="449" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="991">
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="(Deprecated) Deselect this option to use the legacy renderer, which is unsupported and will be removed in a future version." id="991">
                         <font key="font" metaFont="smallSystem"/>
-                        <string key="title">Selecting this option will increase rendering performance but double-tapping with three fingers to look up words will no longer work.</string>
                         <color key="textColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -348,7 +348,7 @@ extern NSString *MMShareFindPboardKey;
 
 extern NSString *MMAutosaveRowsKey;
 extern NSString *MMAutosaveColumnsKey;
-extern NSString *MMRendererKey;
+extern NSString *MMRendererKey; // Deprecated: Non-CoreText renderer
 
 enum {
     MMRendererDefault = 0,

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -32,7 +32,7 @@ extern NSString *MMBaselineOffsetKey;
 extern NSString *MMTranslateCtrlClickKey;
 extern NSString *MMTopLeftPointKey;
 extern NSString *MMOpenInCurrentWindowKey;
-extern NSString *MMNoFontSubstitutionKey;
+extern NSString *MMNoFontSubstitutionKey; // Deprecated: Non-CoreText renderer
 extern NSString *MMAppearanceModeSelectionKey;
 extern NSString *MMNoTitleBarWindowKey;
 extern NSString *MMTitlebarAppearsTransparentKey;


### PR DESCRIPTION
Now that CoreText scrolling performance is fixed with the stateful renderer we should eventually stop supporting the legacy NSTextView renderer which doesn't renderer properly and cannot do proper fixed-width column rendering that Vim uses. Mark it as deprecated for now but it will be removed in the future.