### PR TITLE
Fix popup test failure, and clean up MacVim error codes

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -108,6 +108,10 @@ guitablabel=" to your .gvimrc file to revert back to the default Vim tab
 label.  Setting 'guitablabel' to anything in your .vimrc will also prevent
 this default from taking effect.
 
+							*E9000-M*
+Below is a list of non-standard Vim commands and options that MacVim supports.
+They are only usable when GUI is active.
+
 							*macvim-options*
 These are the non-standard options that MacVim supports:
 	'antialias'	'blurradius'	'fullscreen'
@@ -503,7 +507,7 @@ file for more examples on how to set up menus.  Note: When no window is open a
 minimal default menu is used.  The default menu is set up in MainMenu.nib
 which resides in "Resources/English.lproj/" folder inside the app bundle.
 
-							*Actions.plist*
+							*E9001-M* *Actions.plist*
 Some action messages would not be suitable to call from within Vim, so there
 is a dictionary called "Actions.plist" (in the Resources folder of the
 application bundle) which contains all actions that may be called.  The key in

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5226,6 +5226,8 @@ E898	channel.txt	/*E898*
 E899	eval.txt	/*E899*
 E90	message.txt	/*E90*
 E900	builtin.txt	/*E900*
+E9000-M	gui_mac.txt	/*E9000-M*
+E9001-M	gui_mac.txt	/*E9001-M*
 E901	channel.txt	/*E901*
 E902	channel.txt	/*E902*
 E903	channel.txt	/*E903*

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -1012,7 +1012,7 @@ endif " !has("gui_macvim")
 " The popup menu
 if has("gui_macvim")
   vnoremenu 1.05 PopUp.Look\ Up     :<C-U>call macvim#ShowDefinitionSelected()<CR>
-  vnoremenu 1.06 PopUp.-SEP10-      <Nop>
+  vnoremenu 1.06 PopUp.-SEPLookUp-      <Nop>
 endif
 
 an 1.10 PopUp.&Undo			u

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -1461,7 +1461,7 @@ ex_macaction(eap)
     exarg_T	*eap;
 {
     if (!gui.in_use) {
-        emsg(_("E???: Command only available in GUI mode"));
+        emsg(_("E9000-M: Command only available in GUI mode"));
         return;
     }
 
@@ -1473,7 +1473,7 @@ ex_macaction(eap)
     if (actionDict && [actionDict objectForKey:name] != nil) {
         [[MMBackend sharedInstance] executeActionWithName:name];
     } else {
-        semsg(_("E???: Invalid action: %s"), eap->arg);
+        semsg(_("E9001-M: Invalid action: %s"), eap->arg);
     }
 
     arg = CONVERT_TO_UTF8(arg);
@@ -2540,6 +2540,11 @@ gui_macvim_set_background(int dark)
 /// Implementation of showdefinition()
 void f_showdefinition(typval_T *argvars, typval_T *rettv UNUSED)
 {
+    if (!gui.in_use) {
+        emsg(_("E9000-M: Command only available in GUI mode"));
+        return;
+    }
+
     if (in_vim9script() && check_for_string_arg(argvars, 0) == FAIL)
 	return;
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -3041,7 +3041,7 @@ ex_macmenu(exarg_T *eap)
 
 	    if (!is_valid_macaction(action))
 	    {
-		semsg(_("E???: Invalid action: %s"), arg);
+		semsg(_("E9001-M: Invalid action: %s"), arg);
 		error = TRUE;
 		break;
 	    }

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -891,6 +891,11 @@ func Test_popup_command()
   call writefile(lines, 'Xtest', 'D')
   let buf = RunVimInTerminal('-S XtimerScript Xtest', {})
   call term_sendkeys(buf, ":source $VIMRUNTIME/menu.vim\<CR>")
+  if has('gui_macvim')
+    " Remove the non-standard MacVim menus to the navigation below will work.
+    call term_sendkeys(buf, ":aunmenu PopUp.Look\\ Up\<CR>")
+    call term_sendkeys(buf, ":aunmenu PopUp.-SEPLookUp-\<CR>")
+  endif
   call term_sendkeys(buf, "/X\<CR>:popup PopUp\<CR>")
   call VerifyScreenDump(buf, 'Test_popup_command_01', {})
 


### PR DESCRIPTION
Fix failure in Test_popup_command. The test assumes a certain PopUp menu layout but we recently added a new "Look Up" menu item. Make sure the test removes those non-standard menu items before progressing the test.

Also, while we are at it, make sure the showdefinition() command will fail when not in GUI mode so it doesn't queue up the command queue. Also, convert the E??? error codes to proper error codes (and using a postfix "-M" to make sure they don't conflict with future Vim error codes) so they can be looked up in documentation.