### PR TITLE
Use --with-compiledby configure flag for GitHub Actions CI

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -112,6 +112,7 @@ jobs:
             --enable-cscope
             --enable-gui=macvim
             --with-macarchs=x86_64
+            --with-compiledby="GitHub Actions"
           )
           if ${{ matrix.publish == true }}; then
             CONFOPT+=(


### PR DESCRIPTION
This makes `:version` output cleaner and that it's clear that CI built the published app.