### PR TITLE
Switch Sparkle appcast to use macvim.org domain name

### DIFF
--- a/src/MacVim/Info.plist
+++ b/src/MacVim/Info.plist
@@ -1308,7 +1308,7 @@
 		</dict>
 	</array>
 	<key>SUFeedURL</key>
-	<string>https://raw.githubusercontent.com/macvim-dev/macvim/gh-pages/appcast/latest.xml</string>
+	<string>https://macvim.org/appcast/latest.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>Pt4zsg/8S3/mxKW7Cmt0cZFw/+2LOuXOYS93evP+Mfc=</string>
 	<key>NSAppleEventsUsageDescription</key>


### PR DESCRIPTION
Switch Sparkle's appcast URL to use macvim.org instead of raw GitHub URL. This is more public facing, and gives us more power to maintain control of the updater (as long as we keep control over the domain name), and make it possible to migrate to other platforms from GitHub (if we so wish in the future).

The current URL for the appcast is actually quite problematic as it for some reason point directly to GitHub's raw content of the file, instead of the version generated by GitHub Pages. That means we can't really use GitHub Page's Jekyll static site generator to dynamically create the file (latest.xml) as the raw URL directly reads the source code rather than the generated link on GitHub Page (in which case I don't know why we bothered to put in on a gh-page branch to begin with).

Since some people only open / update MacVim infrequently, that means we can't really change latext.xml to be generated by Jekyll in foreseeable future (at least a year or so) as we don't want to break not-too-old MacVim versions' ability to update. The ability to dynamically generate it would have been useful to handle legacy (pre-10.13) and beta releases.

