### PR TITLE
Fix MacVim CI not re-generating help tags properly

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -158,7 +158,27 @@ jobs:
           cat src/auto/config.mk
           cat src/auto/config.h
 
-      - name: Build
+      # Build Vim first, separately from MacVim, so that we can use it to run
+      # vimtags afterwards to get the most correct help tags before we copy
+      # that into the MacVim bundle.
+      - name: Build Vim
+        env:
+          LC_ALL: C
+        run: |
+          set -o verbose
+
+          NPROC=$(getconf _NPROCESSORS_ONLN)
+          echo "Building Vim with ${NPROC} cores"
+
+          make -C src -j${NPROC} Vim
+
+      # Re-generate Vim help tags, because sometimes the Vim's runtime is not
+      # updated to have the latest tags.
+      - name: Update Vim help tags
+        if: matrix.publish
+        run: make -C runtime/doc vimtags VIMEXE=../../src/vim
+
+      - name: Build MacVim
         env:
           LC_ALL: C
         run: |
@@ -209,10 +229,6 @@ jobs:
           }
           check_arch "${VIM_BIN}"
           check_arch "${MACVIM_BIN}"
-
-      - name: Update Vim help tags
-        if: matrix.publish
-        run: make -C runtime/doc vimtags VIMEXE=../../${VIM_BIN}
 
       - name: Test
         timeout-minutes: 20


### PR DESCRIPTION
We previously added a step to rebuild the Vim help tags when publishing so that we could get the latest tags when generating a MacVim release (sometimes Vim's runtime is lagging behind and doesn't have that done).

However, the step was so placed so far back (after building/testing) that it doesn't actually do anything, as MacVim was already built. Move it earlier so we build MacVim after vimtags are re-generated. As part of doing this we also need to split building Vim itself earlier as vimtags generation requires having a Vim binary.

So the updated steps are 1. Vim, 2. help tags, 3. MacVim, 4. Tests. Previously they were 1. Vim/MacVim, 2. Tests, 3. help tags.