### PR TITLE
Fix vimtutor menu not working

### DIFF
--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -108,8 +108,8 @@ endif
 if has("gui_macvim")
   " Run vimtutor in GUI mode. Need to make sure to override the PATH so we use
   " this app instead of accidentally opening another installed Vim/MacVim.
-  an 9999.5 &Help.Vim\ Tutor       :silent !PATH="$VIM/../../bin":/usr/bin:/bin:/usr/sbin:/sbin $VIM/../../bin/vimtutor -g&<CR>
-  tln 9999.5 &Help.Vim\ Tutor      <C-W>:silent !PATH="$VIM/../../bin":/usr/bin:/bin:/usr/sbin:/sbin $VIM/../../bin/vimtutor -g&<CR>
+  an 9999.5 &Help.Vim\ Tutor       :silent call system('PATH="$VIM/../../bin":/usr/bin:/bin:/usr/sbin:/sbin $VIM/../../bin/vimtutor -g&')<CR>
+  tln 9999.5 &Help.Vim\ Tutor      <C-W>:silent call system('PATH="$VIM/../../bin":/usr/bin:/bin:/usr/sbin:/sbin $VIM/../../bin/vimtutor -g&')<CR>
   an 9999.6 &Help.-sep-vim-tutor-  <Nop>
 endif
 an 9999.10 &Help.&Overview<Tab><F1>	:help<CR>


### PR DESCRIPTION
The "Help.Vim Tutor" menu broke in the latest release.

Previously, the "Help.Vim Tutor" menu was using `:!vimtutor -g &`, but a change in Vim (v8.2.3502) broke that behavior, as the whole script will get terminated as soon as `:!` finishes running. Fix that to use `:call system('vimtutor -g &')` instead, since that still works. See https://github.com/vim/vim/issues/8951 for more discussions.