### PR TITLE
Code clean up / robustification and additional logging for render

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -1775,9 +1775,9 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
             [alert setMessageText:NSLocalizedString(@"Multiple files not found",
                     @"File not found dialog, title")];
             text = [NSString stringWithFormat:NSLocalizedString(
-                    @"Could not open file with name %@, and %d other files.",
+                    @"Could not open file with name %@, and %u other files.",
                     @"File not found dialog, text"),
-                firstMissingFile, count-[files count]-1];
+                firstMissingFile, (unsigned int)(count-[files count]-1)];
         }
 
         [alert setInformativeText:text];

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -88,8 +88,6 @@ static BOOL isUnsafeMessage(int msgid);
 @property (readonly) NSMutableDictionary *itemDict;
 @property (readonly) NSMutableArray *itemOrder;
 
-- (id)initWithVimController:(MMVimController *)controller;
-
 @end
 
 @interface MMTouchBarItemInfo : NSObject;
@@ -828,6 +826,7 @@ static BOOL isUnsafeMessage(int msgid);
             // This should only happen if the system default font has changed
             // name since MacVim was compiled in which case we fall back on
             // using the user fixed width font.
+            ASLogInfo(@"Failed to load font '%@' / %f", name, size);
             font = [NSFont userFixedPitchFontOfSize:size];
         }
 
@@ -1634,7 +1633,7 @@ static BOOL isUnsafeMessage(int msgid);
         touchbarItem = item;
     }
     
-    MMTouchBarItemInfo *touchbarItemInfo = [[MMTouchBarItemInfo alloc] initWithItem:touchbarItem label:touchbarLabel];
+    MMTouchBarItemInfo *touchbarItemInfo = [[[MMTouchBarItemInfo alloc] initWithItem:touchbarItem label:touchbarLabel] autorelease];
     if (submenu) {
         [touchbarItemInfo makeChildTouchBar];
     }
@@ -2009,6 +2008,10 @@ static BOOL isUnsafeMessage(int msgid);
     
 - (id)init
 {
+    if (!(self = [super init])) {
+        return nil;
+    }
+
     _touchbar = [[NSTouchBar alloc] init];
     
     _itemDict = [[NSMutableDictionary alloc] init];

--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -75,7 +75,6 @@
 - (void)setScrollbarThumbValue:(float)val proportion:(float)prop
                     identifier:(int32_t)ident;
 
-- (unsigned int)calculateStyleMask;
 - (void)setBackgroundOption:(int)dark;
 - (void)refreshApperanceMode;
 

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -692,7 +692,13 @@
 
 - (void)setFont:(NSFont *)font
 {
-    [[NSFontManager sharedFontManager] setSelectedFont:font isMultiple:NO];
+    const NSWindow* mainWindow = [NSApp mainWindow];
+    if (mainWindow && (mainWindow == decoratedWindow || mainWindow == fullScreenWindow)) {
+        // Update the shared font manager with the new font, but only if this is the main window,
+        // as the font manager is shared among all the windows.
+        [[NSFontManager sharedFontManager] setSelectedFont:font isMultiple:NO];
+    }
+
     [[vimView textView] setFont:font];
     [self updateResizeConstraints];
     shouldMaximizeWindow = YES;
@@ -1159,6 +1165,7 @@
     [[MMAppController sharedInstance] setMainMenu:[vimController mainMenu]];
 
     if ([vimView textView]) {
+        // Update the shared font manager to always be set to the font of the main window.
         NSFontManager *fm = [NSFontManager sharedFontManager];
         [fm setSelectedFont:[[vimView textView] font] isMultiple:NO];
     }
@@ -1247,6 +1254,7 @@
 
 - (void)windowDidChangeBackingProperties:(NSNotification *)notification
 {
+    ASLogDebug(@"");
     [vimController sendMessage:BackingPropertiesChangedMsgID data:nil];
 }
 


### PR DESCRIPTION
Clean up code per clang analyzer. Make sure to initialize structs properly and clean up potential memory leaks.

When drawing wide characters, clean up the other cell to be empty just to be clean.

When updating fonts for a MacVim window, if it's not the main window, make sure to not update the shared font manager as it's previously a minor bug where it would do that.

Add additional debug logging for renderer to help debug potential CoreText renderer issues. See #1164.