### PR TITLE
Fix crashing on 10.9

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -734,7 +734,12 @@ static void grid_free(Grid *grid) {
 - (void)drawRect:(NSRect)rect
 {
     NSGraphicsContext *context = [NSGraphicsContext currentContext];
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_10
     CGContextRef ctx = context.CGContext;
+#else
+    CGContextRef ctx = [context graphicsPort];
+#endif
+
     [context setShouldAntialias:antialias];
     {
         CGColorSpaceRef colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);

--- a/src/MacVim/MMFullScreenWindow.m
+++ b/src/MacVim/MMFullScreenWindow.m
@@ -382,7 +382,7 @@ enum {
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_12_0)
     // Account for newer MacBook Pro's which have a notch, which can be queried using the safe area API.
-    if ([NSScreen instancesRespondToSelector:@selector(safeAreaInsets)]) {
+    if (@available(macos 12.0, *)) {
         const int safeAreaBehavior = [[NSUserDefaults standardUserDefaults]
                                       integerForKey:MMNonNativeFullScreenSafeAreaBehaviorKey];
 

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -571,8 +571,12 @@
     // has selected as a preference.
     
     // Transparent title bar setting
-    decoratedWindow.titlebarAppearsTransparent = [[NSUserDefaults standardUserDefaults]
-                                                  boolForKey:MMTitlebarAppearsTransparentKey];
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
+    if (@available(macos 10.10, *)) {
+        decoratedWindow.titlebarAppearsTransparent = [[NSUserDefaults standardUserDefaults]
+                                                      boolForKey:MMTitlebarAppearsTransparentKey];
+    }
+#endif
     
     // No title bar setting
     if ([[NSUserDefaults standardUserDefaults]


### PR DESCRIPTION
This fixes MacVim to work again on OSX 10.9. It was previously crashing on launch for last few versions.

`titlebarAppearsTransparent` call: This API was added in 10.10, and previously MacVim wasn't properly guarding it with the proper OS version check, causing it to crash under 10.9 (which is the lowest currently supported macOS version).

CGContext call: The new stateful renderer is using a newer API to retrieve the CGContext from the NS wrapper, but that was also only added in 10.10. When compiling against older versions, just use the older, now-deprecated API "graphicsPort" instead. It still works.

Also, change the version check for `safeAreaInsets` for non-native full screen to use `@available` as well instead of checking for selector. This is more consistent with how other code works and fixes a compiler warning about not checking for OS version.

Fix #1212
