### PR TITLE
Allow never opening window + terminate on last window, with guards

### DIFF
--- a/src/MacVim/Base.lproj/Preferences.xib
+++ b/src/MacVim/Base.lproj/Preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment version="1090" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -67,7 +67,6 @@
                                 </column>
                             </cells>
                             <connections>
-                                <action selector="openUntitledWindowChanged:" target="-2" id="S8l-uX-tEl"/>
                                 <binding destination="58" name="selectedTag" keyPath="values.MMUntitledWindow" id="171"/>
                             </connections>
                         </matrix>
@@ -180,7 +179,6 @@
                                 </menu>
                             </popUpButtonCell>
                             <connections>
-                                <action selector="lastWindowClosedChanged:" target="-2" id="IcT-7v-gxr"/>
                                 <binding destination="58" name="selectedIndex" keyPath="values.MMLastWindowClosedBehavior" id="968"/>
                             </connections>
                         </popUpButton>

--- a/src/MacVim/MMAppController.h
+++ b/src/MacVim/MMAppController.h
@@ -49,6 +49,8 @@
     int                 numChildProcesses;
     NSMutableDictionary *inputQueues;
     int                 processingFlag;
+
+    BOOL                hasShownWindowBefore;
     
 #if !DISABLE_SPARKLE
 #if USE_SPARKLE_1

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -548,17 +548,6 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender
 {
-    if (MMUntitledWindowNever ==
-        [[NSUserDefaults standardUserDefaults]
-         integerForKey:MMUntitledWindowKey]) {
-        // Sanity protection: If we never open a new window on application launch, there could
-        // be an issue here where we immediately terminate MacVim. Because of that, we always
-        // return false regardless of what MMLastWindowClosedBehavior is. Note that the user
-        // should not be able to set these two conflicting options together in the preference pane
-        // but it's possible to do so in the terminal by calling "defaults" manually.
-        return false;
-    }
-
     return (MMTerminateWhenLastWindowClosed ==
             [[NSUserDefaults standardUserDefaults]
                 integerForKey:MMLastWindowClosedBehaviorKey]);

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -548,6 +548,15 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender
 {
+    if (!hasShownWindowBefore) {
+        // If we have not opened a window before, never return YES. This can
+        // happen when MacVim is not configured to open window at launch. We
+        // want to give the user a chance to open a window first. Otherwise
+        // just opening the About MacVim or Settings windows could immediately
+        // terminate the app (since those are not proper app windows),
+        // depending if the OS feels like invoking this method.
+        return NO;
+    }
     return (MMTerminateWhenLastWindowClosed ==
             [[NSUserDefaults standardUserDefaults]
                 integerForKey:MMLastWindowClosedBehaviorKey]);
@@ -888,6 +897,8 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         [NSApp activateIgnoringOtherApps:YES];
         shouldActivateWhenNextWindowOpens = NO;
     }
+
+    hasShownWindowBefore = YES;
 }
 
 - (void)setMainMenu:(NSMenu *)mainMenu

--- a/src/MacVim/MMPreferenceController.m
+++ b/src/MacVim/MMPreferenceController.m
@@ -167,36 +167,6 @@
     [[MMAppController sharedInstance] refreshAllFonts];
 }
 
--(IBAction)lastWindowClosedChanged:(id)sender
-{
-    // Sanity checking for terminate when last window closed + not opening an untitled window.
-    // This results in a potentially awkward situation wehre MacVim will close itself since it
-    // doesn't have any window opened when launched.
-    // Note that the potentially bad behavior is already protected against for in applicationShouldTerminateAfterLastWindowClosed:,
-    // but this sanity checking is to make sure the user can see that in an explicit fashion.
-    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
-    if ([defaults integerForKey:MMLastWindowClosedBehaviorKey] == MMTerminateWhenLastWindowClosed) {
-        if ([defaults integerForKey:MMUntitledWindowKey] == MMUntitledWindowNever) {
-            [defaults setInteger:MMUntitledWindowOnOpen forKey:MMUntitledWindowKey];
-        }
-    }
-}
-
--(IBAction)openUntitledWindowChanged:(id)sender
-{
-    // Sanity checking for terminate when last window closed + not opening an untitled window.
-    // This results in a potentially awkward situation wehre MacVim will close itself since it
-    // doesn't have any window opened when launched.
-    // Note that the potentially bad behavior is already protected against for in applicationShouldTerminateAfterLastWindowClosed:,
-    // but this sanity checking is to make sure the user can see that in an explicit fashion.
-    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
-    if ([defaults integerForKey:MMLastWindowClosedBehaviorKey] == MMTerminateWhenLastWindowClosed) {
-        if ([defaults integerForKey:MMUntitledWindowKey] == MMUntitledWindowNever) {
-            [defaults setInteger:MMHideWhenLastWindowClosed forKey:MMLastWindowClosedBehaviorKey];
-        }
-    }
-}
-
 - (IBAction)smoothResizeChanged:(id)sender
 {
     [[MMAppController sharedInstance] refreshAllResizeConstraints];


### PR DESCRIPTION
Previously we disabled this combo in f6ba7dd40be20 because when implemented naively, it causes an issue where just opening an About MacVim or Settings window could immediately cause MacVim to exit (because macOS determined that there were no non-auxillary window open).  This was awkward and potentially made it hard to change the setting back, and exact behavior depended on OS behavior.

However, it seems like there are legit use case for this combo of settings. Change it so that we allow setting both of them again, but add checks so that `applicationShouldTerminateAfterLastWindowClosed:` will only return `YES` if we have opened at least one Vim window before. This gives the user a chance to open a window first, so using Settings etc wouldn't immediately terminate the app.

Fix #1338
