### PR TITLE
Make SF Symbols double-width

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -1545,6 +1545,15 @@ utf_char2cells(int c)
 	{0x1f6e9, 0x1f6e9},
 	{0x1f6f0, 0x1f6f0},
 	{0x1f6f3, 0x1f6f3}
+#ifdef FEAT_GUI_MACVIM
+	// Include SF Symbols characters, which should be rendered as
+	// double-width. All of them are in the Supplementary Private Use Area-B
+	// range. The exact range was determined by downloading the "SF Symbols"
+	// app from Apple, and then selecting all symbols, copying them out, and
+	// inspecting the unicode values of them.
+	,
+	{0x100000, 0x100d7f}
+#endif
     };
 
     if (c >= 0x100)


### PR DESCRIPTION
macOS 11 (Big Sur) has added SF Symbols support for the OS. While these are primarily designed to be used in apps as images, each symbol does indeed correspond to a Unicode entry and can be used alongside normal texts in a text editor, similar to how emojis work. Since they tend to be pretty square in shape, we should treat them as double-width like emojis.

The Unicode range was extracted by using Apple's SF Symbols app, and copying out all the symbols and inspecting them. It will likely need to be updated if Apple adds more symbols in future updates. For now, they all seem to occupy the low end of Supplementary Private Use Area-B.

Note that these symbols only work when viewed in macOS, and won't work in other platforms like Linux or Windows. They should probably not be used in files that need to be shared outside of macOS.