### PR TITLE
Fix issue with font line spacing support and add option for it

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -241,7 +241,7 @@ is sent back to the server application.
 
 Some settings are global to the MacVim application and would not make sense as
 Vim options.  These settings are stored in the user defaults database and can
-be accessed via the "MacVim.Preferences..." menu item.
+be accessed via the "MacVim.Preferences…" menu item.
 
 							*macvim-user-defaults*
 Not all entries in the user defaults database are exposed via the preference
@@ -265,6 +265,7 @@ KEY				VALUE ~
 *MMNativeFullScreen*		use native full screen mode [bool]
 *MMNoFontSubstitution*		disable automatic font substitution [bool]
 				(Deprecated: Non-CoreText renderer only)
+*MMFontPreserveLineSpacing*	use the line-spacing as specified by font [bool]
 *MMNoTitleBarWindow*		hide title bar [bool]
 *MMTitlebarAppearsTransparent*	enable a transparent titlebar [bool]
 *MMAppearanceModeSelection*	dark mode selection (|macvim-dark-mode|)[bool]

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5015,6 +5015,7 @@ MMAppearanceModeSelection	gui_mac.txt	/*MMAppearanceModeSelection*
 MMCellWidthMultiplier	gui_mac.txt	/*MMCellWidthMultiplier*
 MMDialogsTrackPwd	gui_mac.txt	/*MMDialogsTrackPwd*
 MMDisableLaunchAnimation	gui_mac.txt	/*MMDisableLaunchAnimation*
+MMFontPreserveLineSpacing	gui_mac.txt	/*MMFontPreserveLineSpacing*
 MMFullScreenFadeTime	gui_mac.txt	/*MMFullScreenFadeTime*
 MMLoginShellArgument	gui_mac.txt	/*MMLoginShellArgument*
 MMLoginShellCommand	gui_mac.txt	/*MMLoginShellCommand*

--- a/src/MacVim/Base.lproj/Preferences.xib
+++ b/src/MacVim/Base.lproj/Preferences.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment version="1090" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="MMPreferenceController">
@@ -183,7 +184,7 @@
                     <rect key="frame" x="19" y="22" width="444" height="36"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <subviews>
-                        <button fixedFrame="YES" id="122">
+                        <button id="122">
                             <rect key="frame" x="188" y="18" width="258" height="18"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                             <string key="toolTip">Checks for updates and presents a dialog box showing the release notes and prompt for whether you want to install the new version.</string>
@@ -196,7 +197,7 @@
                                 <binding destination="58" name="value" keyPath="values.SUCheckAtStartup" id="169"/>
                             </connections>
                         </button>
-                        <button fixedFrame="YES" id="UYM-W0-Kgl" userLabel="Auto-install updates">
+                        <button id="UYM-W0-Kgl" userLabel="Auto-install updates">
                             <rect key="frame" x="202" y="-2" width="244" height="18"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                             <string key="toolTip">MacVim will automatically download and install updates without prompting. The updated version will be used the next time MacVim starts.</string>
@@ -211,7 +212,7 @@
                                 <binding destination="58" name="value" keyPath="values.SUAutomaticallyUpdate" id="kyZ-ah-zKf"/>
                             </connections>
                         </button>
-                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" id="124">
+                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="124">
                             <rect key="frame" x="-2" y="19" width="187" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="When MacVim launches:" id="976">
@@ -226,11 +227,11 @@
             <point key="canvasLocation" x="138" y="20"/>
         </customView>
         <customView id="hr4-G4-3ZG" userLabel="Appearance">
-            <rect key="frame" x="0.0" y="0.0" width="483" height="244"/>
+            <rect key="frame" x="0.0" y="0.0" width="483" height="270"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <customView id="fw0-VK-Nbz" userLabel="Dark mode selection">
-                    <rect key="frame" x="19" y="66" width="433" height="156"/>
+                    <rect key="frame" x="19" y="92" width="433" height="156"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="T40-Os-PUf" userLabel="Dark mode selection">
@@ -291,25 +292,22 @@
                     </subviews>
                 </customView>
                 <customView id="7af-iK-4r7" userLabel="Titlebar appearance">
-                    <rect key="frame" x="19" y="20" width="433" height="38"/>
+                    <rect key="frame" x="19" y="46" width="433" height="38"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
-                        <button fixedFrame="YES" id="7ie-0J-0Zr">
+                        <button id="7ie-0J-0Zr">
                             <rect key="frame" x="189" y="19" width="244" height="18"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                             <buttonCell key="cell" type="check" title="Transparent" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="hzd-hj-Pth">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
-                                <connections>
-                                    <binding destination="58" name="enabled" keyPath="values.SUCheckAtStartup" id="nYZ-8w-Dyi"/>
-                                </connections>
                             </buttonCell>
                             <connections>
                                 <action selector="appearanceChanged:" target="-2" id="B97-8h-FDo"/>
                                 <binding destination="58" name="value" keyPath="values.MMTitlebarAppearsTransparent" id="pQP-eb-JXS"/>
                             </connections>
                         </button>
-                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" id="9Rk-gT-kVC" userLabel="Titlebar appearance">
+                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="9Rk-gT-kVC" userLabel="Titlebar appearance">
                             <rect key="frame" x="-2" y="20" width="187" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Titlebar appearance:" id="HEH-Lo-v4I" userLabel="Titlebar appearance:">
@@ -318,15 +316,12 @@
                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
-                        <button fixedFrame="YES" id="Hqh-Ql-2od">
+                        <button id="Hqh-Ql-2od">
                             <rect key="frame" x="189" y="1" width="244" height="18"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                             <buttonCell key="cell" type="check" title="Hidden" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="W40-cB-m1U">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
-                                <connections>
-                                    <binding destination="58" name="enabled" keyPath="values.SUCheckAtStartup" id="c7R-qa-q9c"/>
-                                </connections>
                             </buttonCell>
                             <connections>
                                 <action selector="appearanceChanged:" target="-2" id="WQA-OC-F4I"/>
@@ -335,14 +330,42 @@
                         </button>
                     </subviews>
                 </customView>
+                <customView id="BpJ-rH-ona" userLabel="Font">
+                    <rect key="frame" x="19" y="20" width="433" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <subviews>
+                        <button id="YKV-u2-Egc" userLabel="Preserve Line Spacing">
+                            <rect key="frame" x="189" y="-1" width="244" height="18"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <string key="toolTip">Some fonts have non-standard built-in line spacings (anything other than 1). If this is checked, MacVim will use the font's specified line spacing to calculate line height. Otherwise, it will just set it to 1, which helps if you would like a more compact spacing without having to install another font.</string>
+                            <buttonCell key="cell" type="check" title="Preserve font line spacing" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="2ni-Is-Caz" userLabel="Preserve Line Spacing">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="fontPropertiesChanged:" target="-2" id="uaN-zX-Lvq"/>
+                                <binding destination="58" name="value" keyPath="values.MMFontPreserveLineSpacing" id="i6W-kG-7G5"/>
+                            </connections>
+                        </button>
+                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="VAj-Yx-2uZ" userLabel="Font">
+                            <rect key="frame" x="-2" y="0.0" width="187" height="17"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Font:" id="bMQ-uG-iDR">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                    </subviews>
+                </customView>
             </subviews>
-            <point key="canvasLocation" x="137.5" y="394"/>
+            <point key="canvasLocation" x="138" y="390"/>
         </customView>
         <customView id="620" userLabel="Advanced">
             <rect key="frame" x="0.0" y="0.0" width="483" height="318"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" id="826">
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="826">
                     <rect key="frame" x="17" y="170" width="449" height="56"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="993">
@@ -352,7 +375,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button fixedFrame="YES" id="817">
+                <button id="817">
                     <rect key="frame" x="18" y="228" width="133" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable Quickstart" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="992">
@@ -364,7 +387,7 @@
                         <binding destination="58" name="value" keyPath="values.MMPreloadCacheSize" id="828"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" id="815">
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="815">
                     <rect key="frame" x="17" y="252" width="449" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="(Deprecated) Deselect this option to use the legacy renderer, which is unsupported and will be removed in a future version." id="991">
@@ -373,7 +396,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button fixedFrame="YES" id="782">
+                <button id="782">
                     <rect key="frame" x="18" y="282" width="174" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Use Core Text renderer" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="990">
@@ -385,7 +408,7 @@
                         <binding destination="58" name="value" keyPath="values.MMRenderer" id="1000"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" id="1001">
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="1001">
                     <rect key="frame" x="17" y="74" width="444" height="70"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="1004">
@@ -395,7 +418,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button fixedFrame="YES" id="1013">
+                <button id="1013">
                     <rect key="frame" x="18" y="146" width="174" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Draw marked text inline" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1014">
@@ -406,7 +429,7 @@
                         <binding destination="58" name="value" keyPath="values.MMUseInlineIm" id="1016"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" id="1017">
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="1017">
                     <rect key="frame" x="17" y="20" width="415" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="1020">
@@ -416,7 +439,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button fixedFrame="YES" id="1028">
+                <button id="1028">
                     <rect key="frame" x="18" y="50" width="388" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Prefer native full-screen support (requires Mac OS X 10.7)" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="1029">

--- a/src/MacVim/MMAppController.h
+++ b/src/MacVim/MMAppController.h
@@ -59,6 +59,7 @@
 - (BOOL)openFiles:(NSArray *)filenames withArguments:(NSDictionary *)args;
 
 - (void)refreshAllAppearances;
+- (void)refreshAllFonts;
 
 - (IBAction)newWindow:(id)sender;
 - (IBAction)newWindowAndActivate:(id)sender;

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -229,6 +229,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         [NSNumber numberWithBool:YES],    MMTranslateCtrlClickKey,
         [NSNumber numberWithInt:0],       MMOpenInCurrentWindowKey,
         [NSNumber numberWithBool:NO],     MMNoFontSubstitutionKey,
+        [NSNumber numberWithBool:YES],    MMFontPreserveLineSpacingKey,
         [NSNumber numberWithBool:YES],    MMLoginShellKey,
         [NSNumber numberWithInt:MMRendererCoreText],
                                           MMRendererKey,
@@ -1106,6 +1107,15 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
     for (unsigned i = 0; i < count; ++i) {
         MMVimController *vc = [vimControllers objectAtIndex:i];
         [vc.windowController refreshApperanceMode];
+    }
+}
+
+- (void)refreshAllFonts
+{
+    unsigned count = [vimControllers count];
+    for (unsigned i = 0; i < count; ++i) {
+        MMVimController *vc = [vimControllers objectAtIndex:i];
+        [vc.windowController refreshFonts];
     }
 }
 

--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -32,6 +32,8 @@
     BOOL                        ligatures;
     BOOL                        thinStrokes;
 
+    BOOL                        forceRefreshFont; // when true, don't early out of setFont calls.
+
     MMTextViewHelper            *helper;
 
     NSMutableDictionary<NSNumber *, NSFont *> *fontVariants;

--- a/src/MacVim/MMPreferenceController.m
+++ b/src/MacVim/MMPreferenceController.m
@@ -127,4 +127,10 @@
     [[MMAppController sharedInstance] refreshAllAppearances];
 }
 
+- (IBAction)fontPropertiesChanged:(id)sender
+{
+    // Refresh all windows' fonts.
+    [[MMAppController sharedInstance] refreshAllFonts];
+}
+
 @end

--- a/src/MacVim/MMTextView.h
+++ b/src/MacVim/MMTextView.h
@@ -47,6 +47,7 @@
 - (void)setFont:(NSFont *)newFont;
 - (NSFont *)fontWide;
 - (void)setWideFont:(NSFont *)newFont;
+- (void)refreshFonts;
 - (NSSize)cellSize;
 - (void)setLinespace:(float)newLinespace;
 - (void)setColumnspace:(float)newColumnspace;

--- a/src/MacVim/MMTextView.m
+++ b/src/MacVim/MMTextView.m
@@ -352,6 +352,11 @@
     [(MMTextStorage*)[self textStorage] setWideFont:newFont];
 }
 
+- (void)refreshFonts
+{
+    // Doesn't do anything. CoreText renderer only.
+}
+
 - (NSSize)cellSize
 {
     return [(MMTextStorage*)[self textStorage] cellSize];

--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -82,6 +82,7 @@
 - (void)setDefaultColorsBackground:(NSColor *)back foreground:(NSColor *)fore;
 - (void)setFont:(NSFont *)font;
 - (void)setWideFont:(NSFont *)font;
+- (void)refreshFonts;
 - (void)processInputQueueDidFinish;
 - (void)showTabBar:(BOOL)on;
 - (void)showToolbar:(BOOL)on size:(int)size mode:(int)mode;

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -721,6 +721,11 @@
     [[vimView textView] setWideFont:font];
 }
 
+- (void)refreshFonts
+{
+    [[vimView textView] refreshFonts];
+}
+
 - (void)processInputQueueDidFinish
 {
     // NOTE: Resizing is delayed until after all commands have been processed

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -33,6 +33,7 @@ extern NSString *MMTranslateCtrlClickKey;
 extern NSString *MMTopLeftPointKey;
 extern NSString *MMOpenInCurrentWindowKey;
 extern NSString *MMNoFontSubstitutionKey; // Deprecated: Non-CoreText renderer
+extern NSString *MMFontPreserveLineSpacingKey;
 extern NSString *MMAppearanceModeSelectionKey;
 extern NSString *MMNoTitleBarWindowKey;
 extern NSString *MMTitlebarAppearsTransparentKey;

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -29,6 +29,7 @@ NSString *MMTranslateCtrlClickKey         = @"MMTranslateCtrlClick";
 NSString *MMTopLeftPointKey               = @"MMTopLeftPoint";
 NSString *MMOpenInCurrentWindowKey        = @"MMOpenInCurrentWindow";
 NSString *MMNoFontSubstitutionKey         = @"MMNoFontSubstitution";
+NSString *MMFontPreserveLineSpacingKey    = @"MMFontPreserveLineSpacing";
 NSString *MMAppearanceModeSelectionKey    = @"MMAppearanceModeSelection";
 NSString *MMNoTitleBarWindowKey           = @"MMNoTitleBarWindow";
 NSString *MMTitlebarAppearsTransparentKey = @"MMTitlebarAppearsTransparent";


### PR DESCRIPTION
Recent change to stateful renderer (#858) has inadvertantly changed how MacVim handles line spacing. Previously, MacVim intentionally ignores the line spacing of a font and creates a new dummy font that essentially has line spacing of 1, but the new code uses the font as is. This means font with non-standard line spacing (e.g. Input Mono) will look different. This is technically the correct way to handle fonts but is different from how MacVim has worked for years.

Also, see last time this regression (where MacVim didn't discard line spacing) happened in #928 / #949 which was fixed in #957. Also see #977 where the bug was filed the other way requesting for using the font's line spacing instead of discarding it.

This commit re-introduces the behavior to discard line spacing, but only provides it as an option (can be set in the preference pane), while defaulting to using the line spacing as that seems more correct.

Note that from a casual survey of other terminals and editors, this behavior is quite inconsistent. Xcode does use the font's line spacing, and was partially the motivation of switching to that as a default.

Close #1152.

