### PR TITLE
Support fixing "menu not found" error when started through mvim with default menus disabled.

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -1,4 +1,4 @@
-*gui_mac.txt*	For Vim version 8.2.  Last change: 2020 Aug 13
+*gui_mac.txt*	For Vim version 8.2.  Last change: 2022 Jan 24
 
 
 		  VIM REFERENCE MANUAL    by Bjorn Winckler
@@ -93,6 +93,18 @@ with the Apple Human Interface Guidelines (HIG).
 
 The Help menu's search can be used to search Vim's documentation.  You can use
 it to quickly find the documentation you want in addition to using |:help|.
+
+If you want to disable configuration of command key equivalents when Vim
+sources |menu.vim| you can add this line to your .vimrc file: >
+  :let did_install_default_mac_menus = 1
+
+This is particularly useful if you have opted to disable generation of the
+default menus themselves (by setting 'did_install_default_menus = 1').
+Otherwise, you may get errors on startup due to missing menus.
+
+Because 'filetype' and 'syntax' both cause Vim to source |menu.vim|, you
+must set 'did_install_default_mac_menus' before executing those commands in
+your .vimrc.
 
 							*macvim-window-title*
 The default window title does not include the argument list because it looks

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -1299,62 +1299,65 @@ unlet s:cpo_save
 
 
 if has("gui_macvim")
-  "
-  " Set up menu key equivalents (these should always have the 'D' modifier
-  " set), action bindings, and alternate items.
-  "
-  " Note: menu items which should execute an action are bound to <Nop>; the
-  " action message is specified here via the :macmenu command.
-  "
-  macm File.New\ Window				key=<D-n> action=newWindow:
-  macm File.New\ Tab				key=<D-t>
-  macm File.Open…				key=<D-o> action=fileOpen:
-  macm File.Open\ Tab\.\.\.<Tab>:tabnew		key=<D-T>
-  macm File.Open\ Recent			action=recentFilesDummy:
-  macm File.Close\ Window<Tab>:qa		key=<D-W>
-  macm File.Close				key=<D-w> action=performClose:
-  macm File.Save<Tab>:w				key=<D-s>
-  macm File.Save\ All				key=<D-M-s> alt=YES
-  macm File.Save\ As…<Tab>:sav		key=<D-S>
-  macm File.Print				key=<D-p>
+  if !exists("did_install_default_mac_menus")
+    let did_install_default_mac_menus = 1
+    "
+    " Set up menu key equivalents (these should always have the 'D' modifier
+    " set), action bindings, and alternate items.
+    "
+    " Note: menu items which should execute an action are bound to <Nop>; the
+    " action message is specified here via the :macmenu command.
+    "
+    macm File.New\ Window				key=<D-n> action=newWindow:
+    macm File.New\ Tab				key=<D-t>
+    macm File.Open…				key=<D-o> action=fileOpen:
+    macm File.Open\ Tab\.\.\.<Tab>:tabnew		key=<D-T>
+    macm File.Open\ Recent			action=recentFilesDummy:
+    macm File.Close\ Window<Tab>:qa		key=<D-W>
+    macm File.Close				key=<D-w> action=performClose:
+    macm File.Save<Tab>:w				key=<D-s>
+    macm File.Save\ All				key=<D-M-s> alt=YES
+    macm File.Save\ As…<Tab>:sav		key=<D-S>
+    macm File.Print				key=<D-p>
 
-  macm Edit.Undo<Tab>u				key=<D-z> action=undo:
-  macm Edit.Redo<Tab>^R				key=<D-Z> action=redo:
-  macm Edit.Cut<Tab>"+x				key=<D-x> action=cut:
-  macm Edit.Copy<Tab>"+y			key=<D-c> action=copy:
-  macm Edit.Paste<Tab>"+gP			key=<D-v> action=paste:
-  macm Edit.Select\ All<Tab>ggVG		key=<D-a> action=selectAll:
-  macm Edit.Find.Find…			key=<D-f>
-  macm Edit.Find.Find\ Next			key=<D-g> action=findNext:
-  macm Edit.Find.Find\ Previous			key=<D-G> action=findPrevious:
-  macm Edit.Find.Use\ Selection\ for\ Find	key=<D-e> action=useSelectionForFind:
-  macm Edit.Font.Show\ Fonts			action=orderFrontFontPanel:
-  macm Edit.Font.Bigger				key=<D-=> action=fontSizeUp:
-  macm Edit.Font.Smaller			key=<D--> action=fontSizeDown:
+    macm Edit.Undo<Tab>u				key=<D-z> action=undo:
+    macm Edit.Redo<Tab>^R				key=<D-Z> action=redo:
+    macm Edit.Cut<Tab>"+x				key=<D-x> action=cut:
+    macm Edit.Copy<Tab>"+y			key=<D-c> action=copy:
+    macm Edit.Paste<Tab>"+gP			key=<D-v> action=paste:
+    macm Edit.Select\ All<Tab>ggVG		key=<D-a> action=selectAll:
+    macm Edit.Find.Find…			key=<D-f>
+    macm Edit.Find.Find\ Next			key=<D-g> action=findNext:
+    macm Edit.Find.Find\ Previous			key=<D-G> action=findPrevious:
+    macm Edit.Find.Use\ Selection\ for\ Find	key=<D-e> action=useSelectionForFind:
+    macm Edit.Font.Show\ Fonts			action=orderFrontFontPanel:
+    macm Edit.Font.Bigger				key=<D-=> action=fontSizeUp:
+    macm Edit.Font.Smaller			key=<D--> action=fontSizeDown:
 
-  macm Tools.Spelling.To\ Next\ Error<Tab>]s	key=<D-;>
-  macm Tools.Spelling.Suggest\ Corrections<Tab>z=   key=<D-:>
-  macm Tools.Make<Tab>:make			key=<D-b>
-  macm Tools.List\ Errors<Tab>:cl		key=<D-l>
-  macm Tools.Next\ Error<Tab>:cn		key=<D-C-Right>
-  macm Tools.Previous\ Error<Tab>:cp		key=<D-C-Left>
-  macm Tools.Older\ List<Tab>:cold		key=<D-C-Up>
-  macm Tools.Newer\ List<Tab>:cnew		key=<D-C-Down>
+    macm Tools.Spelling.To\ Next\ Error<Tab>]s	key=<D-;>
+    macm Tools.Spelling.Suggest\ Corrections<Tab>z=   key=<D-:>
+    macm Tools.Make<Tab>:make			key=<D-b>
+    macm Tools.List\ Errors<Tab>:cl		key=<D-l>
+    macm Tools.Next\ Error<Tab>:cn		key=<D-C-Right>
+    macm Tools.Previous\ Error<Tab>:cp		key=<D-C-Left>
+    macm Tools.Older\ List<Tab>:cold		key=<D-C-Up>
+    macm Tools.Newer\ List<Tab>:cnew		key=<D-C-Down>
 
-  macm Window.Minimize		key=<D-m>	action=performMiniaturize:
-  macm Window.Minimize\ All	key=<D-M-m>	action=miniaturizeAll:	alt=YES
-  macm Window.Zoom		key=<D-C-z>	action=performZoom:
-  macm Window.Zoom\ All		key=<D-M-C-z>	action=zoomAll:		alt=YES
-  macm Window.Toggle\ Full\ Screen\ Mode	key=<D-C-f>
-  macm Window.Show\ Next\ Tab			key=<D-}>
-  macm Window.Show\ Previous\ Tab		key=<D-{>
-  macm Window.Bring\ All\ To\ Front		action=arrangeInFront:
-  macm Window.Stay\ in\ Front 	action=stayInFront:
-  macm Window.Stay\ in\ Back 	action=stayInBack:
-  macm Window.Stay\ Level\ Normal action=stayLevelNormal:
+    macm Window.Minimize		key=<D-m>	action=performMiniaturize:
+    macm Window.Minimize\ All	key=<D-M-m>	action=miniaturizeAll:	alt=YES
+    macm Window.Zoom		key=<D-C-z>	action=performZoom:
+    macm Window.Zoom\ All		key=<D-M-C-z>	action=zoomAll:		alt=YES
+    macm Window.Toggle\ Full\ Screen\ Mode	key=<D-C-f>
+    macm Window.Show\ Next\ Tab			key=<D-}>
+    macm Window.Show\ Previous\ Tab		key=<D-{>
+    macm Window.Bring\ All\ To\ Front		action=arrangeInFront:
+    macm Window.Stay\ in\ Front 	action=stayInFront:
+    macm Window.Stay\ in\ Back 	action=stayInBack:
+    macm Window.Stay\ Level\ Normal action=stayLevelNormal:
 
-  macm Help.MacVim\ Help			key=<D-?>
-  macm Help.MacVim\ Website			action=openWebsite:
+    macm Help.MacVim\ Help			key=<D-?>
+    macm Help.MacVim\ Website			action=openWebsite:
+  endif
 endif
 
 if has("touchbar")


### PR DESCRIPTION
While investigating issue #1230, I added `let did_install_default_menus = 1` to my `.vimrc`. This disables the generation of Vim's default menus, per `gui.txt`. It also causes an error to be generated when using `mvim` to start MacVim from the Terminal:

```
Error detected while processing /Users/Josh/Documents/Dotfiles/vim/vimrc[6]../Applications/MacVim.app/Contents/Resources/vim/runtime/syntax/syntax.vim[25]../Applications/MacVim.app/Contents/Resources/vim/runtime/filetype.vim[2366]../Applications/MacVim.app/Contents/Resources/vim/runtime/menu.vim:
line 1306:
E334: Menu not found: File.New\ Window
```

When `did_install_default_menus` is used this way, `menu.vim`'s calls to `macmenu` fail to find any menus, since they were never generated. This change introduces a similar global variable, `did_install_default_mac_menus` that can be set similarly to skip the `macmenu` calls and avoid the errors. This more easily supports the use-case where somebody wants to completely redefine the menu structure, which isn't common, but _is_ what led me down this rabbit hole in the first place.

I considered a few other approaches. They all have pros and cons, this seemed like the simplest overall:

- `menu.vim` aggressively sets `did_install_default_menus` to make the script reentrant. We could set the variable after all the `macmenu` commands finish, letting one variable control both. However, this would make managing upstream merges harder, especially if anything now or in the future causes the script to return early.
- `macmenu` could be changed, adding `!` support, so that `macmenu!` would silently ignore missing menus. This would probably introduce more upstream merge challenges, and wouldn't support the "I'd like to completely skip generating these menus" scenario.

I explicitly did _not_ update `delmenu.vim` to reset the new variable. It would be more correct to do so, but would create an upstream merge conflict for no appreciable benefit: if `menu.vim` is resourced at runtime, `macmenu` has no effect anyway. That could be fixed, but that's a much bigger change.

This is a fairly niche change, so I'm entirely convinced it's worth pulling in, but I did the work so I figured I'd see what folks thought.