### PR TITLE
Update python3 framework detection to use 3.9

### DIFF
--- a/src/MacVim/vimrc
+++ b/src/MacVim/vimrc
@@ -32,12 +32,12 @@ endif
 " or an installation from python.org:
 if exists("&pythonthreedll") && exists("&pythonthreehome") &&
       \ !filereadable(&pythonthreedll)
-  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.8/Python")
-    " MacPorts python 3.8
-    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.8/Python
-  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.8/Python")
+  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.9/Python")
+    " MacPorts python 3.9
+    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.9/Python
+  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.9/Python")
     " https://www.python.org/downloads/mac-osx/
-    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.8/Python
+    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.9/Python
   endif
 endif
 


### PR DESCRIPTION
MacVim's CI build script was already updated to use Python 3.9 from Homebrew when building, so it would use that automatically, but update the auto-detection used for MacPorts and binary install support to use 3.9 as well.