### PR TITLE
Fix non-native full screen sizing, fix 'fuoptions', allow menus

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -263,6 +263,7 @@ KEY				VALUE ~
 *MMLoginShellArgument*		login shell parameter [string]
 *MMLoginShellCommand*		which shell to use to launch Vim [string]
 *MMNativeFullScreen*		use native full screen mode [bool]
+*MMNonNativeFullScreenShowMenu*	show menus when in non-native full screen [bool]
 *MMNoFontSubstitution*		disable automatic font substitution [bool]
 				(Deprecated: Non-CoreText renderer only)
 *MMFontPreserveLineSpacing*	use the line-spacing as specified by font [bool]

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3607,23 +3607,19 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 			{not in Vi}
 			{only in MacVim GUI}
-	In fullscreen mode, most of the screen is black, only a part of the
-	screen is covered by the actual Vim control.  The control is centered.
-	This option controls the size of the Vim control as well as the color
-	of the unused screen area. 
+			{not supported in native full screen mode}
+	In non-native fullscreen mode, MacVim can be configured to either show
+	all the content filling up the whole screen, or only use part of the
+	screen to show the content, centered.  This option controls the size
+	of the Vim control as well as the color of the unused screen area. 
 	value	effect	~
         maxvert	When entering fullscreen, 'lines' is set to the maximum number
-		of lines fitting on the screen in fullscreen mode. When
-		leaving fullscreen, if 'lines' is still equal to the maximized
-		number of lines, it is restored to the value it had before
-		entering fullscreen.
+		of lines fitting on the screen in fullscreen mode. If unset, 
+		'lines' will be unchanged when entering fullscreen mode.
         maxhorz	When entering fullscreen, 'columns' is set to the maximum number
-		of columns fitting on the screen in fullscreen mode. When
-		leaving fullscreen, if 'columns' is still equal to the maximized
-		number of columns, it is restored to the value it had before
-		entering fullscreen.
+		of columns fitting on the screen in fullscreen mode. If unset,
+		'columns' will be unchanged when entering fullscreen mode.
 	background:color
-		{not supported in Mac OS X native full screen}
 		When entering fullscreen, 'color' defines the color of the part
 		of the screen that is not occupied by the Vim control. If
 		'color' is an 8-digit hexadecimal number preceded by '#',
@@ -3645,13 +3641,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	Don't change size when entering fullscreen, and color the background
 	like the current text background: >
 	  :set fuoptions=background:Normal
-<
-	XXX: what if the font size is changed? you probably never want to
-	restore the old 'lines' or 'columns' in that case.
-	XXX: Each time the Vim window resizes (for example due to font size
-	changes, re-maximize Vim to fullscreen?)
-	XXX: The approach doesn't restore vertical Vim size if fu is entered
-	without tabs and leaves with tabs (or the other way round).
 
 
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5030,6 +5030,7 @@ MMLoginShellCommand	gui_mac.txt	/*MMLoginShellCommand*
 MMNativeFullScreen	gui_mac.txt	/*MMNativeFullScreen*
 MMNoFontSubstitution	gui_mac.txt	/*MMNoFontSubstitution*
 MMNoTitleBarWindow	gui_mac.txt	/*MMNoTitleBarWindow*
+MMNonNativeFullScreenShowMenu	gui_mac.txt	/*MMNonNativeFullScreenShowMenu*
 MMShareFindPboard	gui_mac.txt	/*MMShareFindPboard*
 MMShowAddTabButton	gui_mac.txt	/*MMShowAddTabButton*
 MMTabMaxWidth	gui_mac.txt	/*MMTabMaxWidth*

--- a/src/MacVim/Base.lproj/Preferences.xib
+++ b/src/MacVim/Base.lproj/Preferences.xib
@@ -227,11 +227,11 @@
             <point key="canvasLocation" x="138" y="20"/>
         </customView>
         <customView id="hr4-G4-3ZG" userLabel="Appearance">
-            <rect key="frame" x="0.0" y="0.0" width="483" height="270"/>
+            <rect key="frame" x="0.0" y="0.0" width="483" height="315"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <customView id="fw0-VK-Nbz" userLabel="Dark mode selection">
-                    <rect key="frame" x="19" y="92" width="433" height="156"/>
+                    <rect key="frame" x="19" y="137" width="433" height="156"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="T40-Os-PUf" userLabel="Dark mode selection">
@@ -292,7 +292,7 @@
                     </subviews>
                 </customView>
                 <customView id="7af-iK-4r7" userLabel="Titlebar appearance">
-                    <rect key="frame" x="19" y="46" width="433" height="38"/>
+                    <rect key="frame" x="19" y="91" width="433" height="38"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <button id="7ie-0J-0Zr">
@@ -330,27 +330,73 @@
                         </button>
                     </subviews>
                 </customView>
-                <customView id="BpJ-rH-ona" userLabel="Font">
-                    <rect key="frame" x="19" y="20" width="433" height="18"/>
+                <customView id="BpJ-rH-ona" userLabel="Full Screen">
+                    <rect key="frame" x="19" y="45" width="433" height="38"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
-                        <button id="YKV-u2-Egc" userLabel="Preserve Line Spacing">
-                            <rect key="frame" x="189" y="-1" width="244" height="18"/>
+                        <button toolTip="Use macOS's native full screen mode, which integrates with Mission Control and creates a new Space for the window." id="YKV-u2-Egc" userLabel="Use native full screen">
+                            <rect key="frame" x="189" y="19" width="244" height="18"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                            <string key="toolTip">Some fonts have non-standard built-in line spacings (anything other than 1). If this is checked, MacVim will use the font's specified line spacing to calculate line height. Otherwise, it will just set it to 1, which helps if you would like a more compact spacing without having to install another font.</string>
-                            <buttonCell key="cell" type="check" title="Preserve font line spacing" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="2ni-Is-Caz" userLabel="Preserve Line Spacing">
+                            <buttonCell key="cell" type="check" title="Use native full screen mode" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="2ni-Is-Caz" userLabel="Use native full screen">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
                             </buttonCell>
                             <connections>
                                 <action selector="fontPropertiesChanged:" target="-2" id="uaN-zX-Lvq"/>
-                                <binding destination="58" name="value" keyPath="values.MMFontPreserveLineSpacing" id="i6W-kG-7G5"/>
+                                <binding destination="58" name="value" keyPath="values.MMNativeFullScreen" id="Y8t-au-n4b"/>
                             </connections>
                         </button>
-                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="VAj-Yx-2uZ" userLabel="Font">
+                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="VAj-Yx-2uZ" userLabel="Full Sc">
+                            <rect key="frame" x="-2" y="20" width="187" height="17"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Full Screen:" id="bMQ-uG-iDR">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <button id="Fru-Q7-7SG" userLabel="Non-native menu bar">
+                            <rect key="frame" x="189" y="2" width="237" height="18"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <buttonCell key="cell" type="check" title="Show menu bar in non-native mode" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Kok-Et-R5A" userLabel="Show menu bar in non-native full screen">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                                <connections>
+                                    <binding destination="58" name="enabled" keyPath="values.MMNativeFullScreen" id="Uw8-jM-9g1">
+                                        <dictionary key="options">
+                                            <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                        </dictionary>
+                                    </binding>
+                                </connections>
+                            </buttonCell>
+                            <connections>
+                                <action selector="fontPropertiesChanged:" target="-2" id="1RM-UT-GNp"/>
+                                <binding destination="58" name="value" keyPath="values.MMNonNativeFullScreenShowMenu" id="5wX-jg-QPo"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                </customView>
+                <customView id="a3v-cB-TFa" userLabel="Font">
+                    <rect key="frame" x="19" y="20" width="433" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <subviews>
+                        <button id="A48-s0-kdR" userLabel="Preserve Line Spacing">
+                            <rect key="frame" x="189" y="-1" width="244" height="18"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <string key="toolTip">Some fonts have non-standard built-in line spacings (anything other than 1). If this is checked, MacVim will use the font's specified line spacing to calculate line height. Otherwise, it will just set it to 1, which helps if you would like a more compact spacing without having to install another font.</string>
+                            <buttonCell key="cell" type="check" title="Preserve font line spacing" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="SeR-yl-Gtz" userLabel="Preserve Line Spacing">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="fontPropertiesChanged:" target="-2" id="tbK-S9-Vbs"/>
+                                <binding destination="58" name="value" keyPath="values.MMFontPreserveLineSpacing" id="6cJ-Uj-qVy"/>
+                            </connections>
+                        </button>
+                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="8WW-zu-LlE" userLabel="Font">
                             <rect key="frame" x="-2" y="0.0" width="187" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Font:" id="bMQ-uG-iDR">
+                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Font:" id="eV4-3c-P2e">
                                 <font key="font" metaFont="system"/>
                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -359,14 +405,14 @@
                     </subviews>
                 </customView>
             </subviews>
-            <point key="canvasLocation" x="138" y="390"/>
+            <point key="canvasLocation" x="137.5" y="412.5"/>
         </customView>
         <customView id="620" userLabel="Advanced">
-            <rect key="frame" x="0.0" y="0.0" width="483" height="318"/>
+            <rect key="frame" x="0.0" y="0.0" width="483" height="264"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="826">
-                    <rect key="frame" x="17" y="170" width="449" height="56"/>
+                    <rect key="frame" x="17" y="116" width="449" height="56"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="993">
                         <font key="font" metaFont="smallSystem"/>
@@ -376,7 +422,7 @@
                     </textFieldCell>
                 </textField>
                 <button id="817">
-                    <rect key="frame" x="18" y="228" width="133" height="18"/>
+                    <rect key="frame" x="18" y="174" width="133" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable Quickstart" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="992">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -388,7 +434,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="815">
-                    <rect key="frame" x="17" y="252" width="449" height="28"/>
+                    <rect key="frame" x="17" y="198" width="449" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="(Deprecated) Deselect this option to use the legacy renderer, which is unsupported and will be removed in a future version." id="991">
                         <font key="font" metaFont="smallSystem"/>
@@ -397,7 +443,7 @@
                     </textFieldCell>
                 </textField>
                 <button id="782">
-                    <rect key="frame" x="18" y="282" width="174" height="18"/>
+                    <rect key="frame" x="18" y="228" width="174" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Use Core Text renderer" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="990">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -409,7 +455,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="1001">
-                    <rect key="frame" x="17" y="74" width="444" height="70"/>
+                    <rect key="frame" x="17" y="20" width="444" height="70"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="1004">
                         <font key="font" metaFont="smallSystem"/>
@@ -419,7 +465,7 @@
                     </textFieldCell>
                 </textField>
                 <button id="1013">
-                    <rect key="frame" x="18" y="146" width="174" height="18"/>
+                    <rect key="frame" x="18" y="92" width="174" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Draw marked text inline" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1014">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -429,29 +475,8 @@
                         <binding destination="58" name="value" keyPath="values.MMUseInlineIm" id="1016"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="1017">
-                    <rect key="frame" x="17" y="20" width="415" height="28"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="1020">
-                        <font key="font" metaFont="smallSystem"/>
-                        <string key="title">You may want to disable this option when using multiple monitors since the native full-screen support renders secondary monitors useless.</string>
-                        <color key="textColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <button id="1028">
-                    <rect key="frame" x="18" y="50" width="388" height="18"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Prefer native full-screen support (requires Mac OS X 10.7)" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="1029">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <binding destination="58" name="value" keyPath="values.MMNativeFullScreen" id="1031"/>
-                    </connections>
-                </button>
             </subviews>
-            <point key="canvasLocation" x="138" y="770"/>
+            <point key="canvasLocation" x="137.5" y="743"/>
         </customView>
     </objects>
 </document>

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -249,6 +249,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         [NSNumber numberWithBool:NO],     MMSuppressTerminationAlertKey,
         [NSNumber numberWithBool:YES],    MMNativeFullScreenKey,
         [NSNumber numberWithDouble:0.25], MMFullScreenFadeTimeKey,
+        [NSNumber numberWithBool:NO],     MMNonNativeFullScreenShowMenuKey,
         [NSNumber numberWithBool:YES],    MMShareFindPboardKey,
         nil];
 

--- a/src/MacVim/MMFullScreenWindow.h
+++ b/src/MacVim/MMFullScreenWindow.h
@@ -25,8 +25,8 @@
     // These are only valid in full-screen mode and store pre-fu vim size 
     int         nonFuRows, nonFuColumns;
 
-    // These store the size vim had right after entering fu mode
-    int         startFuRows, startFuColumns;
+    /// The non-full-screen size of the Vim view. Used for non-maxvert/maxhorz options.
+    NSSize      nonFuVimViewSize;
 
     // This stores the contents of fuoptions_flags at fu start time
     int         startFuFlags;
@@ -41,7 +41,7 @@
 - (void)setOptions:(int)opt;
 - (void)enterFullScreen;
 - (void)leaveFullScreen;
-- (void)centerView;
+- (NSRect)getDesiredFrame;
 
 - (BOOL)canBecomeKeyWindow;
 - (BOOL)canBecomeMainWindow;

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -785,7 +785,18 @@
                                       keepOnScreen:keepOnScreen];
             }
             else {
-                NSSize frameSize = fullScreenWindow ? [fullScreenWindow frame].size : (fullScreenEnabled ? desiredWindowSize : originalSize);
+                NSSize frameSize;
+                if (fullScreenWindow) {
+                    // Non-native full screen mode.
+                    NSRect desiredFrame = [fullScreenWindow getDesiredFrame];
+                    frameSize = desiredFrame.size;
+                    [vimView setFrameOrigin:desiredFrame.origin]; // This will get set back to normal in MMFullScreenWindow::leaveFullScreen.
+                } else if (fullScreenEnabled) {
+                    // Native full screen mode.
+                    frameSize = desiredWindowSize;
+                } else {
+                    frameSize = originalSize;
+                }
                 [vimView setFrameSizeKeepGUISize:frameSize];
             }
         }

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -56,6 +56,7 @@ extern NSString *MMSuppressTerminationAlertKey;
 extern NSString *MMNativeFullScreenKey;
 extern NSString *MMUseMouseTimeKey;
 extern NSString *MMFullScreenFadeTimeKey;
+extern NSString *MMNonNativeFullScreenShowMenuKey;
 
 
 // Enum for MMUntitledWindowKey

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -52,6 +52,7 @@ NSString *MMSuppressTerminationAlertKey   = @"MMSuppressTerminationAlert";
 NSString *MMNativeFullScreenKey           = @"MMNativeFullScreen";
 NSString *MMUseMouseTimeKey               = @"MMUseMouseTime";
 NSString *MMFullScreenFadeTimeKey         = @"MMFullScreenFadeTime";
+NSString *MMNonNativeFullScreenShowMenuKey  = @"MMNonNativeFullScreenShowMenu";
 
 
 


### PR DESCRIPTION
Fix misc non-native full screen sizing issues. Previously, in certain cases such as using non-native full screen in a secondary monitor, the non-native full screen window would be offsetted and half the window shown offscreen, making it hard to use.

The bug is that we call `resizeVimView` and `centerView` immediately after resizing Vim's frame, but the frame resize only asynchronously calls processInputQueueDidFinish in MMWindowController, which now actually handles all the frame resizing logic. `centerView` was therefore calculating using the wrong info, and tried to center the view on wrong coordinates. Just fix this by removing those two functions as they are no longer needed as processInputQueueDidFinish already does everything.

Also, fix `fuopts` to support unsetting maxvert/maxhorz again (this was what `centerView` was trying to do). Simply add hooks to processInputQueueDidFinish to query the non-native full screen window for what the desired size is, instead of just assuming we wan to fill the whole frame.

* Fix #509

Also, add a new option `MMNonNativeFullScreenShowMenu` to allow showing the menu bar instead of auto-hiding it while using non-native full screen as it could be useful to show it, and less jarring to switch among different apps.

Move preferences around so non-native full screen is now a "regular" option under Apperance instead of Advanced. Also expose the non-native show menu option so it's exposed to users.

This is a follow-up to #1155.
