### PR TITLE
Fix Travis CI to only build x86_64, and fix --with-macarchs flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ env:
       vi_cv_dll_name_python3=/usr/local/Frameworks/Python.framework/Versions/3.9/Python
       vi_cv_dll_name_ruby=/usr/local/opt/ruby/lib/libruby.dylib
       VIMCMD=src/MacVim/build/Release/MacVim.app/Contents/MacOS/Vim
-      CONFOPT="--with-features=huge --enable-netbeans --with-tlib=ncurses --enable-cscope --enable-gui=macvim"
+      MACVIM_BIN=src/MacVim/build/Release/MacVim.app/Contents/MacOS/MacVim
+      CONFOPT="--with-features=huge --enable-netbeans --with-tlib=ncurses --enable-cscope --enable-gui=macvim --with-macarchs=x86_64"
       BASH_SILENCE_DEPRECATION_WARNING=1
 
 _anchors:
@@ -85,6 +86,10 @@ script:
   # Make sure there isn't any dynamic linkage to third-party dependencies in the built binary, as we should only use
   # static linkage to avoid dependency hell. Test that all those dylib's are in /usr/lib which is bundled with macOS and not third-party.
   - (! otool -L ${VIMCMD} | grep '\.dylib\s' | grep -v '^\s*/usr/lib/')
+  # Make sure we are building x86_64 only. arm64 builds don't work properly now, so we don't want to accidentally build
+  # it as it will get prioritized by Apple Silicon Macs.
+  - (lipo -archs ${VIMCMD} | grep '^x86_64$')
+  - (lipo -archs ${MACVIM_BIN} | grep '^x86_64$')
   - echo -en "travis_fold:end:smoketest\\r\\033[0K"
 
   # Run standard test suites.

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -4758,7 +4758,15 @@ fi
 $as_echo_n "checking if architectures are supported... " >&6; }
     save_cflags="$CFLAGS"
     save_ldflags="$LDFLAGS"
-    archflags=`echo "$ARCHS" | sed -e 's/[[:<:]]/-arch /g'`
+
+    # Apple's sed is supposed to treat [[:<:]] as word beginning, but seems
+    # like that broke some time ago and means *any* word character (but
+    # [[:>:]] still seems to work as word end).
+    # Use a more convoluted regex in order to properly to split the archs by
+    # word and prefix each with "-arch" to pass to the compiler.
+    #archflags=`echo "$ARCHS" | sed -e 's/[[[:<:]]]/-arch /g'`
+    archflags=`echo "$ARCHS" | sed 's/[[:>:]][ ][ ]*[[:<:]]/ -arch /g' | sed 's/^/-arch /g'`
+
     CFLAGS="$CFLAGS $archflags"
     LDFLAGS="$LDFLAGS $archflags"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -273,7 +273,15 @@ if test "`(uname) 2>/dev/null`" = Darwin; then
     AC_MSG_CHECKING(if architectures are supported)
     save_cflags="$CFLAGS"
     save_ldflags="$LDFLAGS"
-    archflags=`echo "$ARCHS" | sed -e 's/[[[:<:]]]/-arch /g'`
+
+    # Apple's sed is supposed to treat [[:<:]] as word beginning, but seems
+    # like that broke some time ago and means *any* word character (but
+    # [[:>:]] still seems to work as word end).
+    # Use a more convoluted regex in order to properly to split the archs by
+    # word and prefix each with "-arch" to pass to the compiler.
+    #archflags=`echo "$ARCHS" | sed -e 's/[[[:<:]]]/-arch /g'`
+    archflags=`echo "$ARCHS" | sed 's/[[[:>:]]][[ ]][[ ]]*[[[:<:]]]/ -arch /g' | sed 's/^/-arch /g'`
+
     CFLAGS="$CFLAGS $archflags"
     LDFLAGS="$LDFLAGS $archflags"
     AC_TRY_LINK([ ], [ ],


### PR DESCRIPTION
Apple Silicon build doesn't work in CI yet, and as such we don't want CI to build it, as accidentaly Apple Silicon builds will mean an Apple Silicon Mac prioritize that over Rosetta build which will crash (since we are only building `MacVim` as universal, but the raw `Vim` process is not). Also, add a CI smoketest step to make sure we only build x86_64.

Also, fix up the `--with-macarchs` flag for `configure`. For some reason, Apple seems to have broken sed's word boundary parsing, so need to work around it and use a more convoluted regex to do the word splitting.