### PR TITLE
Fix misc MacVim warnings

### DIFF
--- a/src/MacVim/Info.plist
+++ b/src/MacVim/Info.plist
@@ -1282,6 +1282,7 @@
 			<key>NSSendTypes</key>
 			<array>
 				<string>NSStringPboardType</string>
+				<string>public.utf8-plain-text</string>
 			</array>
 			<key>NSRequiredContext</key>
 			<dict></dict>

--- a/src/MacVim/Info.plist
+++ b/src/MacVim/Info.plist
@@ -1299,6 +1299,7 @@
 			<string>MacVim</string>
 			<key>NSSendTypes</key>
 			<array>
+				<string>public.file-url</string>
 				<string>NSFilenamesPboardType</string>
 			</array>
 			<key>NSUserData</key>

--- a/src/MacVim/MMAppController.h
+++ b/src/MacVim/MMAppController.h
@@ -73,7 +73,9 @@
 - (IBAction)showVimHelp:(id)sender withCmd:(NSString *)cmd;
 - (IBAction)showVimHelp:(id)sender;
 - (IBAction)checkForUpdates:(id)sender;
+#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13
 - (IBAction)zoomAll:(id)sender;
+#endif
 - (IBAction)stayInFront:(id)sender;
 - (IBAction)stayInBack:(id)sender;
 - (IBAction)stayLevelNormal:(id)sender;

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -1315,11 +1315,19 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 #endif
 }
 
+// Note that the zoomAll method does not appear to be called in modern macOS versions
+// as NSApplication just handles it and directly calls each window's zoom:. It's
+// difficult to trace through history to see when that happened as it's not really
+// documented, so we are leaving this method around in case on older macOS
+// versions it's useful.
+#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13
 - (IBAction)zoomAll:(id)sender
 {
+    // TODO ychin: check on 10.13 etc. This was depreacated post 10.14.
     ASLogDebug(@"Zoom all windows");
     [NSApp makeWindowsPerform:@selector(performZoom:) inOrder:YES];
 }
+#endif
 
 - (IBAction)stayInFront:(id)sender
 {

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -638,7 +638,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
             if ([alert runModal] != NSAlertFirstButtonReturn)
                 reply = NSTerminateCancel;
 
-            if ([[alert suppressionButton] state] == NSOnState) {
+            if ([[alert suppressionButton] state] == NSControlStateValueOn) {
                 [[NSUserDefaults standardUserDefaults]
                             setBool:YES forKey:MMSuppressTerminationAlertKey];
             }
@@ -1346,7 +1346,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 {
     ASLogDebug(@"Toggle CoreText renderer");
     NSInteger renderer = MMRendererDefault;
-    BOOL enable = ([sender state] == NSOnState);
+    BOOL enable = ([sender state] == NSControlStateValueOn);
 
     if (enable) {
         renderer = MMRendererCoreText;

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -1647,12 +1647,9 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 - (void)newFileHere:(NSPasteboard *)pboard userData:(NSString *)userData
               error:(NSString **)error
 {
-    if (![[pboard types] containsObject:NSFilenamesPboardType]) {
-        ASLogNotice(@"Pasteboard contains no NSFilenamesPboardType");
+    NSArray<NSString *> *filenames = extractPasteboardFilenames(pboard);
+    if (filenames == nil || filenames.count == 0)
         return;
-    }
-
-    NSArray *filenames = [pboard propertyListForType:NSFilenamesPboardType];
     NSString *path = [filenames lastObject];
 
     BOOL dirIndicator;

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -260,7 +260,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 
     [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
 
-    NSArray *types = [NSArray arrayWithObject:NSStringPboardType];
+    NSArray *types = [NSArray arrayWithObject:NSPasteboardTypeString];
     [NSApp registerServicesMenuSendTypes:types returnTypes:types];
 
     // NOTE: Set the current directory to user's home directory, otherwise it
@@ -1587,8 +1587,8 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 - (void)openSelection:(NSPasteboard *)pboard userData:(NSString *)userData
                 error:(NSString **)error
 {
-    if (![[pboard types] containsObject:NSStringPboardType]) {
-        ASLogNotice(@"Pasteboard contains no NSStringPboardType");
+    if (![[pboard types] containsObject:NSPasteboardTypeString]) {
+        ASLogNotice(@"Pasteboard contains no NSPasteboardTypeString");
         return;
     }
 
@@ -1600,13 +1600,13 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 
     if (openInCurrentWindow && (vc = [self topmostVimController])) {
         [vc sendMessage:AddNewTabMsgID data:nil];
-        [vc dropString:[pboard stringForType:NSStringPboardType]];
+        [vc dropString:[pboard stringForType:NSPasteboardTypeString]];
     } else {
         // Save the text, open a new window, and paste the text when the next
         // window opens.  (If this is called several times in a row, then all
         // but the last call may be ignored.)
         if (openSelectionString) [openSelectionString release];
-        openSelectionString = [[pboard stringForType:NSStringPboardType] copy];
+        openSelectionString = [[pboard stringForType:NSPasteboardTypeString] copy];
 
         [self newWindow:self];
     }
@@ -1615,13 +1615,13 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 - (void)openFile:(NSPasteboard *)pboard userData:(NSString *)userData
            error:(NSString **)error
 {
-    if (![[pboard types] containsObject:NSStringPboardType]) {
-        ASLogNotice(@"Pasteboard contains no NSStringPboardType");
+    if (![[pboard types] containsObject:NSPasteboardTypeString]) {
+        ASLogNotice(@"Pasteboard contains no NSPasteboardTypeString");
         return;
     }
 
     // TODO: Parse multiple filenames and create array with names.
-    NSString *string = [pboard stringForType:NSStringPboardType];
+    NSString *string = [pboard stringForType:NSPasteboardTypeString];
     string = [string stringByTrimmingCharactersInSet:
             [NSCharacterSet whitespaceAndNewlineCharacterSet]];
     string = [string stringByStandardizingPath];

--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -1138,7 +1138,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
             NSColor *col = [NSColor performSelector:NSSelectorFromString(obj)];
             if (col) {
                 CGFloat r, g, b, a;
-                col = [col colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
+                col = [col colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
                 [col getRed:&r green:&g blue:&b alpha:&a];
                 return (((int)(r*255+.5f) & 0xff) << 16)
                      + (((int)(g*255+.5f) & 0xff) << 8)
@@ -1473,9 +1473,9 @@ static char_u *extractSelectedText()
 
         NSString *string = [[NSString alloc] initWithUTF8String:(char*)str];
 
-        NSArray *types = [NSArray arrayWithObject:NSStringPboardType];
+        NSArray *types = [NSArray arrayWithObject:NSPasteboardTypeString];
         [pboard declareTypes:types owner:nil];
-        BOOL ok = [pboard setString:string forType:NSStringPboardType];
+        BOOL ok = [pboard setString:string forType:NSPasteboardTypeString];
     
         [string release];
         vim_free(str);
@@ -2502,12 +2502,14 @@ static char_u *extractSelectedText()
         case NSScrollerIncrementPage:
             value += (size > 2 ? size - 2 : 1);
             break;
+#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_7
         case NSScrollerDecrementLine:
             --value;
             break;
         case NSScrollerIncrementLine:
             ++value;
             break;
+#endif
         case NSScrollerKnob:
             isStillDragging = YES;
             // fall through ...

--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -13,7 +13,13 @@
 @class MMTextViewHelper;
 
 
-@interface MMCoreTextView : NSView <NSTextInput> {
+@interface MMCoreTextView : NSView <
+    NSTextInput
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
+    , NSFontChanging
+#endif
+    >
+{
     // From MMTextStorage
     int                         maxRows, maxColumns;
     NSColor                     *defaultBackgroundColor;
@@ -50,6 +56,11 @@
 }
 
 - (id)initWithFrame:(NSRect)frame;
+
+//
+// NSFontChanging methods
+//
+- (void)changeFont:(id)sender;
 
 //
 // MMTextStorage methods

--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -245,7 +245,7 @@ static void grid_free(Grid *grid) {
     [helper setTextView:self];
 
     [self registerForDraggedTypes:[NSArray arrayWithObjects:
-            NSFilenamesPboardType, NSStringPboardType, nil]];
+            NSFilenamesPboardType, NSPasteboardTypeString, nil]];
 
     ligatures = NO;
 

--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -244,8 +244,8 @@ static void grid_free(Grid *grid) {
     helper = [[MMTextViewHelper alloc] init];
     [helper setTextView:self];
 
-    [self registerForDraggedTypes:[NSArray arrayWithObjects:
-            NSFilenamesPboardType, NSPasteboardTypeString, nil]];
+    [self registerForDraggedTypes:@[getPasteboardFilenamesType(),
+                                    NSPasteboardTypeString]];
 
     ligatures = NO;
 

--- a/src/MacVim/MMFindReplaceController.m
+++ b/src/MacVim/MMFindReplaceController.m
@@ -34,8 +34,8 @@
         [findBox setStringValue:text];
 
     // NOTE: The 'flags' values must match the FRD_ defines in gui.h.
-    [matchWordButton setState:(flags & 0x08 ? NSOnState : NSOffState)];
-    [ignoreCaseButton setState:(flags & 0x10 ? NSOffState : NSOnState)];
+    [matchWordButton setState:(flags & 0x08 ? NSControlStateValueOn : NSControlStateValueOff)];
+    [ignoreCaseButton setState:(flags & 0x10 ? NSControlStateValueOff : NSControlStateValueOn)];
 
     [window makeKeyAndOrderFront:self];
 }
@@ -52,12 +52,12 @@
 
 - (BOOL)ignoreCase
 {
-    return [ignoreCaseButton state] == NSOnState;
+    return [ignoreCaseButton state] == NSControlStateValueOn;
 }
 
 - (BOOL)matchWord
 {
-    return [matchWordButton state] == NSOnState;
+    return [matchWordButton state] == NSControlStateValueOn;
 }
 
 @end // MMFindReplaceController

--- a/src/MacVim/MMTextView.m
+++ b/src/MacVim/MMTextView.m
@@ -545,7 +545,11 @@
     [super drawRect:rect];
 
     if (invertRects) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_10
+        CGContextRef cgctx = context.CGContext;
+#else
         CGContextRef cgctx = (CGContextRef)[context graphicsPort];
+#endif
         CGContextSaveGState(cgctx);
         CGContextSetBlendMode(cgctx, kCGBlendModeDifference);
         CGContextSetRGBFillColor(cgctx, 1.0, 1.0, 1.0, 1.0);

--- a/src/MacVim/MMTextView.m
+++ b/src/MacVim/MMTextView.m
@@ -819,8 +819,7 @@
 
 - (NSArray *)acceptableDragTypes
 {
-    return [NSArray arrayWithObjects:NSFilenamesPboardType,
-            NSPasteboardTypeString, nil];
+    return @[getPasteboardFilenamesType(), NSPasteboardTypeString];
 }
 
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender

--- a/src/MacVim/MMTextView.m
+++ b/src/MacVim/MMTextView.m
@@ -816,7 +816,7 @@
 - (NSArray *)acceptableDragTypes
 {
     return [NSArray arrayWithObjects:NSFilenamesPboardType,
-           NSStringPboardType, nil];
+            NSPasteboardTypeString, nil];
 }
 
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender

--- a/src/MacVim/MMTextViewHelper.m
+++ b/src/MacVim/MMTextViewHelper.m
@@ -519,9 +519,9 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
         NSString *string = [pboard stringForType:NSPasteboardTypeString];
         [[self vimController] dropString:string];
         return YES;
-    } else if ([[pboard types] containsObject:NSFilenamesPboardType]) {
-        NSArray *files = [pboard propertyListForType:NSFilenamesPboardType];
-        [[self vimController] dropFiles:files forceOpen:NO];
+    } else if ([[pboard types] containsObject:getPasteboardFilenamesType()]) {
+        NSArray<NSString *> *filenames = extractPasteboardFilenames(pboard);
+        [[self vimController] dropFiles:filenames forceOpen:NO];
         return YES;
     }
 
@@ -533,7 +533,7 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
     NSDragOperation sourceDragMask = [sender draggingSourceOperationMask];
     NSPasteboard *pboard = [sender draggingPasteboard];
 
-    if ( [[pboard types] containsObject:NSFilenamesPboardType]
+    if ( [[pboard types] containsObject:getPasteboardFilenamesType()]
             && (sourceDragMask & NSDragOperationCopy) )
         return NSDragOperationCopy;
     if ( [[pboard types] containsObject:NSPasteboardTypeString]
@@ -548,7 +548,7 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
     NSDragOperation sourceDragMask = [sender draggingSourceOperationMask];
     NSPasteboard *pboard = [sender draggingPasteboard];
 
-    if ( [[pboard types] containsObject:NSFilenamesPboardType]
+    if ( [[pboard types] containsObject:getPasteboardFilenamesType()]
             && (sourceDragMask & NSDragOperationCopy) )
         return NSDragOperationCopy;
     if ( [[pboard types] containsObject:NSPasteboardTypeString]

--- a/src/MacVim/MMTextViewHelper.m
+++ b/src/MacVim/MMTextViewHelper.m
@@ -515,8 +515,8 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
 {
     NSPasteboard *pboard = [sender draggingPasteboard];
 
-    if ([[pboard types] containsObject:NSStringPboardType]) {
-        NSString *string = [pboard stringForType:NSStringPboardType];
+    if ([[pboard types] containsObject:NSPasteboardTypeString]) {
+        NSString *string = [pboard stringForType:NSPasteboardTypeString];
         [[self vimController] dropString:string];
         return YES;
     } else if ([[pboard types] containsObject:NSFilenamesPboardType]) {
@@ -536,7 +536,7 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
     if ( [[pboard types] containsObject:NSFilenamesPboardType]
             && (sourceDragMask & NSDragOperationCopy) )
         return NSDragOperationCopy;
-    if ( [[pboard types] containsObject:NSStringPboardType]
+    if ( [[pboard types] containsObject:NSPasteboardTypeString]
             && (sourceDragMask & NSDragOperationCopy) )
         return NSDragOperationCopy;
 
@@ -551,7 +551,7 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
     if ( [[pboard types] containsObject:NSFilenamesPboardType]
             && (sourceDragMask & NSDragOperationCopy) )
         return NSDragOperationCopy;
-    if ( [[pboard types] containsObject:NSStringPboardType]
+    if ( [[pboard types] containsObject:NSPasteboardTypeString]
             && (sourceDragMask & NSDragOperationCopy) )
         return NSDragOperationCopy;
 

--- a/src/MacVim/MMVimController.h
+++ b/src/MacVim/MMVimController.h
@@ -15,6 +15,16 @@
 @class MMTouchBarInfo;
 
 
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12
+/// Button used for Touch Bar support, with an additional metadata to store the
+/// Vim command it should send.
+@interface MMTouchBarButton : NSButton {
+    NSArray *_desc;
+}
+- (NSArray *)desc;
+- (void)setDesc:(NSArray *)desc;
+@end
+#endif
 
 @interface MMVimController : NSObject<
     NSToolbarDelegate

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -102,13 +102,6 @@ static BOOL isUnsafeMessage(int msgid);
 - (void)setTouchBarItem:(NSTouchBarItem *)item;
 - (void)makeChildTouchBar;
 @end
-
-@interface MMTouchBarButton : NSButton {
-    NSArray *_desc;
-}
-- (NSArray *)desc;
-- (void)setDesc:(NSArray *)desc;
-@end
 #endif
 
 @interface MMVimController (Private)
@@ -183,7 +176,7 @@ static BOOL isUnsafeMessage(int msgid);
     popupMenuItems = [[NSMutableArray alloc] init];
     toolbarItemDict = [[NSMutableDictionary alloc] init];
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
-    if (NSClassFromString(@"NSTouchBar")) {
+    if (@available(macos 10.12.2, *)) {
         touchbarInfo = [[MMTouchBarInfo alloc] init];
     }
 #endif
@@ -1221,7 +1214,7 @@ static BOOL isUnsafeMessage(int msgid);
 
     if ([rootName isEqual:MMTouchbarMenuName]) {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
-        if (NSClassFromString(@"NSTouchBar")) {
+        if (@available(macos 10.12.2, *)) {
             if ([desc count] < 2) // Cannot be 1, as we need at least TouchBar.<menu_name>
                 return;
             if ([desc count] >= 3) // Unfortunately currently Apple does not support nested popover's so we can only do one level nesting
@@ -1305,7 +1298,7 @@ static BOOL isUnsafeMessage(int msgid);
         if ([desc count] >= 4) // Unfortunately currently Apple does not support nested popover's so we can only do one level nesting
             return;
 
-        if (NSClassFromString(@"NSTouchBar")) {
+        if (@available(macos 10.12.2, *)) {
             MMTouchBarInfo *submenuTouchbar = nil;
             if (![self touchBarItemForDescriptor:desc touchBar:&submenuTouchbar touchBarItem:nil]) {
                 return;
@@ -1388,7 +1381,7 @@ static BOOL isUnsafeMessage(int msgid);
     }
     if ([rootName isEqual:MMTouchbarMenuName]){
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
-        if (NSClassFromString(@"NSTouchBar")) {
+        if (@available(macos 10.12.2, *)) {
             MMTouchBarInfo *submenuTouchbar = nil;
             if (![self touchBarItemForDescriptor:desc touchBar:&submenuTouchbar touchBarItem:nil]) {
                 return;
@@ -1442,7 +1435,7 @@ static BOOL isUnsafeMessage(int msgid);
 
     if ([rootName isEqual:MMTouchbarMenuName]) {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
-        if (NSClassFromString(@"NSTouchBar")) {
+        if (@available(macos 10.12.2, *)) {
             MMTouchBarItemInfo *touchbarItem = nil;
             if (![self touchBarItemForDescriptor:desc touchBar:nil touchBarItem:&touchbarItem]) {
                 return;
@@ -1481,7 +1474,7 @@ static BOOL isUnsafeMessage(int msgid);
 
     if ([rootName isEqual:MMTouchbarMenuName]) {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
-        if (NSClassFromString(@"NSTouchBar")) {
+        if (@available(macos 10.12.2, *)) {
             MMTouchBarItemInfo *touchbarItem = nil;
             if (![self touchBarItemForDescriptor:desc touchBar:nil touchBarItem:&touchbarItem]) {
                 return;

--- a/src/MacVim/MMVimView.m
+++ b/src/MacVim/MMVimView.m
@@ -151,8 +151,7 @@ enum {
     [[tabBarControl addTabButton] setTarget:self];
     [[tabBarControl addTabButton] setAction:@selector(addNewTab:)];
     [tabBarControl setAllowsDragBetweenWindows:NO];
-    [tabBarControl registerForDraggedTypes:
-                            [NSArray arrayWithObject:NSFilenamesPboardType]];
+    [tabBarControl registerForDraggedTypes:[NSArray arrayWithObject:getPasteboardFilenamesType()]];
 
     [tabBarControl setAutoresizingMask:NSViewWidthSizable|NSViewMinYMargin];
     
@@ -588,7 +587,7 @@ enum {
         forTabAtIndex:(NSUInteger)tabIndex
 {
     NSPasteboard *pb = [sender draggingPasteboard];
-    return [[pb types] containsObject:NSFilenamesPboardType]
+    return [[pb types] containsObject:getPasteboardFilenamesType()]
             ? NSDragOperationCopy
             : NSDragOperationNone;
 }
@@ -598,22 +597,19 @@ enum {
         forTabAtIndex:(NSUInteger)tabIndex
 {
     NSPasteboard *pb = [sender draggingPasteboard];
-    if ([[pb types] containsObject:NSFilenamesPboardType]) {
-        NSArray *filenames = [pb propertyListForType:NSFilenamesPboardType];
-        if ([filenames count] == 0)
-            return NO;
-        if (tabIndex != NSNotFound) {
-            // If dropping on a specific tab, only open one file
-            [vimController file:[filenames objectAtIndex:0]
-                draggedToTabAtIndex:tabIndex];
-        } else {
-            // Files were dropped on empty part of tab bar; open them all
-            [vimController filesDraggedToTabBar:filenames];
-        }
-        return YES;
-    } else {
+    NSArray<NSString*>* filenames = extractPasteboardFilenames(pb);
+    if (filenames == nil || filenames.count == 0)
         return NO;
+
+    if (tabIndex != NSNotFound) {
+        // If dropping on a specific tab, only open one file
+        [vimController file:[filenames objectAtIndex:0]
+            draggedToTabAtIndex:tabIndex];
+    } else {
+        // Files were dropped on empty part of tab bar; open them all
+        [vimController filesDraggedToTabBar:filenames];
     }
+    return YES;
 }
 
 

--- a/src/MacVim/MMVimView.m
+++ b/src/MacVim/MMVimView.m
@@ -192,6 +192,10 @@ enum {
     return textView.defaultBackgroundColor.alphaComponent == 1;
 }
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_7
+// The core logic should not be reachable in 10.7 or above and is deprecated code.
+// See documentation for showsResizeIndicator and placeScrollbars: comments.
+// As such, just ifdef out the whole thing as we no longer support 10.7.
 - (void)drawRect:(NSRect)rect
 {
     // On Leopard, we want to have a textured window background for nice
@@ -202,9 +206,6 @@ enum {
             || !([[self window] styleMask] & NSWindowStyleMaskTexturedBackground))
         return;
     
-    // This should not be reachable in 10.7 or above and is deprecated code.
-    // See documentation for showsResizeIndicator and placeScrollbars: comments.
-
 #if (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_7)
     int sw = [NSScroller scrollerWidthForControlSize:NSControlSizeRegular scrollerStyle:NSScrollerStyleLegacy];
 #else
@@ -243,6 +244,7 @@ enum {
         [path stroke];
     }
 }
+#endif
 
 - (MMTextView *)textView
 {

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1764,7 +1764,7 @@
 
     if (!query) {
         // Use find pasteboard for next query.
-        NSPasteboard *pb = [NSPasteboard pasteboardWithName:NSFindPboard];
+        NSPasteboard *pb = [NSPasteboard pasteboardWithName:NSPasteboardNameFind];
         NSArray *supportedTypes = [NSArray arrayWithObjects:VimFindPboardType,
                                    NSPasteboardTypeString, nil];
         NSString *bestType = [pb availableTypeFromArray:supportedTypes];

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1114,7 +1114,8 @@
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
 - (IBAction)vimTouchbarItemAction:(id)sender
 {
-    NSArray *desc = [sender desc];
+    MMTouchBarButton *button = (MMTouchBarButton*)sender;
+    NSArray *desc = [button desc];
     NSDictionary *attrs = [NSDictionary dictionaryWithObject:desc
                                                       forKey:@"descriptor"];
     [vimController sendMessage:ExecuteMenuMsgID data:[attrs dictionaryAsData]];

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -128,10 +128,27 @@
 {
     backgroundDark = NO;
     
-    unsigned styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
-            | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable
-            | NSWindowStyleMaskUnifiedTitleAndToolbar
-            | NSWindowStyleMaskTexturedBackground;
+    unsigned styleMask = NSWindowStyleMaskTitled
+                       | NSWindowStyleMaskClosable
+                       | NSWindowStyleMaskMiniaturizable
+                       | NSWindowStyleMaskResizable
+                       | NSWindowStyleMaskUnifiedTitleAndToolbar;
+
+    // Textured background has been a deprecated feature for a while. For a
+    // while we kept using it to avoid showing a black line below the title
+    // bar, but since macOS 11.0 this flag is completely ignored and
+    // deprecated. Since it's hard to test older versions of macOS well, simply
+    // preserve the existing functionality on older macOS versions, while not
+    // setting it in macOS 11+.
+    BOOL usingTexturedBackground = NO;
+#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_VERSION_11_0
+    if (@available(macos 11.0, *)) {
+        // Don't set the textured background because it's been completely deprecated and won't do anything.
+    } else {
+        styleMask = styleMask | NSWindowStyleMaskTexturedBackground;
+        usingTexturedBackground = YES;
+    }
+#endif
 
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     if ([userDefaults boolForKey:MMNoTitleBarWindowKey]) {
@@ -179,7 +196,7 @@
     [win setDelegate:self];
     [win setInitialFirstResponder:[vimView textView]];
 
-    if ([win styleMask] & NSWindowStyleMaskTexturedBackground) {
+    if (usingTexturedBackground) {
         // On Leopard, we want to have a textured window to have nice
         // looking tabs. But the textured window look implies rounded
         // corners, which looks really weird -- disable them. This is a
@@ -1722,9 +1739,17 @@
 {
     BOOL tabBarVisible  = ![[vimView tabBarControl] isHidden];
     BOOL toolbarHidden  = [decoratedWindow toolbar] == nil;
-    BOOL windowTextured = ([decoratedWindow styleMask] &
-                            NSWindowStyleMaskTexturedBackground) != 0;
     BOOL hideSeparator  = NO;
+
+    // See initWithVimController: for textured background deprecation notes.
+    BOOL windowTextured = NO;
+#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_VERSION_11_0
+    if (@available(macos 11.0, *)) {
+    } else {
+        windowTextured = ([decoratedWindow styleMask] &
+                          NSWindowStyleMaskTexturedBackground) != 0;
+    }
+#endif
 
     if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_10) {
         // The tabline separator is mostly an old feature and not necessary

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -1,4 +1,4 @@
-/* vi:set ts=8 sts=4 sw=4 ft=objc:
+/* vi:set ts=8 sts=4 sw=4 ft=objc fdm=syntax:
  *
  * VIM - Vi IMproved		by Bram Moolenaar
  *				MacVim GUI port by Bjorn Winckler
@@ -8,7 +8,12 @@
  * See README.txt for an overview of the Vim source code.
  */
 
+// This file contains root-level commonly used definitions that both Vim and
+// MacVim processes need access to.
+
 #import <Cocoa/Cocoa.h>
+
+#pragma region Backward compatibility defines
 
 // Taken from /usr/include/AvailabilityMacros.h
 #ifndef MAC_OS_X_VERSION_10_7
@@ -58,6 +63,10 @@
 # define NSAppKitVersionNumber10_14 1671
 #endif
 
+// Deprecated constants. Since these are constants, we just need the compiler,
+// not the runtime to know about them. As such, we can use MAX_ALLOWED to
+// determine if we need to map or not.
+
 #if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_12
 // Deprecated constants in 10.12 SDK
 # define NSAlertStyleCritical NSCriticalAlertStyle
@@ -91,6 +100,16 @@
 # define NSWindowStyleMaskUnifiedTitleAndToolbar NSUnifiedTitleAndToolbarWindowMask
 #endif
 
+// Deprecated runtime values. Since these are runtime values, we need to use the
+// minimum required OS as determining factor. Otherwise it would crash.
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED <  MAC_OS_X_VERSION_10_13
+// Deprecated runtime values in 10.13 SDK.
+# define NSPasteboardNameFind NSFindPboard
+#endif
+
+#pragma endregion
+
 #import <asl.h>
 #if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_12
 # define MM_USE_ASL
@@ -98,6 +117,7 @@
 # import <os/log.h>
 #endif
 
+#pragma region Shared protocols
 
 //
 // This is the protocol MMBackend implements.
@@ -171,7 +191,9 @@
                  client:(in byref id <MMVimClientProtocol>)client;
 @end
 
+#pragma endregion
 
+#pragma region IPC messages
 
 //
 // The following enum lists all messages that are passed between MacVim and
@@ -330,6 +352,8 @@ enum {
     MMGestureForceClick,
 };
 
+#pragma endregion
+
 
 // Create a string holding the labels of all messages in message queue for
 // debugging purposes (condense some messages since there may typically be LOTS
@@ -405,6 +429,7 @@ extern NSString *VimFindPboardType;
 // MacVim Apple Event Constants
 #define keyMMUntitledWindow       'MMuw'
 
+#pragma region Logging
 
 // Logging related functions and macros.
 //
@@ -496,3 +521,5 @@ void ASLInit();
 # define ASLogTmp(fmt, ...)    ASLog(OS_LOG_TYPE_DEFAULT, fmt, ##__VA_ARGS__)
 
 #endif
+
+#pragma endregion

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -72,6 +72,7 @@
 # define NSAlertStyleCritical NSCriticalAlertStyle
 # define NSAlertStyleInformational NSInformationalAlertStyle
 # define NSAlertStyleWarning NSWarningAlertStyle
+# define NSButtonTypeSwitch NSSwitchButton
 # define NSCompositingOperationSourceOver NSCompositeSourceOver
 # define NSCompositingOperationDifference NSCompositeDifference
 # define NSControlSizeRegular NSRegularControlSize
@@ -98,6 +99,12 @@
 # define NSWindowStyleMaskTexturedBackground NSTexturedBackgroundWindowMask
 # define NSWindowStyleMaskTitled NSTitledWindowMask
 # define NSWindowStyleMaskUnifiedTitleAndToolbar NSUnifiedTitleAndToolbarWindowMask
+#endif
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_13
+// Deprecated constants in 10.13 SDK
+#define NSControlStateValueOn NSOnState
+#define NSControlStateValueOff NSOffState
 #endif
 
 // Deprecated runtime values. Since these are runtime values, we need to use the

--- a/src/MacVim/MacVim.m
+++ b/src/MacVim/MacVim.m
@@ -159,7 +159,7 @@ debugStringForMessageQueue(NSArray *queue)
 
 - (unsigned)argbInt {
     CGFloat rf, gf, bf, af;
-    [[self colorUsingColorSpace:NSColorSpace.deviceRGBColorSpace]
+    [[self colorUsingColorSpace:NSColorSpace.sRGBColorSpace]
      getRed:&rf green:&gf blue:&bf alpha:&af];
     unsigned r = rf * 255, g = gf * 255, b = bf * 255, a = af*255;
     return a<<24 | r<<16 | g<<8 | b;
@@ -171,7 +171,7 @@ debugStringForMessageQueue(NSArray *queue)
     float g = ((rgb>>8) & 0xff)/255.0f;
     float b = (rgb & 0xff)/255.0f;
 
-    return [NSColor colorWithDeviceRed:r green:g blue:b alpha:1.0f];
+    return [NSColor colorWithSRGBRed:r green:g blue:b alpha:1.0f];
 }
 
 + (NSColor *)colorWithArgbInt:(unsigned)argb
@@ -181,7 +181,7 @@ debugStringForMessageQueue(NSArray *queue)
     float g = ((argb>>8) & 0xff)/255.0f;
     float b = (argb & 0xff)/255.0f;
 
-    return [NSColor colorWithDeviceRed:r green:g blue:b alpha:a];
+    return [NSColor colorWithSRGBRed:r green:g blue:b alpha:a];
 }
 
 @end // NSColor (MMExtras)

--- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
+++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
@@ -1002,9 +1002,11 @@
 			files = (
 			);
 			inputPaths = (
+				"$(PROJECT_DIR)/icons",
 			);
 			name = "Make Document Icons";
 			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1017,9 +1019,11 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/mvim",
 			);
 			name = "Copy mvim scripts";
 			outputPaths = (
+				$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/bin/mvim,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1034,11 +1038,13 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/../po",
 			);
 			name = "Copy locale message translation files";
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/vim/runtime/lang",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1047,18 +1053,21 @@
 		};
 		90C052E1251E889500E2D81E /* Copy vimtutor */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"${SRCROOT}/../vimtutor",
+				"${SRCROOT}/../gvimtutor",
 			);
 			name = "Copy vimtutor";
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/bin/vimtutor,
+				$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/bin/gvimtutor,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -169,8 +169,11 @@ NSView *showHiddenFilesView();
 NSString *normalizeFilename(NSString *filename);
 NSArray *normalizeFilenames(NSArray *filenames);
 
-
 BOOL shouldUseYosemiteTabBarStyle();
 BOOL shouldUseMojaveTabBarStyle();
 
 int getCurrentAppearance(NSAppearance *appearance);
+
+// Pasteboard helpers
+NSPasteboardType getPasteboardFilenamesType();
+NSArray<NSString*>* extractPasteboardFilenames(NSPasteboard *pboard);

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -267,7 +267,7 @@ showHiddenFilesView()
         initWithFrame:NSMakeRect(0, 0, 140, 18)] autorelease];
     [button setTitle:
         NSLocalizedString(@"Show Hidden Files", @"Show Hidden Files Checkbox")];
-    [button setButtonType:NSSwitchButton];
+    [button setButtonType:NSButtonTypeSwitch];
 
     [button setTarget:nil];
     [button setAction:@selector(hiddenFilesButtonToggled:)];

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -1916,9 +1916,9 @@ gui_macvim_add_to_find_pboard(char_u *pat)
 
     if (!s) return;
 
-    NSPasteboard *pb = [NSPasteboard pasteboardWithName:NSFindPboard];
+    NSPasteboard *pb = [NSPasteboard pasteboardWithName:NSPasteboardNameFind];
     NSArray *supportedTypes = [NSArray arrayWithObjects:VimFindPboardType,
-            NSStringPboardType, nil];
+            NSPasteboardTypeString, nil];
     [pb declareTypes:supportedTypes owner:nil];
 
     // Put two entries on the Find pasteboard:
@@ -1927,7 +1927,7 @@ gui_macvim_add_to_find_pboard(char_u *pat)
     // The second entry will be used by other applications when taking entries
     // off the Find pasteboard, whereas MacVim will use the first if present.
     [pb setString:s forType:VimFindPboardType];
-    [pb setString:[s stringByRemovingFindPatterns] forType:NSStringPboardType];
+    [pb setString:[s stringByRemovingFindPatterns] forType:NSPasteboardTypeString];
 }
 
     void


### PR DESCRIPTION
MacVim currently has a *lot* of warnings, especially when compiling locally with a higher deployment target than 10.9 (which the CI uses). This PR fixes most of them to help reduce on the spam on the road to being able to turn on warnings as errors. Most of the warnings are deprecation warnings, and since we still support 10.9, the work needs to make sure to maintain compatibility with older versions of macOS and also code compatibility. This PR would also help make the build output be a lot less spammy once we move the main binary to build against 10.13 once Xcode 14.1 comes out and links against macOS 13.0 SDK (which only supports down to 10.13) instead of 12.0 SDK that we use now (which supports down to 10.9).

The PR is broken into a lot of smaller commits to make the work easier to follow and easier to revert if something goes wrong.

After this PR, there are a few items left:

* NSConnection / etc warnings. This is the big one but fixing it requires completely changing our IPC mechanism. It will be handled by #1157.
* NSToolbarSeparatorItemIdentifier. These are used for the `-sep-` tool bar items and apparently they haven't been working for a loong time. They will be addressed in a future PR which will introduce toolbar/menu/touch bar changes like SF symbol support.
* Misc setTarget/setAction warnings when using PSMTabBar. These are minor, but since we plan to replace our tab implementation in #1120 anyway there's no need to fix them and add merge conflicts.
* Random .xib warnings about sizing constraints etc. I have never seen this to become an actual issue, and this won't stop us from turning on warnings as errors (since these aren't source code) and so not fixing them for now.

---

commit c41e05baac96c0e26d8a593dd477fe4c292be115

Fix warning: zoomAll / makeWindowsPerform

Fix the deprecation warning on makeWindowsPerform. While we could simply replace it with the more updated form, one thing I noticed was that zoomAll: simply wasn't getting called. It appears that NSApplication has a native handler of it and would call zoom: on each window by itself, and as such there's no point in making our own zoomAll: method at all. I couldn't find out if this was the case in old macOS versions, and so just ifdef out the zoomAll function in newer versions of macOS which also fixes the deprecation warning.

---

commit dc1ad365ded0112ffd05e48aa3b192bf7bdb86dc

Fix NSFilenamesPboardType -> NSPasteboardTypeFileURL deprecation warning

This is a little tricky because it's not a simple map. With NSPasteboardTypeFileURL, we have to use readObjectsForClasses:options: to obtain a list of URL objects and then turn them into file path strings. Previously you could just get a list of file names directly with NSFilenamesPboardType. Also, this new enum was only defined in 10.13, so we have to maintain parallel paths to support both types of getting the list of file names from the pasteboard. Also refactored the code that use this to a function in Miscllaneous.m to avoid the headache. Note that the old NSFilenamesPboardType method still works today, so this is mostly to clean up old code and deprecation warnings.

Also made the "new file here" plugin accept both the old and new pasteboard types, just in case.

---

commit 94564fdc40d8008ac619e0d25490e8b7e93df911

Fix NSWindowStyleMaskTexturedBackground deprecation warning

Seems like the flag has been completely useless since macOS 11. We previously kept it around despite its deprecation status because it seems to make the title bar not show a black line, but since macOS 11 it has been showing that anyway, so remove usage of it. Also, clean up misc pre-Lion-era code and block them behind ifdef. Can remove those code in future if we want to clean up.

---

commit 2faa2855c475bd5673581cdc1d08af32eadf80dc

Fix MMTouchBarButton warning when calling "desc" function

Refactor the code so that the relevant class is in header and can be called. Also fix different places where I call NSClassFromString to use @available check instead, as I believe that's the recommended method and more efficient as well (due to it being native to the compiler).

---

commit cd325778997b794cecd643343129375e6de11661

Fix MacVim warnings: enum renames, graphicsPort, setcmdheight

The list of warnings fixed:

- Fix misc AppKit control states enums that got renamed and deprecated.
- NSFindPboardType -> NSPasteboardTypeFind deprecation.
- Fix usage of deprecated "graphicsPort" API to use CGContext instead.
- Use NSFontChanging protocol if it's available.
- Move MMCoreTextView's setcmdheight to the correct section in the private implementation category.

---

commit 2e67bf421a3d21af99ce3b73e98baa285244805b

Fix warnings due to usages of the deprecated NSStringPboardType

This turned out more complicated than I thoguht because the newer NSPasteboardTypeString (public.utf8-plain-text) is actually a different value from NSStringPboardType (NSStringPboardType), so it could potentially lead to behavior differences. The right-click Services menu in particular seems to not behave in the expected way, because writeSelectionToPasteboard: (called by the OS) is passing NSStringPboardType to us, even though we specifically only accept NSPasteboardTypeString in validRequestorForSendType:returnType:. Just fixed the code to ignore the passed in type.

Also update the Info.plist file to accept the public.utf8-plain-text for this service as well.

---

commit 2a6dea1b37cc64fc5b38a7a6e9f21ff7930f1a8a

Fix build phase dependency warnings

Make sure to specify the build phase (e.g. building locale files) input/output dependencies so they can be properly skipped during incremental builds if the input files haven't changed. Previously some of them were set to use dependency tracking, but with no input/output specified, therefore triggering a warning as Xcode had to run them every build.

---

commit e9e129017c167cda74669b901bbe9e847a1857f0

Fix MacVim compiler warnings (for Vim-process files)

Fix NSStringPboardType and NSFindPboard deprecation warnings.

Also, fix up an awkward use of colors in that we are loading the ARGB values of system colors using device calibrated space but CoreText renderer uses sRGB instead. Just load it as sRGB.

This should fix up all Vim-side compiler warnings except for the usage of NSConnection, which is a much larger task to tackle as we need to move to XPC. Note that the set of warnings differ depending on whether we have `MACOSX_DEPLOYMENT_TARGET=10.9` set or not as Xcode will recommend different changes. With that set we currently do not throw any warnings on the Vim process side (since NSConnection was not deprecated at 10.9 yet).
