### PR TITLE
CI: Update environments to macos-11 and macos-12

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -17,8 +17,8 @@ env:
   vi_cv_path_ruby: /usr/local/opt/ruby/bin/ruby
   vi_cv_dll_name_perl: /System/Library/Perl/5.18/darwin-thread-multi-2level/CORE/libperl.dylib
   vi_cv_dll_name_python: /System/Library/Frameworks/Python.framework/Versions/2.7/Python
-  vi_cv_dll_name_python3: /usr/local/Frameworks/Python.framework/Versions/3.9/Python
-  vi_cv_dll_name_python3_arm64: /opt/homebrew/Frameworks/Python.framework/Versions/3.9/Python
+  vi_cv_dll_name_python3: /usr/local/Frameworks/Python.framework/Versions/3.10/Python
+  vi_cv_dll_name_python3_arm64: /opt/homebrew/Frameworks/Python.framework/Versions/3.10/Python
   vi_cv_dll_name_ruby: /usr/local/opt/ruby/lib/libruby.dylib
   vi_cv_dll_name_ruby_arm64: /opt/homebrew/opt/ruby/lib/libruby.dylib
   vi_cv_dll_name_lua_arm64: /opt/homebrew/lib/liblua.dylib
@@ -33,17 +33,16 @@ jobs:
   # Builds and test MacVim
   build-and-test:
 
-    # Test on macOS 10.15 / 11.x, and also older version of Xcode for compatibility testing.
+    # Test on macOS 11.x / 12.x, and also older version of Xcode for compatibility testing.
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: macos-10.15
-            xcode: '11.7'
-          - os: macos-10.15
           - os: macos-11
             xcode: '13.0'
             publish: true
+          - os: macos-11
+          - os: macos-12
 
     runs-on: ${{ matrix.os }}
 

--- a/src/MacVim/MMBackend.h
+++ b/src/MacVim/MMBackend.h
@@ -143,7 +143,7 @@
               silent:(BOOL)silent;
 - (NSArray *)serverList;
 - (NSString *)peekForReplyOnPort:(int)port;
-- (NSString *)waitForReplyOnPort:(int)port;
+- (NSString *)waitForReplyOnPort:(int)port timeout:(NSTimeInterval)timeout;
 - (BOOL)sendReply:(NSString *)reply toPort:(int)port;
 
 - (BOOL)waitForAck;

--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -1582,7 +1582,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
     return nil;
 }
 
-- (NSString *)waitForReplyOnPort:(int)port
+- (NSString *)waitForReplyOnPort:(int)port timeout:(NSTimeInterval)timeout
 {
     ASLogDebug(@"port=%d", port);
     
@@ -1593,13 +1593,16 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
     NSNumber *key = [NSNumber numberWithInt:port];
     NSMutableArray *replies = nil;
     NSString *reply = nil;
+    NSDate *limitDate = timeout > 0
+        ? [NSDate dateWithTimeIntervalSinceNow:timeout] : [NSDate distantFuture];
 
     // Wait for reply as long as the connection to the server is valid (unless
     // user interrupts wait with Ctrl-C).
     while (!got_int && [conn isValid] &&
-            !(replies = [serverReplyDict objectForKey:key])) {
+            !(replies = [serverReplyDict objectForKey:key]) &&
+            (timeout <= 0 || [limitDate timeIntervalSinceNow] > 0)) {
         [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
-                                 beforeDate:[NSDate distantFuture]];
+                                 beforeDate:limitDate];
     }
 
     if (replies) {

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -2118,9 +2118,10 @@ serverPeekReply(int port, char_u **str)
  * Return -1 on error.
  */
     int
-serverReadReply(int port, char_u **str)
+serverReadReply(int port, char_u **str, int timeout)
 {
-    NSString *reply = [[MMBackend sharedInstance] waitForReplyOnPort:port];
+    NSString *reply = [[MMBackend sharedInstance] waitForReplyOnPort:port
+							     timeout:timeout];
     if (reply && str) {
         *str = [reply vimStringSave];
         return 0;

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -2533,3 +2533,14 @@ gui_macvim_set_background(int dark)
 {
     [[MMBackend sharedInstance] setBackground:dark];
 }
+
+
+// -- Netbeans Integration Support -------------------------------------------
+
+#if defined(FEAT_NETBEANS_INTG) || defined(PROTO)
+    void
+netbeans_draw_multisign_indicator(int row UNUSED)
+{
+    // NOP
+}
+#endif // FEAT_NETBEANS_INTG

--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -457,7 +457,7 @@ cmdsrv_main(
 		    if (p == NULL)
 			break;
 # elif defined(MAC_CLIENTSERVER)
-                    if (serverReadReply(srv, &p) < 0)
+                    if (serverReadReply(srv, &p, 0) < 0)
                         break;
 # else
 		    if (serverReadReply(xterm_dpy, srv, &p, TRUE, -1) < 0)
@@ -934,7 +934,7 @@ f_remote_read(typval_T *argvars UNUSED, typval_T *rettv)
 	    r = serverGetReply((HWND)n, FALSE, TRUE, TRUE, timeout);
 	if (r == NULL)
 # elif defined(MAC_CLIENTSERVER)
-        if (serverReadReply(serverStrToPort(serverid), &r) < 0)
+        if (serverReadReply(serverStrToPort(serverid), &r, timeout) < 0)
 # else
 	if (check_connection() == FAIL
 		|| serverReadReply(X_DISPLAY, serverStrToWin(serverid),

--- a/src/gui.c
+++ b/src/gui.c
@@ -2327,7 +2327,9 @@ gui_outstr_nowrap(
     guicolor_T	sp_color;
 #if !defined(FEAT_GUI_GTK)
     GuiFont	font = NOFONT;
+# if !defined(FEAT_GUI_MACVIM)
     GuiFont	wide_font = NOFONT;
+# endif
 # ifdef FEAT_XFONTSET
     GuiFontset	fontset = NOFONTSET;
 # endif
@@ -2431,7 +2433,7 @@ gui_outstr_nowrap(
 	}
 	else
 	    font = gui.norm_font;
-
+# if !defined(FEAT_GUI_MACVIM)
 	/*
 	 * Choose correct wide_font by font.  wide_font should be set with font
 	 * at same time in above block.  But it will make many "ifdef" nasty
@@ -2445,6 +2447,7 @@ gui_outstr_nowrap(
 	    wide_font = gui.wide_ital_font;
 	else if (font == gui.norm_font && gui.wide_font)
 	    wide_font = gui.wide_font;
+# endif
     }
 # ifdef FEAT_XFONTSET
     if (fontset != NOFONTSET)
@@ -2701,6 +2704,7 @@ gui_outstr_nowrap(
 	// Draw the sign on top of the spaces.
 	gui_mch_drawsign(gui.row, signcol, gui.highlight_mask);
 # if defined(FEAT_NETBEANS_INTG) && (defined(FEAT_GUI_X11) \
+	|| defined(FEAT_GUI_MACVIM) \
 	|| defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN))
     if (multi_sign)
 	netbeans_draw_multisign_indicator(gui.row);

--- a/src/proto/gui_macvim.pro
+++ b/src/proto/gui_macvim.pro
@@ -133,3 +133,5 @@ void gui_mch_destroy_sign(void *sign);
 
 void *gui_macvim_new_autoreleasepool();
 void gui_macvim_release_autoreleasepool(void *pool);
+
+void netbeans_draw_multisign_indicator(int row);

--- a/src/proto/gui_macvim.pro
+++ b/src/proto/gui_macvim.pro
@@ -91,7 +91,7 @@ int serverSendToVim(char_u *name, char_u *cmd, char_u **result, int *server, int
 char_u *serverGetVimNames(void);
 int serverStrToPort(char_u *str);
 int serverPeekReply(int port, char_u **str);
-int serverReadReply(int port, char_u **str);
+int serverReadReply(int port, char_u **str, int timeout);
 int serverSendReply(char_u *serverid, char_u *str);
 
 void gui_mch_enter_fullscreen(guicolor_T bg);


### PR DESCRIPTION
> The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead.

And fix build errors on `macos-12`: Apple clang-13 sets `-Wunused-but-set-variable` by default so when with `-Werror` a build fails.