### PR TITLE
Remove fade-to-black animation for native/custom fullscreen

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -314,6 +314,8 @@ this behaviour set MMLoginShellArgument to "--".
 ==============================================================================
 4. MacVim appearance					*macvim-appearance*
 
+MacVim can be used in full screen mode, see 'fullscreen'.
+
 				*macvim-appearance-mode* *macvim-dark-mode*
 MacVim will by default use the system apperance mode (light or dark). However,
 you can manually force MacVim to use either light or dark mode in the

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3580,27 +3580,30 @@ A jump table for the options with a short description can be found at |Q_op|.
 	(e.g. toolbar, title bar).  The tab bar and scroll bars remain visible.
 	Updates to the window position are ignored in fullscreen mode.
 
+	By default, this will use macOS's native full screen feature, which
+	will put the MacVim window into another Space under Mission Control.
+	MacVim also provides a custom full screen solution which you can
+	select by setting |MMNativeFullScreen| to NO, or toggle it under
+	Preferences → Appearance. Under custom full-screen, the window will
+	not be put in another space, which makes it easier to Cmd-Tab to other
+	windows.
+
+	Custom / non-native full screen configuration:~
+
 	See 'fuoptions' for how Vim resizes and colors the background when 
 	entering and leaving fullscreen mode.
 
-	You can use the hidden preference MMFullScreenFadeTime to adjust how
-	long the animation takes to fade in and out.  The default is 0.25
-	seconds.  See |macvim-preferences|for how to set hidden preferences.
+	There is an optional fade-to-black effect while transitioning that
+	could be turned on by using the hidden preference
+	|MMFullScreenFadeTime| (specified in seconds). It defaults to 0,
+	meaning this effect is turned off.  Setting it to a positive value
+	(e.g. 0.25) will create an effect that fades to black during the full
+	screen transition to make it less jarring.
 
-	Note: Setting 'fullscreen' usually changes the size of the Vim
-	control. However, for technical reasons, 'lines' and 'columns' will
-	currently only be updated when Vim runs its event loop. As a
-	consequence, if you set 'fullscreen' and 'lines' or 'columns' in a
-	Vim script file, you should always set 'fullscreen' after setting
-	'lines' and 'columns', else 'lines' and 'columns' will be overwritten
-	with the values 'fullscreen' sets after the script has been executed
-	and the event loop is ran again.
+	Note: While in 'fullscreen', you cannot set 'lines' or 'columns', as
+	they are determined by the size of the window.  'fuoptions' allows you
+	to override part of that behavior if using custom full screen.
 
-	XXX: Add fuenter/fuleave autocommands? You might want to display
-	a NERDTree or a Tlist only in fullscreen for example. Then again, this
-	could probably be in a sizechanged autocommand that triggers if the
-	size is above a certain threshold.
-	XXX: Think about how 'fullscreen' and 'transparency' should interact. 
 
 						*'fuoptions'* *'fuopt'*
 'fuoptions' 'fuopt'	string (default "maxvert,maxhorz")

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -1383,7 +1383,8 @@ if has("touchbar")
   endfunc
   aug FullScreenTouchBar
     au!
-    au VimEnter,VimResized * call <SID>SetupFullScreenTouchBar()
+    au VimEnter * call <SID>SetupFullScreenTouchBar()
+    au OptionSet fullscreen call <SID>SetupFullScreenTouchBar()
   aug END
 
   " 2. Character (i.e. emojis) picker. Only in modes where user is actively

--- a/src/MacVim/Base.lproj/Preferences.xib
+++ b/src/MacVim/Base.lproj/Preferences.xib
@@ -342,11 +342,10 @@
                                 <font key="font" metaFont="system"/>
                             </buttonCell>
                             <connections>
-                                <action selector="fontPropertiesChanged:" target="-2" id="uaN-zX-Lvq"/>
                                 <binding destination="58" name="value" keyPath="values.MMNativeFullScreen" id="Y8t-au-n4b"/>
                             </connections>
                         </button>
-                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="VAj-Yx-2uZ" userLabel="Full Sc">
+                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="VAj-Yx-2uZ">
                             <rect key="frame" x="-2" y="20" width="187" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Full Screen:" id="bMQ-uG-iDR">
@@ -362,7 +361,7 @@
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
                                 <connections>
-                                    <binding destination="58" name="enabled" keyPath="values.MMNativeFullScreen" id="Uw8-jM-9g1">
+                                    <binding destination="58" name="enabled" keyPath="values.MMNativeFullScreen" id="YVo-6f-uND">
                                         <dictionary key="options">
                                             <string key="NSValueTransformerName">NSNegateBoolean</string>
                                         </dictionary>
@@ -370,7 +369,6 @@
                                 </connections>
                             </buttonCell>
                             <connections>
-                                <action selector="fontPropertiesChanged:" target="-2" id="1RM-UT-GNp"/>
                                 <binding destination="58" name="value" keyPath="values.MMNonNativeFullScreenShowMenu" id="5wX-jg-QPo"/>
                             </connections>
                         </button>

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -248,7 +248,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 #endif // INCLUDE_OLD_IM_CODE
         [NSNumber numberWithBool:NO],     MMSuppressTerminationAlertKey,
         [NSNumber numberWithBool:YES],    MMNativeFullScreenKey,
-        [NSNumber numberWithDouble:0.25], MMFullScreenFadeTimeKey,
+        [NSNumber numberWithDouble:0.0],  MMFullScreenFadeTimeKey,
         [NSNumber numberWithBool:NO],     MMNonNativeFullScreenShowMenuKey,
         [NSNumber numberWithBool:YES],    MMShareFindPboardKey,
         nil];

--- a/src/MacVim/MMFullScreenWindow.m
+++ b/src/MacVim/MMFullScreenWindow.m
@@ -150,10 +150,12 @@ enum {
     // fade to black
     Boolean didBlend = NO;
     CGDisplayFadeReservationToken token;
-    if (CGAcquireDisplayFadeReservation(fadeReservationTime, &token) == kCGErrorSuccess) {
-        CGDisplayFade(token, fadeTime, kCGDisplayBlendNormal,
-            kCGDisplayBlendSolidColor, .0, .0, .0, true);
-        didBlend = YES;
+    if (fadeTime > 0) {
+        if (CGAcquireDisplayFadeReservation(fadeReservationTime, &token) == kCGErrorSuccess) {
+            CGDisplayFade(token, fadeTime, kCGDisplayBlendNormal,
+                kCGDisplayBlendSolidColor, .0, .0, .0, true);
+            didBlend = YES;
+        }
     }
 
     // NOTE: The window may have moved to another screen in between init.. and
@@ -238,10 +240,12 @@ enum {
     // fade to black
     Boolean didBlend = NO;
     CGDisplayFadeReservationToken token;
-    if (CGAcquireDisplayFadeReservation(fadeReservationTime, &token) == kCGErrorSuccess) {
-        CGDisplayFade(token, fadeTime, kCGDisplayBlendNormal,
-            kCGDisplayBlendSolidColor, .0, .0, .0, true);
-        didBlend = YES;
+    if (fadeTime > 0) {
+        if (CGAcquireDisplayFadeReservation(fadeReservationTime, &token) == kCGErrorSuccess) {
+            CGDisplayFade(token, fadeTime, kCGDisplayBlendNormal,
+                kCGDisplayBlendSolidColor, .0, .0, .0, true);
+            didBlend = YES;
+        }
     }
 
     // restore old vim view size


### PR DESCRIPTION
For native fullscreen, simply remove the custom animation as it doesn't look good and doesn't look native. This was added back when resizing the window rapidly would result in artifacts, but they should have all been fixed. As such, no need to hide everything under a black fade.

For custom fullscreen, make it so that if `MMFullScreenFadeTime` is set to 0 (which is now the default), the fading animation will simply not be drawn as it simply flickers. Since it now defaults to 0, the user will have to manually set this back to 0.25 to get the old functionality, which is ok as it's somewhat a legacy feature anyway and there shouldn't be any flickering now during the transition.

Also, update documentation on full-screen to provide more info on native vs custom, and clean up old outdated texts.

Misc driveby fixes related to full screen:
- Robustify the Touch Bar full screen button to listen to `OptionSet` event which is more robust than relying on `VimResized`, which also didn't work when 'fuoptions' is set to nothing.
- Make MacVim handle the DidFailToEnter/ExitFullScreen events better.  These events could fire when using native full screen while the user is e.g. switching space. We need to make sure to properly update the states when these two events happen and let Vim know what the current `'fullscreen'` state is so both sides are synced.
- Fix up the preferences pane's full screen buttons to not trigger fontPropertiesChanged which was a mistake due to copy-and-paste in Interface Builder.

See:
- #292 / #289 which implemented the fade effect.
