### PR TITLE
Cancel outstanding PR builds when pushing new commits

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -4,6 +4,13 @@ on:
   push:
   pull_request:
 
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for
+  # pull requests or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 env:
   MACOSX_DEPLOYMENT_TARGET: '10.9'
 


### PR DESCRIPTION
Copy over the GitHub Actions concurrency settings from Vim upstream to allow for killing PR builds when a new commit has been pushed.