### PR TITLE
Add File.Close support for terminal which also makes it work for Cmd-W

### DIFF
--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -165,6 +165,7 @@ if has("gui_macvim")
   an <silent> 10.330 &File.Close\ Window<Tab>:qa    :conf qa<CR>
   tln <silent> 10.330 &File.Close\ Window<Tab>:qa   <C-W>:conf qa<CR>
   an <silent> 10.332 &File.Close<Tab>:q		    :conf q<CR>
+  tln <silent> 10.332 &File.Close<Tab>:q		    <C-W>:conf q<CR>
   an <silent> 10.341 &File.Save\ All		    :browse conf wa<CR>
   an 10.350 &File.Save\ As…<Tab>:sav	    :browse confirm saveas<CR>
 else

--- a/src/MacVim/MMAppController.h
+++ b/src/MacVim/MMAppController.h
@@ -20,7 +20,13 @@
 #endif
 
 
-@interface MMAppController : NSObject <MMAppProtocol, NSUserInterfaceItemSearching> {
+@interface MMAppController : NSObject <
+    MMAppProtocol,
+    NSUserInterfaceItemSearching
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
+    , NSMenuItemValidation
+#endif
+> {
     NSConnection        *connection;
     NSMutableArray      *vimControllers;
     NSString            *openSelectionString;
@@ -62,6 +68,11 @@
 - (void)refreshAllFonts;
 - (void)refreshAllResizeConstraints;
 - (void)refreshAllTextViews;
+
+//
+// NSMenuItemValidation
+//
+- (BOOL)validateMenuItem:(NSMenuItem *)item;
 
 - (IBAction)newWindow:(id)sender;
 - (IBAction)newWindowAndActivate:(id)sender;

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -1160,6 +1160,14 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
     }
 }
 
+- (BOOL)validateMenuItem:(NSMenuItem *)item
+{
+    // For the actions defined in this class we do want them to always be
+    // enabled since they are usually app functionality and independent of
+    // each Vim's state.
+    return YES;
+}
+
 - (IBAction)newWindow:(id)sender
 {
     ASLogDebug(@"Open new window");


### PR DESCRIPTION
Since Vim upstream added support for `:confirm q` for terminals, we can now get our File.Close menu to work properly for them as well. This also means Cmd-W (which is bound to that menu item) works too.

Also just add validateMenuItem: for MMAppController even if we are just returning YES. This makes it semantically clearer and is easier to debug.