### PR TITLE
Allows smooth resizing of MacVim's window

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -273,6 +273,7 @@ KEY				VALUE ~
 *MMNoTitleBarWindow*		hide title bar [bool]
 *MMTitlebarAppearsTransparent*	enable a transparent titlebar [bool]
 *MMAppearanceModeSelection*	dark mode selection (|macvim-dark-mode|)[bool]
+*MMSmoothResize*		allow smooth resizing of MacVim window [bool]
 *MMShareFindPboard*		share search text to Find Pasteboard [bool]
 *MMShowAddTabButton*		enable "add tab" button on tabline [bool]
 *MMTabMaxWidth*			maximum width of a tab [int]

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5418,6 +5418,7 @@ MMNonNativeFullScreenSafeAreaBehavior	gui_mac.txt	/*MMNonNativeFullScreenSafeAre
 MMNonNativeFullScreenShowMenu	gui_mac.txt	/*MMNonNativeFullScreenShowMenu*
 MMShareFindPboard	gui_mac.txt	/*MMShareFindPboard*
 MMShowAddTabButton	gui_mac.txt	/*MMShowAddTabButton*
+MMSmoothResize	gui_mac.txt	/*MMSmoothResize*
 MMTabMaxWidth	gui_mac.txt	/*MMTabMaxWidth*
 MMTabMinWidth	gui_mac.txt	/*MMTabMinWidth*
 MMTabOptimumWidth	gui_mac.txt	/*MMTabOptimumWidth*

--- a/src/MacVim/Base.lproj/Preferences.xib
+++ b/src/MacVim/Base.lproj/Preferences.xib
@@ -20,12 +20,12 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <userDefaultsController representsSharedInstance="YES" id="58" userLabel="Shared Defaults"/>
         <customView id="115" userLabel="General">
-            <rect key="frame" x="0.0" y="0.0" width="483" height="314"/>
+            <rect key="frame" x="0.0" y="0.0" width="483" height="337"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <customView id="5x5-P0-afk" userLabel="Open untitled window">
-                    <rect key="frame" x="19" y="234" width="433" height="58"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <rect key="frame" x="20" y="259" width="433" height="58"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="117">
                             <rect key="frame" x="-2" y="41" width="187" height="17"/>
@@ -70,8 +70,8 @@
                     </subviews>
                 </customView>
                 <customView id="p6o-fo-STi" userLabel="Open files from applications">
-                    <rect key="frame" x="19" y="94" width="433" height="132"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <rect key="frame" x="20" y="119" width="433" height="132"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="116">
                             <rect key="frame" x="-2" y="115" width="187" height="17"/>
@@ -149,8 +149,8 @@
                     </subviews>
                 </customView>
                 <customView id="dlz-JQ-U4e" userLabel="After last window closes">
-                    <rect key="frame" x="19" y="66" width="381" height="22"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <rect key="frame" x="20" y="89" width="381" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="126">
                             <rect key="frame" x="-2" y="3" width="187" height="17"/>
@@ -182,9 +182,37 @@
                         </popUpButton>
                     </subviews>
                 </customView>
+                <customView id="6BL-o0-OrR" userLabel="Window Resizing">
+                    <rect key="frame" x="20" y="64" width="444" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <subviews>
+                        <button id="f9h-8n-asD" userLabel="allow smooth resizing">
+                            <rect key="frame" x="188" y="-1" width="258" height="18"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <string key="toolTip">Smoothly resizes MacVim's window instead of fixing it to the grid size. It's also recommended to set "guioptions+=k" in your vimrc when this is set.</string>
+                            <buttonCell key="cell" type="check" title="Smoothly resizes window" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="4YN-AX-Vrz">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="smoothResizeChanged:" target="-2" id="paG-Lx-hcb"/>
+                                <binding destination="58" name="value" keyPath="values.MMSmoothResize" id="Wkt-gU-ZnK"/>
+                            </connections>
+                        </button>
+                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="Lmi-H0-cPd" userLabel="Window resizing">
+                            <rect key="frame" x="-2" y="0.0" width="187" height="17"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Resizing window:" id="ExQ-6y-pyN" userLabel="Window resizing:">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                    </subviews>
+                </customView>
                 <customView id="0hT-y8-Hge" userLabel="Updater">
-                    <rect key="frame" x="19" y="22" width="444" height="36"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <rect key="frame" x="20" y="20" width="444" height="36"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <button id="122">
                             <rect key="frame" x="188" y="18" width="258" height="18"/>
@@ -226,7 +254,7 @@
                     </subviews>
                 </customView>
             </subviews>
-            <point key="canvasLocation" x="138" y="20"/>
+            <point key="canvasLocation" x="137.5" y="21.5"/>
         </customView>
         <customView id="hr4-G4-3ZG" userLabel="Appearance">
             <rect key="frame" x="0.0" y="0.0" width="483" height="315"/>

--- a/src/MacVim/MMAppController.h
+++ b/src/MacVim/MMAppController.h
@@ -60,6 +60,7 @@
 
 - (void)refreshAllAppearances;
 - (void)refreshAllFonts;
+- (void)refreshAllResizeConstraints;
 
 - (IBAction)newWindow:(id)sender;
 - (IBAction)newWindowAndActivate:(id)sender;

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -252,6 +252,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         [NSNumber numberWithBool:NO],     MMNonNativeFullScreenShowMenuKey,
         [NSNumber numberWithInt:0],       MMNonNativeFullScreenSafeAreaBehaviorKey,
         [NSNumber numberWithBool:YES],    MMShareFindPboardKey,
+        [NSNumber numberWithBool:NO],     MMSmoothResizeKey,
         nil];
 
     [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
@@ -1129,6 +1130,15 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
     for (unsigned i = 0; i < count; ++i) {
         MMVimController *vc = [vimControllers objectAtIndex:i];
         [vc.windowController refreshFonts];
+    }
+}
+
+- (void)refreshAllResizeConstraints
+{
+    const unsigned count = [vimControllers count];
+    for (unsigned i = 0; i < count; ++i) {
+        MMVimController *vc = [vimControllers objectAtIndex:i];
+        [vc.windowController updateResizeConstraints:YES];
     }
 }
 

--- a/src/MacVim/MMPreferenceController.h
+++ b/src/MacVim/MMPreferenceController.h
@@ -27,4 +27,11 @@
 - (IBAction)openInCurrentWindowSelectionChanged:(id)sender;
 - (IBAction)checkForUpdatesChanged:(id)sender;
 - (IBAction)appearanceChanged:(id)sender;
+- (IBAction)lastWindowClosedChanged:(id)sender;
+- (IBAction)openUntitledWindowChanged:(id)sender;
+- (IBAction)smoothResizeChanged:(id)sender;
+
+// Appearance pane
+- (IBAction)fontPropertiesChanged:(id)sender;
+
 @end

--- a/src/MacVim/MMPreferenceController.m
+++ b/src/MacVim/MMPreferenceController.m
@@ -163,4 +163,9 @@
     }
 }
 
+- (IBAction)smoothResizeChanged:(id)sender
+{
+    [[MMAppController sharedInstance] refreshAllResizeConstraints];
+}
+
 @end

--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -77,6 +77,7 @@
 
 - (void)setBackgroundOption:(int)dark;
 - (void)refreshApperanceMode;
+- (void)updateResizeConstraints:(BOOL)resizeWindow;
 
 - (void)setDefaultColorsBackground:(NSColor *)back foreground:(NSColor *)fore;
 - (void)setFont:(NSFont *)font;

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -58,6 +58,7 @@ extern NSString *MMUseMouseTimeKey;
 extern NSString *MMFullScreenFadeTimeKey;
 extern NSString *MMNonNativeFullScreenShowMenuKey;
 extern NSString *MMNonNativeFullScreenSafeAreaBehaviorKey;
+extern NSString *MMSmoothResizeKey;
 
 
 // Enum for MMUntitledWindowKey

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -54,6 +54,7 @@ NSString *MMUseMouseTimeKey               = @"MMUseMouseTime";
 NSString *MMFullScreenFadeTimeKey         = @"MMFullScreenFadeTime";
 NSString *MMNonNativeFullScreenShowMenuKey  = @"MMNonNativeFullScreenShowMenu";
 NSString *MMNonNativeFullScreenSafeAreaBehaviorKey = @"MMNonNativeFullScreenSafeAreaBehavior";
+NSString *MMSmoothResizeKey               = @"MMSmoothResize";
 
 
 


### PR DESCRIPTION
Adds a setting that allows for smoothly resizing the window. Previously, MacVim would only allow resizing in fixed increment of the grid size and snap to such sizes. This was a little more consistent with how terminals tend to work, and allows for optimal window sizing, and it was also an artifact of the old MacVim renderer where it didn't have a stateful renderer that could repaint the text view.

The snapping could be jarring for users more used to modern text editors which allow for smoothly resizing of the window though, and it makes third party tools that could snap macOS windows to the side not work properly as there's usually a gap near the bottom. With guioption-k, MacVim already allows for decoupling the window size from the Vim's grid size anyway, so adding smooth resizing allows to work much better under those assumptions.

In addition to allowing smooth resizing, this change also makes it so that the CoreText renderer will fill to the right a little bit when rendering the rightmost column when MacVim's window size isn't exactly the Vim grid size. Previously, if a color scheme has NonText color (e.g. desert), or the user has 'cursorline' set, smooth resize (or in full screen or guioption-k) would leave a gap to the right, looking a little ugly. This allows the last column's to fully fill to the right, resulting in a much more consistent look when resizing the window.

Close #948