### PR TITLE
Fix setting `guifontwide` to redraw texts and clear the cache

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -409,6 +409,12 @@ static void grid_free(Grid *grid) {
         [fontWide release];
         fontWide = [newFont retain];
     }
+
+    [self clearAll];
+    [fontVariants removeAllObjects];
+    [characterStrings removeAllObjects];
+    [characterLines removeAllObjects];
+
 }
 
 - (NSFont *)font


### PR DESCRIPTION
Previously setting `guifontwide` doesn't do anything for drawn text, and you have to set a new `guifont` in order for it to clear.