### PR TITLE
Add automation to auto-close PR/issues if they are waiting for response

### DIFF
--- a/.github/workflows/macvim-issues.yaml
+++ b/.github/workflows/macvim-issues.yaml
@@ -1,0 +1,20 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "45 3 * * *" # 3:45 am UTC. Just a random time intentionally picked to be not during busy hours.
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v4
+        with:
+          any-of-labels: "Response Needed"
+          days-before-stale: 45
+          days-before-close: 7
+          stale-issue-message: "This issue is stale because it has been waiting for a response for 45 days with no activity."
+          stale-pr-message: "This pull request is stale because it has been waiting for a response for 45 days with no activity."
+          close-issue-reason: "not_planned"


### PR DESCRIPTION
If a PR or issue has been tagged with "Response Needed" on GitHub, this will auto-mark as stale in 45 days, and then close it in 7 days afterwards. This allows us to simply mark an issue as "Response Needed" and not need to come back after a while to close the issue which is time consuming and easy to forget, leading to lots of stale open issues.

Don't turn this on for all issues. Only do this for those explicitly tagged as needing response.