### PR TITLE
Add SF Symbol support for tool bar, Touch Bar, menu icons

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -771,6 +771,9 @@ level.  Vim interprets the items in this menu as follows:
     A space in the file name must be escaped with a backslash.
     A menu priority must come _after_ the icon argument: >
 	:amenu icon=foo 1.42 ToolBar.Foo :echo "42!"<CR>
+<
+    In MacVim, the "icon=" argument can also be used to specify SF symbols or
+    system named images.  See |macvim-toolbar-icon| for more details.
 2)  An item called 'BuiltIn##', where ## is a number, is taken as number ## of
     the built-in bitmaps available in Vim.  Currently there are 31 numbered
     from 0 to 30 which cover most common editing operations |builtin-tools|. >

--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -420,6 +420,11 @@ Default Menus~
 
 See |macvim-default-menus|.
 
+Icons~
+
+Unlike regular Vim, MacVim menus can be customized with an icon.  Simply use
+the "icon=" parameter similar to toolbar. See |macvim-toolbar-icon| for usage.
+
 Customization~
 
 Menus in macOS behave slightly different from other platforms.  For that
@@ -554,16 +559,40 @@ empty space which will shink or expand so that the items to the right of it
 are right-aligned.  A space (flexspace) will be created for any toolbar item
 whose name begins with "-space" ("-flexspace") and ends with "-"
 
-Toolbar icons should be tiff, png, icns, or heic, of dimension 32x32 or 24x24
-pixels.  The larger size is used when 'tbis' is "medium" or "large", otherwise
-the smaller size is used (which is the default).  If the icon file only
-contains one dimension then macOS will scale the icon to the appropriate
-dimension if necessary.  To avoid this, use a file format which supports
-multiple resolutions (such as icns) and provide both 32x32 and 24x24 versions
-of the icon.
+							*macvim-toolbar-icon*
+In regular Vim, the "icon=" argument (see |toolbar-icon|) can be used to
+specify an image file by file path.  In MacVim, the argument could also be
+used for specifying an SF symbol or a macOS system image.  Simply use the SF
+symbol name or the system image name and MacVim will use load them instead of
+an image file.  Below are examples for using an SF symbol "gearshape.2" and a
+macOS system image named "NSAdvanced": >
+	:an icon=gearshape.2 ToolBar.Setting1   <Nop>
+	:an icon=NSAdvanced  ToolBar.Setting2   <Nop>
+Some SF symbols in macOS can be customized with different styles.  You can do
+so by using colon-delimited options (most of them require macOS 13 Ventura).
+The available options are `monochrome`, `hierarchical`, `palette`,
+`multicolor`, and `variable-0.5` (where 0.5 can be substituted with any number
+between 0 and 1). Download Apple's SF Symbols app to find out what the symbol
+names are and what styling options each one supports.  Some examples below: >
+	:an icon=bolt.circle:hierarchical       ToolBar.Bolt  :echo '⚡️'<CR>
+	:an icon=cloud.sun.rain.fill:multicolor ToolBar.Cloud :echo '🌦️'<CR>
+	:an icon=homekit:variable-0.4:palette   ToolBar.Home  :echo '🏠'<CR>
+<
+If your icon image is a template image (meaning that it is a grayscale image
+designed to be mapped to whatever foreground color is), you can add
+`:template` to the end of an image name, which will mark it as a template
+image to macOS: >
+	:an icon=/a/b/black-and-white.png:template ToolBar.Foo <Nop>
+<
+Supported image formats depend on the version of macOS.  Safe formats include
+png, icns, ico.  Later macOS versions also support heic and webp.
 
-Note: Only a subset of the builtin toolbar items presently have icons.  If no
-icon can be found a warning triangle is displayed instead.
+Toolbar icons should be of dimension 32x32 or 24x24 pixels.  The larger size
+is used when 'tbis' is "medium" or "large", otherwise the smaller size is used
+(which is the default).  If the icon file only contains one dimension then
+macOS will scale the icon to the appropriate dimension if necessary.  To avoid
+this, use a file format which supports multiple resolutions (such as icns) and
+provide both 32x32 and 24x24 versions of the icon.
 
 ==============================================================================
 8. Touch Bar						*macvim-touchbar*
@@ -573,6 +602,9 @@ Touch Bar in MacVim is configurable, and works similar to the toolbar (see
 instead of "ToolBar": >
 	:an TouchBar.Hello          :echo "Hello"<CR>
 <
+This feature only works on Mac devices that come with Touch Bars. On the ones
+that don't, nothing will show up.
+
 You can also create submenus. Due to macOS restrictions, submenus can only be
 one level deep: >
 	:an TouchBar.Navigate.Next  :next<CR>
@@ -593,13 +625,14 @@ begin with "-flexspace" and ends with "-".
 
 						*macvim-touchbar-icon*
 You can specify icons for Touch Bar buttons the same way for toolbar icons
-(see |macvim-toolbar|).  When a button has an icon, it won't show the menu
+(see |macvim-toolbar-icon|).  When a button has an icon, it won't show the menu
 name.  Touch Bar icons should ideally be 36x36 pixels, and no larger than
 44x44 pixels. >
-	:an icon=/home/foo/bar.png TouchBar.DoSomething :echo 'Do'<CR>
-You can also use default template icons provided by Apple by using their
-template names. An example: >
+	:an icon=/home/foo/bar.png          TouchBar.DoThing  :echo 'Do'<CR>
+You can use any image for the icon, but macOS comes with a few default
+template images designed for use with Touch Bar.  Some examples: >
 	:an icon=NSTouchBarListViewTemplate TouchBar.ShowList :ls<CR>
+	:an icon=NSTouchBarRefreshTemplate  TouchBar.Refresh  :e!<CR>
 <
 						*macvim-touchbar-title*
 By default, the Touch Bar buttons will use the menu names as the title. If an
@@ -614,10 +647,7 @@ the icon. Example: >
 You can also insert emojis by adding a character picker button (specified by
 using a name that begin wtih "-characterpicker" and ends with "-"): >
 	:inoremenu TouchBar.-characterpicker-	<Nop>
-
-This feature only works on Mac devices that come with Touch Bars. On the ones
-that don't, nothing will show up.
-
+<
 						*macvim-touchbar-defaults*
 Here is a list of default Touch Bar buttons that MacVim sets up:
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -8410,6 +8410,7 @@ macvim-start	gui_mac.txt	/*macvim-start*
 macvim-tablabel	gui_mac.txt	/*macvim-tablabel*
 macvim-todo	gui_mac.txt	/*macvim-todo*
 macvim-toolbar	gui_mac.txt	/*macvim-toolbar*
+macvim-toolbar-icon	gui_mac.txt	/*macvim-toolbar-icon*
 macvim-touchbar	gui_mac.txt	/*macvim-touchbar*
 macvim-touchbar-characterpicker	gui_mac.txt	/*macvim-touchbar-characterpicker*
 macvim-touchbar-defaults	gui_mac.txt	/*macvim-touchbar-defaults*

--- a/src/MacVim/MMPreferenceController.m
+++ b/src/MacVim/MMPreferenceController.m
@@ -58,7 +58,7 @@
 
 - (void)setupToolbar
 {
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
     if (@available(macos 11.0, *)) {
         // Use SF Symbols for versions of the OS that supports it to be more unified with OS appearance.
         [self addView:generalPreferences

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -43,8 +43,14 @@
 #ifndef MAC_OS_X_VERSION_10_14
 # define MAC_OS_X_VERSION_10_14 101400
 #endif
+#ifndef MAC_OS_VERSION_11_0
+# define MAC_OS_VERSION_11_0 110000
+#endif
 #ifndef MAC_OS_VERSION_12_0
 # define MAC_OS_VERSION_12_0 120000
+#endif
+#ifndef MAC_OS_VERSION_13_0
+# define MAC_OS_VERSION_13_0 130000
 #endif
 
 #ifndef NSAppKitVersionNumber10_10


### PR DESCRIPTION
Can now specify SF Symbols for tool bar / Touch Bar icons. The API remains the same where we use the "icon=" syntax in Vim menus to specify the icon, and just passing in the symbol name (e.g. 'gear.circle'). Also extended this to system named images like 'NSAdvanced' (the old gear shaped image), as previously we only had a specical case for Touch Bar system named template images. When loading the icon, MacVim will automatically determine whether it's an SF Symbol, system named image, or a file.

SF Symbols can also be customized to be of a particular symbol style, or have a variable number set, by using colon-delimted option strings. For example: `aqi.high:palette:variable-0.5` is a symbol that uses the palette style, set to 0.5 variable value.

Menu items now also support icons, the same as tool bars. We still don't support specifying icons for a submenu (which has been an issue for Touch Bar) since the Vim menu API doesn't support a way to do so.

Also add an ability to use a `:template` value to specify that an image file is a template image. This is important to fix a minor regression introduced in #1214 where every image loaded in were assumed to be template.

Add documentation to make this clear. See `:help macvim-toolbar-icon`.

Also see comment in #1105 which requested this feature