### PR TITLE
Allow pinning the cmdline to be aligned to the bottom of window

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -256,12 +256,14 @@ Here is a list of relevant dictionary entries:
 
 KEY				VALUE ~
 *MMCellWidthMultiplier*		width of a normal glyph in em units [float]
+*MMCmdLineAlignBottom*		Pin command-line to bottom of MacVim [bool]
 *MMDialogsTrackPwd*		open/save dialogs track the Vim pwd [bool]
 *MMDisableLaunchAnimation*	disable launch animation when opening a new
 				MacVim window [bool]
-*MMFullScreenFadeTime*		fade delay for non-native fullscreen [float]
+*MMFontPreserveLineSpacing*	use the line-spacing as specified by font [bool]
 *MMLoginShellArgument*		login shell parameter [string]
 *MMLoginShellCommand*		which shell to use to launch Vim [string]
+*MMFullScreenFadeTime*		fade delay for non-native fullscreen [float]
 *MMNativeFullScreen*		use native full screen mode [bool]
 *MMNonNativeFullScreenShowMenu*	show menus when in non-native full screen [bool]
 *MMNonNativeFullScreenSafeAreaBehavior*
@@ -269,7 +271,6 @@ KEY				VALUE ~
 				the safe area (aka the "notch") [int]
 *MMNoFontSubstitution*		disable automatic font substitution [bool]
 				(Deprecated: Non-CoreText renderer only)
-*MMFontPreserveLineSpacing*	use the line-spacing as specified by font [bool]
 *MMNoTitleBarWindow*		hide title bar [bool]
 *MMTitlebarAppearsTransparent*	enable a transparent titlebar [bool]
 *MMAppearanceModeSelection*	dark mode selection (|macvim-dark-mode|)[bool]

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5405,6 +5405,7 @@ M	motion.txt	/*M*
 MDI	starting.txt	/*MDI*
 MMAppearanceModeSelection	gui_mac.txt	/*MMAppearanceModeSelection*
 MMCellWidthMultiplier	gui_mac.txt	/*MMCellWidthMultiplier*
+MMCmdLineAlignBottom	gui_mac.txt	/*MMCmdLineAlignBottom*
 MMDialogsTrackPwd	gui_mac.txt	/*MMDialogsTrackPwd*
 MMDisableLaunchAnimation	gui_mac.txt	/*MMDisableLaunchAnimation*
 MMFontPreserveLineSpacing	gui_mac.txt	/*MMFontPreserveLineSpacing*

--- a/src/MacVim/Base.lproj/Preferences.xib
+++ b/src/MacVim/Base.lproj/Preferences.xib
@@ -257,11 +257,11 @@
             <point key="canvasLocation" x="137.5" y="21.5"/>
         </customView>
         <customView id="hr4-G4-3ZG" userLabel="Appearance">
-            <rect key="frame" x="0.0" y="0.0" width="483" height="315"/>
+            <rect key="frame" x="0.0" y="0.0" width="483" height="341"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <customView id="fw0-VK-Nbz" userLabel="Dark mode selection">
-                    <rect key="frame" x="19" y="137" width="433" height="156"/>
+                    <rect key="frame" x="19" y="163" width="433" height="156"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="T40-Os-PUf" userLabel="Dark mode selection">
@@ -322,7 +322,7 @@
                     </subviews>
                 </customView>
                 <customView id="7af-iK-4r7" userLabel="Titlebar appearance">
-                    <rect key="frame" x="19" y="91" width="433" height="38"/>
+                    <rect key="frame" x="19" y="117" width="433" height="38"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <button id="7ie-0J-0Zr">
@@ -361,7 +361,7 @@
                     </subviews>
                 </customView>
                 <customView id="BpJ-rH-ona" userLabel="Full Screen">
-                    <rect key="frame" x="19" y="45" width="433" height="38"/>
+                    <rect key="frame" x="19" y="71" width="433" height="38"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <button toolTip="Use macOS's native full screen mode, which integrates with Mission Control and creates a new Space for the window." id="YKV-u2-Egc" userLabel="Use native full screen">
@@ -405,7 +405,7 @@
                     </subviews>
                 </customView>
                 <customView id="a3v-cB-TFa" userLabel="Font">
-                    <rect key="frame" x="19" y="20" width="433" height="18"/>
+                    <rect key="frame" x="19" y="46" width="433" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <button id="A48-s0-kdR" userLabel="Preserve Line Spacing">
@@ -432,8 +432,36 @@
                         </textField>
                     </subviews>
                 </customView>
+                <customView id="Dey-Wx-2gx" userLabel="Cmdline">
+                    <rect key="frame" x="20" y="20" width="433" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <subviews>
+                        <button id="qMh-iV-0iD">
+                            <rect key="frame" x="189" y="-1" width="244" height="18"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <string key="toolTip">When using smooth resizing, guioption+=k, or full screen; MacVim's window size can sometimes be slightly larger than Vim's content size, causing the command-line to not be aligned to the bottom. This option will make sure the command-line is always pinned to the bottom.</string>
+                            <buttonCell key="cell" type="check" title="Pin to the bottom of the window" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="uZL-IX-Dv8">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="cmdlineAlignBottomChanged:" target="-2" id="LgN-MI-0Nt"/>
+                                <binding destination="58" name="value" keyPath="values.MMCmdLineAlignBottom" id="pIr-52-5vV"/>
+                            </connections>
+                        </button>
+                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="Lzq-i0-zWi" userLabel="Cmdline">
+                            <rect key="frame" x="-2" y="0.0" width="187" height="17"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Command-line:" id="2Lp-vX-AcA">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                    </subviews>
+                </customView>
             </subviews>
-            <point key="canvasLocation" x="137.5" y="412.5"/>
+            <point key="canvasLocation" x="137.5" y="425.5"/>
         </customView>
         <customView id="620" userLabel="Advanced">
             <rect key="frame" x="0.0" y="0.0" width="483" height="264"/>
@@ -504,7 +532,7 @@
                     </connections>
                 </button>
             </subviews>
-            <point key="canvasLocation" x="137.5" y="743"/>
+            <point key="canvasLocation" x="144" y="911"/>
         </customView>
     </objects>
 </document>

--- a/src/MacVim/MMAppController.h
+++ b/src/MacVim/MMAppController.h
@@ -61,6 +61,7 @@
 - (void)refreshAllAppearances;
 - (void)refreshAllFonts;
 - (void)refreshAllResizeConstraints;
+- (void)refreshAllTextViews;
 
 - (IBAction)newWindow:(id)sender;
 - (IBAction)newWindowAndActivate:(id)sender;

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -40,6 +40,7 @@
 #import "MMAppController.h"
 #import "MMPreferenceController.h"
 #import "MMVimController.h"
+#import "MMVimView.h"
 #import "MMWindowController.h"
 #import "MMTextView.h"
 #import "Miscellaneous.h"
@@ -253,6 +254,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         [NSNumber numberWithInt:0],       MMNonNativeFullScreenSafeAreaBehaviorKey,
         [NSNumber numberWithBool:YES],    MMShareFindPboardKey,
         [NSNumber numberWithBool:NO],     MMSmoothResizeKey,
+        [NSNumber numberWithBool:NO],     MMCmdLineAlignBottomKey,
         nil];
 
     [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
@@ -1124,6 +1126,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
     }
 }
 
+/// Refresh all Vim text views' fonts.
 - (void)refreshAllFonts
 {
     unsigned count = [vimControllers count];
@@ -1133,12 +1136,26 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
     }
 }
 
+/// Refresh all resize constraints based on smooth resize configurations
+/// and resize the windows to match the constraints.
 - (void)refreshAllResizeConstraints
 {
     const unsigned count = [vimControllers count];
     for (unsigned i = 0; i < count; ++i) {
         MMVimController *vc = [vimControllers objectAtIndex:i];
         [vc.windowController updateResizeConstraints:YES];
+    }
+}
+
+/// Refresh all text views and re-render them, as well as updating their
+/// cmdline alignment properties to make sure they are pinned properly.
+- (void)refreshAllTextViews
+{
+    unsigned count = [vimControllers count];
+    for (unsigned i = 0; i < count; ++i) {
+        MMVimController *vc = [vimControllers objectAtIndex:i];
+        [vc.windowController.vimView.textView updateCmdlineRow];
+        vc.windowController.vimView.textView.needsDisplay = YES;
     }
 }
 

--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -86,6 +86,7 @@
 - (BOOL)convertPoint:(NSPoint)point toRow:(int *)row column:(int *)column;
 - (NSRect)rectForRow:(int)row column:(int)column numRows:(int)nr
           numColumns:(int)nc;
+- (void)updateCmdlineRow;
 
 //
 // NSTextView methods

--- a/src/MacVim/MMPreferenceController.m
+++ b/src/MacVim/MMPreferenceController.m
@@ -168,4 +168,9 @@
     [[MMAppController sharedInstance] refreshAllResizeConstraints];
 }
 
+- (IBAction)cmdlineAlignBottomChanged:(id)sender
+{
+    [[MMAppController sharedInstance] refreshAllTextViews];
+}
+
 @end

--- a/src/MacVim/MMTextView.h
+++ b/src/MacVim/MMTextView.h
@@ -39,6 +39,8 @@
 - (void)setImControl:(BOOL)enable;
 - (void)activateIm:(BOOL)enable;
 - (void)checkImState;
+- (void)refreshFonts;
+- (void)updateCmdlineRow;
 
 //
 // MMTextStorage methods
@@ -47,7 +49,6 @@
 - (void)setFont:(NSFont *)newFont;
 - (NSFont *)fontWide;
 - (void)setWideFont:(NSFont *)newFont;
-- (void)refreshFonts;
 - (NSSize)cellSize;
 - (void)setLinespace:(float)newLinespace;
 - (void)setColumnspace:(float)newColumnspace;

--- a/src/MacVim/MMTextView.m
+++ b/src/MacVim/MMTextView.m
@@ -357,6 +357,11 @@
     // Doesn't do anything. CoreText renderer only.
 }
 
+- (void)updateCmdlineRow
+{
+    // Doesn't do anything. CoreText renderer only.
+}
+
 - (NSSize)cellSize
 {
     return [(MMTextStorage*)[self textStorage] cellSize];

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -59,6 +59,7 @@ extern NSString *MMFullScreenFadeTimeKey;
 extern NSString *MMNonNativeFullScreenShowMenuKey;
 extern NSString *MMNonNativeFullScreenSafeAreaBehaviorKey;
 extern NSString *MMSmoothResizeKey;
+extern NSString *MMCmdLineAlignBottomKey;
 
 
 // Enum for MMUntitledWindowKey

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -55,7 +55,7 @@ NSString *MMFullScreenFadeTimeKey         = @"MMFullScreenFadeTime";
 NSString *MMNonNativeFullScreenShowMenuKey  = @"MMNonNativeFullScreenShowMenu";
 NSString *MMNonNativeFullScreenSafeAreaBehaviorKey = @"MMNonNativeFullScreenSafeAreaBehavior";
 NSString *MMSmoothResizeKey               = @"MMSmoothResize";
-
+NSString *MMCmdLineAlignBottomKey         = @"MMCmdLineAlignBottom";
 
 
 @implementation NSIndexSet (MMExtras)


### PR DESCRIPTION
Add a setting that could pin the command-line portion of Vim to the bottom of the MacVim window. This is useful when smooth resizing is set, guioption+=k, or in full screen. In those situations, the MacVim window size is usually not direct multiples of the Vim text sizes. Previously the command-line would be drawn like other texts, and hence not aligned to the bottom and hence looking aesthetically a little off.

When this setting is set, the command-line portion would be aligned to the bottom of the window. This essentially moves the gap (due to the extra height of the window) from the bottom to be between cmdline and the rest of Vim. When cmdheight is changed, or other situations (e.g. typing too much cmdline height to be increased), the gap will be adjusted as well.

Implementation-wise, this was done by passing the `commandline_row` var from Vim to MacVim, which serves as a good estimate of where the command-line is. This works better than just using the `cmdheight` option as it is closer to the current state of the cmdline. One issue is that in hit-enter prompts, the row is set to the 2nd to last row to anticipate more messages, and we just add a big hack by incrementing the row by 1 in hit-enter state so only the "Press Enter..." part is aligned to bottom. We also have to do something similar to when it's showing "--more--" for similar reasons.

- An alternative would have been to modify Vim to provide us the information we want (the number of rows below the status line) but it's pretty tricky to do as cmdline_row is used in lots of places. It's easier / simpler to do a simple hack like this to localize the damage.

Close #833