### PR TITLE
Support strikethrough/underdouble/underdashed/underdotted styles

### DIFF
--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -27,7 +27,9 @@
     // From NSTextView
     NSSize                      insetSize;
 
-    float                       fontDescent;
+    CGFloat                     fontDescent;
+    CGFloat                     fontAscent;
+    CGFloat                     fontXHeight;
     BOOL                        antialias;
     BOOL                        ligatures;
     BOOL                        thinStrokes;

--- a/src/gui.c
+++ b/src/gui.c
@@ -2527,7 +2527,14 @@ gui_outstr_nowrap(
     if (hl_mask_todo & HL_UNDERCURL)
 	draw_flags |= DRAW_UNDERC;
 
-    // TODO: HL_UNDERDOUBLE, HL_UNDERDOTTED, HL_UNDERDASHED
+    // MacVim note: underdouble/underdotted/underdashed are not implemented in Vim yet.
+    // These are MacVim-only for now.
+    if (hl_mask_todo & HL_UNDERDOUBLE)
+	draw_flags |= DRAW_UNDERDOUBLE;
+    if (hl_mask_todo & HL_UNDERDOTTED)
+	draw_flags |= DRAW_UNDERDOTTED;
+    if (hl_mask_todo & HL_UNDERDASHED)
+	draw_flags |= DRAW_UNDERDASHED;
 
     // Do we strikethrough the text?
     if (hl_mask_todo & HL_STRIKETHROUGH)

--- a/src/gui.h
+++ b/src/gui.h
@@ -128,8 +128,18 @@
 #endif
 #define DRAW_CURSOR		0x20	// drawing block cursor (win32)
 #define DRAW_STRIKE		0x40	// strikethrough
-#define DRAW_WIDE		0x80	// drawing wide char (MacVim)
-#define DRAW_COMP		0x100	// drawing composing char (MacVim)
+// MacVim note: underdouble/underdotted/underdashed are not implemented in Vim yet.
+// These are MacVim-only for now.
+// IMPORTANT: If resolving a merge conflict when merging from upstream, if Vim decided
+//	      to use different values for these constants, MMCoreTextView.m would need
+//	      to be updated to reflect them as well, or the renderer won't understand
+//	      these values.
+#define DRAW_UNDERDOUBLE	0x80	// draw double underline
+#define DRAW_UNDERDOTTED	0x100	// draw dotted underline
+#define DRAW_UNDERDASHED	0x200	// draw dashed underline
+
+#define DRAW_WIDE		0x1000	// drawing wide char (MacVim)
+#define DRAW_COMP		0x2000	// drawing composing char (MacVim)
 
 // For our own tearoff menu item
 #define TEAR_STRING		"-->Detach"


### PR DESCRIPTION
Add support for all the missing text styles for MacVim for Vim parity.

For strikethrough, this needed to be done as a second pass to make sure they get drawn on top of the text. This is necessary because currently the logic buffers texts up before dispatching them later in a line, so it's just easier to loop through the line a second time if we detected strikethrough. For the strikethrough position, we simply use the half of xheight which seems to work best in looking good.

For underdouble, the logic is a little tricky because sometimes we don't have space below the line. When that's the case, simply draw the second line on top of the first line.

For underdotted, need to do something smart to space out the dots. When the width is divisible by 2, they get spaced out evenly. If they are not, try to make it work if divisible by 3. If that's not the case, we just readjust the size of dot/gap a little bit to make it fit, even though now we have non-integer sizes (from experimentation, the antialising works well enough that it's not too jarring).

Also fix rendering of undercurl to work for double-width characters as well.

Note that underdouble/underdotted/underdashed are not supported in regular gVim yet, and so I had to add the ifdef for those in gui.c. These may cause merge conflicts later which should be easily resolved.

Known issue 1: Note that currently underline is not respecting the font's underline thickness and position. We always use a thickness of 1 pt, and hard-code a 0.4*descent position, which are not great. Thickness in particular should scale with the font size. They should be fixed in a future commit.

Known issue 2: There are some current clipping bugs in the renderer. This is because the line height returned by NSLayoutManager is sometimes smaller than ascent+descent+leading, *and* MMCoreTextView for some reason takes the `ceil(descent)` (presumably to make the rendering grid-aligned). This should be fixed later.

Fix #1034