### PR TITLE
Update Python vimrc detection to 3.10

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -17,7 +17,7 @@ env:
   vi_cv_path_ruby: /usr/local/opt/ruby/bin/ruby
   vi_cv_dll_name_perl: /System/Library/Perl/5.18/darwin-thread-multi-2level/CORE/libperl.dylib
   vi_cv_dll_name_python: /System/Library/Frameworks/Python.framework/Versions/2.7/Python
-  vi_cv_dll_name_python3: /usr/local/Frameworks/Python.framework/Versions/3.10/Python
+  vi_cv_dll_name_python3: /usr/local/Frameworks/Python.framework/Versions/3.10/Python # Make sure to keep src/MacVim/vimrc synced with the Python version here for the Python DLL detection logic.
   vi_cv_dll_name_python3_arm64: /opt/homebrew/Frameworks/Python.framework/Versions/3.10/Python
   vi_cv_dll_name_ruby: /usr/local/opt/ruby/lib/libruby.dylib
   vi_cv_dll_name_ruby_arm64: /opt/homebrew/opt/ruby/lib/libruby.dylib

--- a/src/MacVim/vimrc
+++ b/src/MacVim/vimrc
@@ -32,12 +32,13 @@ endif
 " or an installation from python.org:
 if exists("&pythonthreedll") && exists("&pythonthreehome") &&
       \ !filereadable(&pythonthreedll)
-  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.9/Python")
-    " MacPorts python 3.9
-    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.9/Python
-  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.9/Python")
+  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.10/Python")
+    " MacPorts python 3.10
+    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.10/Python
+  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.10/Python")
     " https://www.python.org/downloads/mac-osx/
-    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.9/Python
+    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.10/Python
   endif
 endif
 
+" vim: sw=2 ts=2 et


### PR DESCRIPTION
CI build has been updated to build MacVim against Python 3.10, so we want to update the other detection to use 3.10 as well. Also added a comment to CI file to make sure we remember to update the vimrc file when updating the version.