### PR TITLE
Fix opening a tab crashing MacVim

### DIFF
--- a/src/MacVim/PSMTabBarControl/source/PSMRolloverButton.m
+++ b/src/MacVim/PSMTabBarControl/source/PSMRolloverButton.m
@@ -52,7 +52,9 @@
 
 - (void)removeTrackingRect
 {
-    [self removeTrackingRect:_myTrackingRectTag];
+    if (_myTrackingRectTag != 0)
+        [self removeTrackingRect:_myTrackingRectTag];
+    _myTrackingRectTag = 0;
 }
 
 // override for rollover effect


### PR DESCRIPTION
This seems to be a really old bug but new interactions with macOS (probably due to macOS 13 Ventura) caused it to surface and crash. Previously it was assuming a call to removeTrackingRect must always come only after addTrackingRect was called, which was not a good assumption to make. As a result, we could call this and end up triggering other code in macOS when passing in a 0 tracking tag.

Fix #1333