### PR TITLE
Support looking up selected texts, and also add data detector for URLs etc

### DIFF
--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -79,7 +79,7 @@
     NSString* toolTip_;
 }
 
-- (id)initWithFrame:(NSRect)frame;
+- (instancetype)initWithFrame:(NSRect)frame;
 
 //
 // NSFontChanging methods
@@ -145,6 +145,7 @@
 // NSTextView methods
 //
 - (void)keyDown:(NSEvent *)event;
+- (void)quickLookWithEvent:(NSEvent *)event;
 
 //
 // NSTextInputClient methods
@@ -160,6 +161,8 @@
 - (nonnull NSArray<NSAttributedStringKey> *)validAttributesForMarkedText;
 - (NSRect)firstRectForCharacterRange:(NSRange)range actualRange:(nullable NSRangePointer)actualRange;
 - (NSUInteger)characterIndexForPoint:(NSPoint)point;
+
+- (CGFloat)baselineDeltaForCharacterAtIndex:(NSUInteger)anIndex;
 
 //
 // NSTextContainer methods

--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -223,7 +223,7 @@ static void grid_free(Grid *grid) {
     int cmdlineRow; ///< Row number (0-indexed) where the cmdline starts. Used for pinning it to the bottom if desired.
 }
 
-- (id)initWithFrame:(NSRect)frame
+- (instancetype)initWithFrame:(NSRect)frame
 {
     if (!(self = [super initWithFrame:frame]))
         return nil;
@@ -1597,6 +1597,12 @@ static void rowColFromUtfRange(const Grid* grid, NSRange range,
     return utfCharIndexFromRowCol(&grid, row, col);
 }
 
+/// Returns the cursor location in the text storage. Note that the API is
+/// supposed to return a range if there are selected texts, but since we don't
+/// have access to the full text storage in MacVim (it requires IPC calls to
+/// Vim), we just return the cursor with the range always having zero length.
+/// This affects the quickLookWithEvent: implementation where we have to
+/// manually handle the selected text case.
 - (NSRange)selectedRange
 {
     if ([helper hasMarkedText]) {
@@ -1667,7 +1673,74 @@ static void rowColFromUtfRange(const Grid* grid, NSRange range,
     }
 }
 
+/// Optional function in text input client. Returns the proper baseline delta
+/// for the returned rect. We need to do this because we take the ceil() of
+/// fontDescent, which subtly changes the baseline relative to what the OS thinks,
+/// and would have resulted in a slightly offset text under certain fonts/sizes.
+- (CGFloat)baselineDeltaForCharacterAtIndex:(NSUInteger)anIndex
+{
+    // Note that this function is calculated top-down, so we need to subtract from height.
+    return cellSize.height - fontDescent;
+}
+
 #pragma endregion // Text Input Client
+
+/// Perform data lookup. This gets called by the OS when the user uses
+/// Ctrl-Cmd-D or the trackpad to look up data.
+- (void)quickLookWithEvent:(NSEvent *)event
+{
+    // The default implementation would query using the NSTextInputClient API
+    // which works fine.
+    //
+    // However, by default, if there are texts that are selected, *and* the
+    // user performs lookup when the mouse is on top of said selected text, the
+    // OS will use that for the lookup instead. E.g. if the user has selected
+    // "ice cream" and perform a lookup on it, the lookup will be "ice cream"
+    // instead of "ice" or "cream". We need to implement this in a custom
+    // fashion because our `selectedRange` implementation doesn't properly
+    // return the selected text (which we cannot do easily since our text
+    // storage isn't representative of the Vim's internal buffer, see above
+    // design notes), by querying Vim for the selected text manually.
+
+    MMVimController *vc = [self vimController];
+    id<MMBackendProtocol> backendProxy = [vc backendProxy];
+    if ([backendProxy selectedTextToPasteboard:nil]) {
+        // We have selected text. Proceed to see if the mouse is directly on
+        // top of said selection and if so, show definition of that instead.
+        const NSPoint pt = [self convertPoint:[event locationInWindow] fromView:nil];
+        int row, col;
+        if ([self convertPoint:pt toRow:&row column:&col]) {
+            int selRow = 0, selCol = 0;
+            const BOOL isMouseInSelection = [backendProxy mouseScreenposIsSelection:row column:col selRow:&selRow selCol:&selCol];
+
+            if (isMouseInSelection) {
+                NSString *selectedText = [backendProxy selectedText];
+                if (selectedText) {
+                    NSAttributedString *attrText = [[[NSAttributedString alloc] initWithString:selectedText
+                                                                                    attributes:@{NSFontAttributeName: font}
+                                                    ] autorelease];
+
+                    const NSRect selRect = [self rectForRow:selRow
+                                                     column:selCol
+                                                    numRows:1
+                                                 numColumns:1];
+
+                    NSPoint baselinePt = selRect.origin;
+                    baselinePt.y += fontDescent;
+
+                    // We have everything we need. Just show the definition and return.
+                    [self showDefinitionForAttributedString:attrText atPoint:baselinePt];
+                    return;
+                }
+            }
+        }
+    }
+
+    // Just call the default implementation, which will call misc
+    // NSTextInputClient methods on us and use that to determine what/where to
+    // show.
+    [super quickLookWithEvent:event];
+}
 
 @end // MMCoreTextView
 

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -146,6 +146,8 @@
 - (id)evaluateExpressionCocoa:(in bycopy NSString *)expr
                   errorString:(out bycopy NSString **)errstr;
 - (BOOL)selectedTextToPasteboard:(byref NSPasteboard *)pboard;
+- (NSString *)selectedText;
+- (BOOL)mouseScreenposIsSelection:(int)row column:(int)column selRow:(byref int *)startRow selCol:(byref int *)startCol;
 - (oneway void)acknowledgeConnection;
 @end
 

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -146,7 +146,7 @@ find_end_of_word(pos_T *pos)
  * Returns IN_BUFFER and sets "mpos->col" to the column when in buffer text.
  * The column is one for the first column.
  */
-    static int
+    int
 get_fpos_of_mouse(pos_T *mpos)
 {
     win_T	*wp;

--- a/src/proto/mouse.pro
+++ b/src/proto/mouse.pro
@@ -21,4 +21,8 @@ int mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump, int *pline
 win_T *mouse_find_win(int *rowp, int *colp, mouse_find_T popup);
 int vcol2col(win_T *wp, linenr_T lnum, int vcol);
 void f_getmousepos(typval_T *argvars, typval_T *rettv);
+
+// MacVim-only
+int get_fpos_of_mouse(pos_T *mpos);
+
 /* vim: set ft=c : */


### PR DESCRIPTION
Part of Epic #1311 

## Add data detector support for lookup, so URLs etc will work properly

This automatically uses NSDataDetector to detect special data around the lookup cursor position, and if found, will manually call showDefinition instead of letting the OS do it for us (honestly, this feature should be built-in to the OS instead of such manual work). Right now only doing address/phone number/URL (URL has priority), because we don't have built-in definition support for the other types like flight info and so on. This also only works for what is drawn on-screen only, because as usual, MacVim doesn't have access to the native text storage, unless we rely on lots of callbacks back-and-forth (which is possible, but annoying to implement).


---

## Make data lookup support selected text

Doing data lookup (e.g. Ctrl-Cmd-D) on top of a selected text now properly look up the entire selected range (e.g. "ice cream", instead of just "ice" or "cream"). This would have come by default if we could implement NSTextInputClient's selectedRange properly but since MacVim doesn't have access to the internal Vim buffers easily this is easier said than done. As such, we have a custom implementation where if we detect a lookup event, manually detect that we have the mouse cursor on top of selected text and show the definition for that manually.

Also fix a minor issue in text input client so that the baseline is now reported correctly for certan font size comboes, as our fontDescent is rounded up for some reason.
