### PR TITLE
Fix non-native full screen on MacBooks with notch

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -264,6 +264,9 @@ KEY				VALUE ~
 *MMLoginShellCommand*		which shell to use to launch Vim [string]
 *MMNativeFullScreen*		use native full screen mode [bool]
 *MMNonNativeFullScreenShowMenu*	show menus when in non-native full screen [bool]
+*MMNonNativeFullScreenSafeAreaBehavior*
+				behavior for non-native full sreen regarding
+				the safe area (aka the "notch") [int]
 *MMNoFontSubstitution*		disable automatic font substitution [bool]
 				(Deprecated: Non-CoreText renderer only)
 *MMFontPreserveLineSpacing*	use the line-spacing as specified by font [bool]
@@ -330,7 +333,10 @@ There are two types of full screen modes.  By default, MacVim uses macOS'
 native full screen functionality, which creates a separate space in Mission
 Control.  MacVim also provides a non-native full screen mode, which can be set
 by disabling native full screen in the preference panel, or by setting
-|MMNativeFullScreen| to `NO` manually.
+|MMNativeFullScreen| to `NO` manually.  If you have a MacBook with a "notch"
+at the top of the screen, you can set |MMNonNativeFullScreenShowMenu| to `NO`
+and |MMNonNativeFullScreenSafeAreaBehavior| to 1 to utilitize the whole screen
+(this will cause some of the content to be obscured by the notch).
 
 ==============================================================================
 5. Special colors					*macvim-colors*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5364,6 +5364,7 @@ MMLoginShellCommand	gui_mac.txt	/*MMLoginShellCommand*
 MMNativeFullScreen	gui_mac.txt	/*MMNativeFullScreen*
 MMNoFontSubstitution	gui_mac.txt	/*MMNoFontSubstitution*
 MMNoTitleBarWindow	gui_mac.txt	/*MMNoTitleBarWindow*
+MMNonNativeFullScreenSafeAreaBehavior	gui_mac.txt	/*MMNonNativeFullScreenSafeAreaBehavior*
 MMNonNativeFullScreenShowMenu	gui_mac.txt	/*MMNonNativeFullScreenShowMenu*
 MMShareFindPboard	gui_mac.txt	/*MMShareFindPboard*
 MMShowAddTabButton	gui_mac.txt	/*MMShowAddTabButton*

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -250,6 +250,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         [NSNumber numberWithBool:YES],    MMNativeFullScreenKey,
         [NSNumber numberWithDouble:0.0],  MMFullScreenFadeTimeKey,
         [NSNumber numberWithBool:NO],     MMNonNativeFullScreenShowMenuKey,
+        [NSNumber numberWithInt:0],       MMNonNativeFullScreenSafeAreaBehaviorKey,
         [NSNumber numberWithBool:YES],    MMShareFindPboardKey,
         nil];
 

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -38,6 +38,9 @@
 #ifndef MAC_OS_X_VERSION_10_14
 # define MAC_OS_X_VERSION_10_14 101400
 #endif
+#ifndef MAC_OS_VERSION_12_0
+# define MAC_OS_VERSION_12_0 120000
+#endif
 
 #ifndef NSAppKitVersionNumber10_10
 # define NSAppKitVersionNumber10_10 1343

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -57,6 +57,7 @@ extern NSString *MMNativeFullScreenKey;
 extern NSString *MMUseMouseTimeKey;
 extern NSString *MMFullScreenFadeTimeKey;
 extern NSString *MMNonNativeFullScreenShowMenuKey;
+extern NSString *MMNonNativeFullScreenSafeAreaBehaviorKey;
 
 
 // Enum for MMUntitledWindowKey

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -53,6 +53,7 @@ NSString *MMNativeFullScreenKey           = @"MMNativeFullScreen";
 NSString *MMUseMouseTimeKey               = @"MMUseMouseTime";
 NSString *MMFullScreenFadeTimeKey         = @"MMFullScreenFadeTime";
 NSString *MMNonNativeFullScreenShowMenuKey  = @"MMNonNativeFullScreenShowMenu";
+NSString *MMNonNativeFullScreenSafeAreaBehaviorKey = @"MMNonNativeFullScreenSafeAreaBehavior";
 
 
 


### PR DESCRIPTION
This makes sure non-native full screen mode will not use the areas with the notch (which exists in new Apple Silicon MacBooks) when menu bar is configured to not show during non-native full screen. Previously it will use the whole screen which resulted in some texts being clipped by the sensor bar / "notch".

Add a new option `MMNonNativeFullScreenSafeAreaBehavior` which allows the user to get the old behavior back by setting it to 1. This allows for maximum display area on a MacBook display, but some content will be obscured by the notch and the rounded corners. This is a command-line-only option for now as it's relatively niche. In the future we could potentially add new types of behaviors (such as showing the tab bar or toolbar in the notch area).

Also, fix a manual one-pixel offset in the old menu bar size calculation which was a hack to align things to hide the first row of pixels (which arguably looks better if cursorline is on) but it was actually incorrect. Just don't do the one-pixel hack.
