### PR TITLE
Fix broken preference pane sizing when sparkle disabled

### DIFF
--- a/src/MacVim/MMPreferenceController.m
+++ b/src/MacVim/MMPreferenceController.m
@@ -26,11 +26,6 @@
     NSRect frame = generalPreferences.frame;
     frame.size.height -= sparkleHeight;
     generalPreferences.frame = frame;
-    for (NSView *subview in generalPreferences.subviews) {
-        frame = subview.frame;
-        frame.origin.y -= sparkleHeight;
-        subview.frame = frame;
-    }
 #endif
     [super windowDidLoad];
 


### PR DESCRIPTION
The recent change that added smooth resizing changed the alignment for the General preference pane from bottom to top aligned as it never made sense to be bottom aligned. However, there was code in in the preference controller to correct for that when resizing the pane when sparkle is disabled, which caused the resizing to not work. Fix that to account for the top alignment instead of bottom.

Fix #1281