### PR TITLE
Add Github Actions CI for MacVim

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -1,0 +1,167 @@
+name: MacVim GitHub CI
+
+on:
+  push:
+  pull_request:
+
+env:
+  MACOSX_DEPLOYMENT_TARGET: 10.9
+
+  VERSIONER_PERL_VERSION: 5.18
+  VERSIONER_PYTHON_VERSION: 2.7
+  vi_cv_path_python: /usr/bin/python
+  vi_cv_path_python3: /usr/local/bin/python3
+  vi_cv_path_plain_lua: /usr/local/bin/lua
+  vi_cv_path_ruby: /usr/local/opt/ruby/bin/ruby
+  vi_cv_dll_name_perl: /System/Library/Perl/5.18/darwin-thread-multi-2level/CORE/libperl.dylib
+  vi_cv_dll_name_python: /System/Library/Frameworks/Python.framework/Versions/2.7/Python
+  vi_cv_dll_name_python3: /usr/local/Frameworks/Python.framework/Versions/3.9/Python
+  vi_cv_dll_name_ruby: /usr/local/opt/ruby/lib/libruby.dylib
+
+  VIMCMD: src/MacVim/build/Release/MacVim.app/Contents/MacOS/Vim
+  MACVIM_BIN: src/MacVim/build/Release/MacVim.app/Contents/MacOS/MacVim
+
+  CONFOPT: "--with-features=huge --enable-netbeans --with-tlib=ncurses --enable-cscope --enable-gui=macvim --with-macarchs=x86_64"
+  LANGOPT: "--enable-perlinterp=dynamic --enable-pythoninterp=dynamic --enable-python3interp=dynamic --enable-rubyinterp=dynamic --enable-luainterp=dynamic --with-lua-prefix=/usr/local"
+
+  HAS_GETTEXT: 1
+
+  BASH_SILENCE_DEPRECATION_WARNING: 1
+
+jobs:
+
+  # Builds and test MacVim
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+
+    # Set up and install gettext for localization.
+    # Instead of using the default binary installed by Homebrew, need to build our own because gettext is statically
+    # linked in MacVim, and need to be built against MACOSX_DEPLOYMENT_TARGET to ensure the built binary will work on
+    # supported macOS versions.
+    - name: Set up gettext
+      run: |
+        # Patch the official Homebrew gettext formula to explicitly build for min deployment target
+        cp /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gettext.rb gettext.rb
+
+        cat << EOF > gettext_diff.patch
+        --- gettext_orig.rb
+        +++ gettext.rb
+        @@ -24,2 +24,3 @@
+           def install
+        +    ENV["MACOSX_DEPLOYMENT_TARGET"] = "${MACOSX_DEPLOYMENT_TARGET}"
+             args = [
+        EOF
+
+        patch gettext.rb gettext_diff.patch
+
+        # Uninstall the already installed gettext because we want to build our own
+        brew uninstall --ignore-dependencies gettext
+    - name: Cache gettext
+      uses: actions/cache@v2
+      with:
+        path: /usr/local/Cellar/gettext
+        key: gettext-homebrew-cache-${{ runner.os }}-${{ hashFiles('gettext.rb') }}
+    - name: Install gettext
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
+      run: |
+        brew install -s gettext.rb  # This will be a no-op if gettext was cached
+        brew link gettext           # If gettext was cached, this step is necessary to relink it to /usr/local/
+
+
+    - name: Install packages
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
+      run: |
+        brew install python
+        brew install ruby
+        brew install lua
+        brew unlink perl # We just use system perl to reduce dependencies
+
+
+    - name: Configure
+      run: |
+        set -o errexit
+        set -o verbose
+
+        ./configure ${CONFOPT} ${LANGOPT} --enable-fail-if-missing
+        sed -i.bak -f ci/config.mk.sed -f ci/config.mk.clang.sed src/auto/config.mk
+        # Ruby is keg-only in Homebrew, so need to manually link in the path so Vim will know where to look for the binaries.
+        perl -p -i -e "s#(?<=-DDYNAMIC_RUBY_DLL=\\\\\").*?(?=\\\\\")#${vi_cv_dll_name_ruby}#" src/auto/config.mk
+        if [[ -n "${LANGOPT}" ]]; then
+          grep -q -- "-DDYNAMIC_PERL_DLL=\\\\\"${vi_cv_dll_name_perl}\\\\\"" src/auto/config.mk
+          grep -q -- "-DDYNAMIC_PYTHON_DLL=\\\\\"${vi_cv_dll_name_python}\\\\\"" src/auto/config.mk
+          grep -q -- "-DDYNAMIC_PYTHON3_DLL=\\\\\"${vi_cv_dll_name_python3}\\\\\"" src/auto/config.mk
+          grep -q -- "-DDYNAMIC_RUBY_DLL=\\\\\"${vi_cv_dll_name_ruby}\\\\\"" src/auto/config.mk
+        fi
+    - name: Show configure output
+      run: |
+        cat src/auto/config.mk
+        cat src/auto/config.h
+    - name: Make
+      run: |
+        set -o errexit
+        set -o verbose
+        NPROC=$(getconf _NPROCESSORS_ONLN) && echo "Building MacVim with ${NPROC} cores"
+        make -j${NPROC}
+    - name: Show Vim version
+      run: ${VIMCMD} --version
+    - name: Smoketest
+      run: |
+        set -o errexit
+        set -o verbose
+
+        # Smoketest scripting languages
+        macvim_excmd() {
+          ${VIMCMD} -u NONE -i NONE -g -f -X -V1 -es "$@" -c 'echo ""' -c 'qall!' 2>&1
+        }
+        if [[ -n "${LANGOPT}" ]]; then macvim_excmd -c 'lua print("Test")'; fi
+        if [[ -n "${LANGOPT}" ]]; then macvim_excmd -c 'perl VIM::Msg("Test")'; fi
+        if [[ -n "${LANGOPT}" ]]; then macvim_excmd -c 'py import sys; print("Test")'; fi
+        if [[ -n "${LANGOPT}" ]]; then macvim_excmd -c 'py3 import sys; print("Test")'; fi
+        if [[ -n "${LANGOPT}" ]]; then macvim_excmd -c 'ruby puts("Test")'; fi
+
+        # Check that localized messages work by printing ':version' and checking against localized word
+        if [[ -n "${HAS_GETTEXT}" ]]; then macvim_excmd -c 'lang es_ES' -c 'version' | grep Enlazado; fi
+
+        # Make sure there isn't any dynamic linkage to third-party dependencies in the built binary, as we should only use
+        # static linkage to avoid dependency hell. Test that all those dylib's are in /usr/lib which is bundled with macOS and not third-party.
+        if (otool -L ${VIMCMD} | grep '\.dylib\s' | grep -v '^\s*/usr/lib/'); then echo 'Found external dynamic linkage!' && exit 1; fi
+
+        # Make sure we are building x86_64 only. arm64 builds don't work properly now, so we don't want to accidentally build
+        # it as it will get prioritized by Apple Silicon Macs.
+        (lipo -archs ${VIMCMD} | grep '^x86_64$')
+        (lipo -archs ${MACVIM_BIN} | grep '^x86_64$')
+
+    - name: Update Vim help tags
+      run: make -C runtime/doc vimtags VIMEXE=../../src/MacVim/build/Release/MacVim.app/Contents/bin/vim
+
+    - name: Test
+      if: false # TODO: Tests are failing, turn off temporarily to unblock
+      timeout-minutes: 20
+      run: make test
+    - name: Test GUI
+      if: false # TODO: Tests are failing, turn off temporarily to unblock
+      timeout-minutes: 20
+      run: make -C src/testdir clean && make -C src testgui
+
+    # Creates a DMG package of MacVim. Note that this doesn't create a GitHub release for us, because we would prefer to
+    # do it manually, for two reasons: 1) signing / notarization are currently done out of CI, 2) we want to manually
+    # format our release notes and add pictures to make them look nice.
+    - name: Build MacVim dmg image
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        # Use the --skip-jenkins flag to skip the prettify osascript calls which could fail due to permission issues in
+        # CI environment.
+        make -C src macvim-dmg CREATEDMG_FLAGS=--skip-jenkins
+
+    - name: Upload MacVim image
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: actions/upload-artifact@v2
+      with:
+        name: MacVim.dmg
+        path: src/MacVim/build/Release/MacVim.dmg


### PR DESCRIPTION
This is the initial work to migrate to Github Actions from Travis CI for MacVim CI (see #1127). Sets up a MacVim-specific workflow that builds and test MacVim, and also publishes built artifacts for releases.

Some notest on implementation:

- Testing is currently disabled as it seems to be failing on a few tests.
- gettext is now custom built instead using the Homebrew version. The latest versions of the binary were built with later SDKs and would cause MacVim to not work in older macOS versions (10.13), see #1138.  To fix this, we need to manually build gettext with min SDK set to 10.9 (the current MacVim target) before we link it with MacVim. We do this by copying the brew formula and manually patch in the min SDK and then install from source.
- When publishing a build when a tag is pushed, simply have the workflow publish a dmg artifact, instead of pushing it to the release like Travis CI. Currently, releases are manual and requires offline signing/notarization steps that are out of CI, and also release notes formatting that also requires manual work. As such, there is no point in automating releases other than building a dmg that we can then sign and publish.

Features to add later:

- Test matrix. We should test on the available OS versions (currently 10.15 and 11.0) and also different Xcode / macOS SDKs to try catch backwards compatibility issues.
- Enable testing once the tests are fixed.
- Apple Silicon universal build support.
