### PR TITLE
Set up CI to do split legacy build for macOS 10.9-10.12

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -12,18 +12,22 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: '10.9'
+  MACOSX_DEPLOYMENT_TARGET: '10.13'
+  MACOSX_DEPLOYMENT_TARGET_LEGACY: '10.9'
+
+  MACVIM_ARCHS: "x86_64 arm64"  # Universal app for Intel/Apple Silicon
+  MACVIM_ARCHS_LEGACY: "x86_64" # Legacy builds only need to build x86-64 because Apple Silicon can't run on these old OSes
 
   CC: clang
 
-  VERSIONER_PERL_VERSION: '5.18'
+  VERSIONER_PERL_VERSION: '5.30'
   VERSIONER_PYTHON_VERSION: '2.7'
   vi_cv_path_python: /usr/local/bin/python
   vi_cv_path_python3: /usr/local/bin/python3
   vi_cv_path_plain_lua: /usr/local/bin/lua
   vi_cv_path_ruby: /usr/local/opt/ruby/bin/ruby
-  vi_cv_dll_name_perl: /System/Library/Perl/5.18/darwin-thread-multi-2level/CORE/libperl.dylib
-  vi_cv_dll_name_python: /usr/local/Library/Frameworks/Python.framework/Versions/2.7/Python
+  vi_cv_dll_name_perl: /System/Library/Perl/5.30/darwin-thread-multi-2level/CORE/libperl.dylib
+  vi_cv_dll_name_python: /usr/local/Frameworks/Python.framework/Versions/2.7/Python
   vi_cv_dll_name_python3: /usr/local/Frameworks/Python.framework/Versions/3.10/Python # Make sure to keep src/MacVim/vimrc synced with the Python version here for the Python DLL detection logic.
   vi_cv_dll_name_python3_arm64: /opt/homebrew/Frameworks/Python.framework/Versions/3.10/Python
   vi_cv_dll_name_ruby: /usr/local/opt/ruby/lib/libruby.dylib
@@ -40,22 +44,38 @@ jobs:
   # Builds and test MacVim
   build-and-test:
 
-    # Test on macOS 11.x / 12.x, and also older version of Xcode for compatibility testing.
+    # Test on macOS 11.x / 12.x, and also older versions of Xcode for compatibility testing.
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: macos-11
-            publish: true
+          # Oldest version of Xcode supported on GitHub Action to test source code backwards compatibility
           - os: macos-11
             xcode: '11.7'
+
+          # Older version of Xcode, and used to publish legacy builds (for macOS 10.9 - 10.12)
           - os: macos-12
+            xcode: '14.0' # last version of Xcode that uses the macOS 12 SDK, which still supports deploying to macOS 10.9
+            publish: true
+            legacy: true
+            publish_postfix: '_10.9'
+
+          # Most up to date OS and Xcode. Used to publish release for the main build.
+          - os: macos-12
+            xcode: '14.1'
+            publish: true
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up legacy build
+        if: matrix.legacy
+        run: |
+          echo "MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET_LEGACY" >> $GITHUB_ENV
+          echo "MACVIM_ARCHS=$MACVIM_ARCHS_LEGACY" >> $GITHUB_ENV
 
       # Set up, install, and cache gettext library for localization.
       #
@@ -93,9 +113,16 @@ jobs:
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
-          brew install python
+          brew install python3
           brew install ruby
           brew install lua
+
+          # CI sometimes have custom installed Python instead of using Homebrew. Forcefully re-
+          # link Python, and then check that we are using the Homebrew version. This avoids us
+          # using a mystery Python installation that we don't control.
+          brew unlink python3 && brew link --overwrite python3
+          readlink -f $vi_cv_path_python3 | grep "^$(brew --cellar python3)"
+
           if [[ -d /usr/local/Cellar/perl ]]; then
             # We just use system perl to reduce dependencies
             brew unlink perl
@@ -129,7 +156,7 @@ jobs:
               --enable-rubyinterp=dynamic
               --enable-luainterp=dynamic
               --with-lua-prefix=/usr/local
-              --with-macarchs="x86_64 arm64"
+              --with-macarchs="$MACVIM_ARCHS"
             )
           else
             CONFOPT+=(
@@ -215,8 +242,8 @@ jobs:
           # Smoketest scripting languages
           macvim_excmd -c 'lua print("Test")'
           macvim_excmd -c 'perl VIM::Msg("Test")'
-          macvim_excmd -c 'py import sys; print("Test")'
-          macvim_excmd -c 'py3 import sys; print("Test")'
+          macvim_excmd -c 'py print "Test"'
+          macvim_excmd -c 'py3 print("Test")'
           macvim_excmd -c 'ruby puts("Test")'
 
           # Check that localized messages work by printing ':version' and checking against localized word
@@ -231,8 +258,10 @@ jobs:
           # Make sure we are building universal x86_64 / arm64 builds and didn't accidentally create a thin app.
           check_arch() {
             local archs=($(lipo -archs "$1"))
-            if [[ ${archs[@]} != "x86_64 arm64" ]]; then
+            if [[ ${archs[@]} != "$MACVIM_ARCHS" ]]; then
               echo "Wrong arch(s) in $1: ${archs[@]}"; false
+            else
+              lipo -info "$1"
             fi
           }
           check_arch "${VIM_BIN}"
@@ -258,9 +287,13 @@ jobs:
           # CI environment.
           make -C src macvim-dmg CREATEDMG_FLAGS=--skip-jenkins
 
+          if ${{ matrix.publish_postfix != '' }}; then
+            mv src/MacVim/build/Release/MacVim.dmg src/MacVim/build/Release/MacVim${{ matrix.publish_postfix }}.dmg
+          fi
+
       - name: Upload MacVim image
         if: startsWith(github.ref, 'refs/tags/') && matrix.publish
         uses: actions/upload-artifact@v3
         with:
-          name: MacVim.dmg
-          path: src/MacVim/build/Release/MacVim.dmg
+          name: MacVim${{ matrix.publish_postfix  }}.dmg
+          path: src/MacVim/build/Release/MacVim${{ matrix.publish_postfix }}.dmg


### PR DESCRIPTION
SDK for the new macOS 13 (released as part of Xcode 14.1) increased the minimum deployed OS from 10.9 to 10.13. Since we still want to support a minimum OS requirement of 10.9, while building against the latest SDK to get the most up-to-date features, we have to split the build process to build two separate binaries. A regular MacVim that targets the macOS 13 SDK (with min OS target 10.13), and a "legacy" MacVim that targets the macOS 12 SDK (with min OS target 10.9).

Change the GitHub Action CI config to have two separate matrix entries that publish, with one having a "legacy" flag set, which will use the older version of Xcode and the correct env vars set. It will also only build for x86-64 (no arm64) since currently all Apple Silicon hardware can run the latest versions of macOS and would have no need to run legacy builds.

Also, fix some scripting issues:

- fix Python 2 library path set incorrectly
- Update Perl to 5.30 from 5.18, as 5.18 is no longer installed in macOS 13. We could potentially change Perl to use the Homebrew version instead similar to how Python and other scripting languages are done but for now this works fine (except it won't work on older macOS versions). Perl is a rarely used language for Vim plugins anyway.

See https://github.com/macvim-dev/macvim/discussions/1288