### PR TITLE
macOS 11: SF symbols for preference pane / use the right toolbar styles

### DIFF
--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -222,6 +222,15 @@
     }
 #endif
 
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+    if (@available(macos 11.0, *)) {
+        // macOS 11 will default to a unified toolbar style unless you use the new
+        // toolbarStyle to tell it to use a "preference" style, which makes it look nice
+        // and centered.
+        win.toolbarStyle = NSWindowToolbarStyleUnifiedCompact;
+    }
+#endif
+
     [[NSNotificationCenter defaultCenter]
         addObserver:self
            selector:@selector(applicationDidChangeScreenParameters:)


### PR DESCRIPTION
Use SF symbols (only for macOS 11+ / Big Sur) for preference pane's toolbar to be consistent with rest of OS. Set toolbar style to be "preference" as otherwise it defaults to "unified" which is not correct for a preference pane.

Set toolbar style for main MacVim window to be "unified compact", as the default "unified" is too larger and not useful for text editing. For example, Xcode also uses this.