### PR TITLE
Don't rely on NSCache to retain newly-created lines.

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -1138,7 +1138,7 @@ static void grid_free(Grid *grid) {
     if (!strCache){
         strCache = characterLines[key] = [[[NSCache alloc] init] autorelease];
     }
-    CTLineRef line = (CTLineRef)[strCache objectForKey:string];
+    CTLineRef line = (CTLineRef)[[strCache objectForKey:string] retain];
     if (!line) {
         NSAttributedString *attrString = [[NSAttributedString alloc]
             initWithString:string
@@ -1150,9 +1150,8 @@ static void grid_free(Grid *grid) {
         line = CTLineCreateWithAttributedString((CFAttributedStringRef)attrString);
         [attrString release];
         [strCache setObject:(id)line forKey:[[string copy] autorelease]];
-        CFRelease(line);
     }
-    return line;
+    return (CTLineRef)[(id)line autorelease];
 }
 
 @end // MMCoreTextView (Private)


### PR DESCRIPTION
When there's memory pressure, the cache just drops the line immediately. Fixes #1164.