### PR TITLE
Fix GitHub action to close stale issue not working

### DIFF
--- a/.github/workflows/macvim-issues.yaml
+++ b/.github/workflows/macvim-issues.yaml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v5
         with:
           any-of-labels: "Response Needed"
           days-before-stale: 45


### PR DESCRIPTION
I previously added the use of the "close-issue-reason" parameter but it's only available in v5, whereas I was pointing to v4.