### PR TITLE
Update Python3 from 3.10 to 3.11 in CI

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -20,16 +20,17 @@ env:
 
   CC: clang
 
-  VERSIONER_PERL_VERSION: '5.30'
-  VERSIONER_PYTHON_VERSION: '2.7'
+  VERSIONER_PERL_VERSION: '5.30'  # macOS default Perl installation uses this to determine which one to use
+  PYTHON3_VERSION: '3.11'         # Make sure to keep src/MacVim/vimrc synced with the Python version here for the Python DLL detection logic.
+
   vi_cv_path_python: /usr/local/bin/python
   vi_cv_path_python3: /usr/local/bin/python3
   vi_cv_path_plain_lua: /usr/local/bin/lua
   vi_cv_path_ruby: /usr/local/opt/ruby/bin/ruby
-  vi_cv_dll_name_perl: /System/Library/Perl/5.30/darwin-thread-multi-2level/CORE/libperl.dylib
+  vi_cv_dll_name_perl: /System/Library/Perl/%s/darwin-thread-multi-2level/CORE/libperl.dylib
   vi_cv_dll_name_python: /usr/local/Frameworks/Python.framework/Versions/2.7/Python
-  vi_cv_dll_name_python3: /usr/local/Frameworks/Python.framework/Versions/3.10/Python # Make sure to keep src/MacVim/vimrc synced with the Python version here for the Python DLL detection logic.
-  vi_cv_dll_name_python3_arm64: /opt/homebrew/Frameworks/Python.framework/Versions/3.10/Python
+  vi_cv_dll_name_python3: /usr/local/Frameworks/Python.framework/Versions/%s/Python
+  vi_cv_dll_name_python3_arm64: /opt/homebrew/Frameworks/Python.framework/Versions/%s/Python
   vi_cv_dll_name_ruby: /usr/local/opt/ruby/lib/libruby.dylib
   vi_cv_dll_name_ruby_arm64: /opt/homebrew/opt/ruby/lib/libruby.dylib
   vi_cv_dll_name_lua_arm64: /opt/homebrew/lib/liblua.dylib
@@ -137,6 +138,23 @@ jobs:
             # We just use system perl to reduce dependencies
             brew unlink perl
           fi
+
+          # With Perl and Python, we need to manually specify the version number for various reasons
+          # (e.g. library paths include the version number). Because of that, check that the version
+          # matches the expectation and fail if they don't, so we can go and fix it. Only do for
+          # Python because a wrong Perl version would just fail the build later.
+          if [[ "$(python3 --version)" != *"Python $PYTHON3_VERSION"* ]]; then
+            printf "\n"
+            echo "Wrong Python 3 version: $(python3 --version). Expected $PYTHON3_VERSION."
+            printf "\n"
+            echo "This likely happened because Homebrew was updated to point to a newer version of"
+            echo "Python 3. Update PYTHON3_VERSION to fix this."
+            exit -1
+          fi
+
+          echo "vi_cv_dll_name_perl=$(printf $vi_cv_dll_name_perl $VERSIONER_PERL_VERSION)" >> $GITHUB_ENV
+          echo "vi_cv_dll_name_python3=$(printf $vi_cv_dll_name_python3 $PYTHON3_VERSION)" >> $GITHUB_ENV
+          echo "vi_cv_dll_name_python3_arm64=$(printf $vi_cv_dll_name_python3_arm64 $PYTHON3_VERSION)" >> $GITHUB_ENV
 
       # All set up steps are done. Build and test MacVim below.
 

--- a/src/MacVim/vimrc
+++ b/src/MacVim/vimrc
@@ -32,12 +32,12 @@ endif
 " or an installation from python.org:
 if exists("&pythonthreedll") && exists("&pythonthreehome") &&
       \ !filereadable(&pythonthreedll)
-  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.10/Python")
-    " MacPorts python 3.10
-    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.10/Python
-  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.10/Python")
+  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.11/Python")
+    " MacPorts python
+    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.11/Python
+  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.11/Python")
     " https://www.python.org/downloads/mac-osx/
-    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.10/Python
+    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.11/Python
   endif
 endif
 


### PR DESCRIPTION
Also, refactor CI configs to only specify the Python 3 and Perl versions in one place, so we don't have to multiple lines in the config file.  Additionally, add checks to make sure the Homebrew Python 3 version matches the configured one, so we will have a failed build and be notified this way instead of silently building against an old version of Python in CI, which would still work as GitHub CI has older versions of Python installed.
