### PR TITLE
Fix misc CoreText rendering bugs and issues with clipping and composing characters

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -290,6 +290,7 @@ KEY				VALUE ~
 *MMNoTitleBarWindow*		hide title bar [bool]
 *MMTitlebarAppearsTransparent*	enable a transparent titlebar [bool]
 *MMAppearanceModeSelection*	dark mode selection (|macvim-dark-mode|)[bool]
+*MMRendererClipToRow*		clip tall characters to the row they are on [bool]
 *MMSmoothResize*		allow smooth resizing of MacVim window [bool]
 *MMShareFindPboard*		share search text to Find Pasteboard [bool]
 *MMShowAddTabButton*		enable "add tab" button on tabline [bool]

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5498,6 +5498,7 @@ MMNoFontSubstitution	gui_mac.txt	/*MMNoFontSubstitution*
 MMNoTitleBarWindow	gui_mac.txt	/*MMNoTitleBarWindow*
 MMNonNativeFullScreenSafeAreaBehavior	gui_mac.txt	/*MMNonNativeFullScreenSafeAreaBehavior*
 MMNonNativeFullScreenShowMenu	gui_mac.txt	/*MMNonNativeFullScreenShowMenu*
+MMRendererClipToRow	gui_mac.txt	/*MMRendererClipToRow*
 MMShareFindPboard	gui_mac.txt	/*MMShareFindPboard*
 MMShowAddTabButton	gui_mac.txt	/*MMShowAddTabButton*
 MMSmoothResize	gui_mac.txt	/*MMSmoothResize*

--- a/src/MacVim/Base.lproj/Preferences.xib
+++ b/src/MacVim/Base.lproj/Preferences.xib
@@ -425,8 +425,8 @@
                         <button id="A48-s0-kdR" userLabel="Preserve Line Spacing">
                             <rect key="frame" x="189" y="-1" width="244" height="18"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                            <string key="toolTip">Some fonts have non-standard built-in line spacings (anything other than 1). If this is checked, MacVim will use the font's specified line spacing to calculate line height. Otherwise, it will just set it to 1, which helps if you would like a more compact spacing without having to install another font.</string>
-                            <buttonCell key="cell" type="check" title="Preserve font line spacing" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="SeR-yl-Gtz" userLabel="Preserve Line Spacing">
+                            <string key="toolTip">macOS can sometimes use a conservative approach to calculating line spacing for a font (by setting a 1.2 line spacing). This could potentially lead to line spacing feeling too wide. Unchecking this will use a tighter calculation and use a 1.0 line spacing instead.</string>
+                            <buttonCell key="cell" type="check" title="Use macOS line spacing calculation" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="SeR-yl-Gtz" userLabel="Preserve Line Spacing">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
                             </buttonCell>

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -260,6 +260,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         [NSNumber numberWithBool:YES],    MMShareFindPboardKey,
         [NSNumber numberWithBool:NO],     MMSmoothResizeKey,
         [NSNumber numberWithBool:NO],     MMCmdLineAlignBottomKey,
+        [NSNumber numberWithBool:NO],     MMRendererClipToRowKey,
         [NSNumber numberWithBool:YES],    MMAllowForceClickLookUpKey,
         [NSNumber numberWithBool:NO],     MMUpdaterPrereleaseChannelKey,
         nil];

--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -12,6 +12,8 @@
 
 @class MMTextViewHelper;
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 /// The main text view that manages drawing Vim's content using Core Text, and
 /// handles input. We are using this instead of NSTextView because of the
@@ -84,7 +86,7 @@
 //
 // NSFontChanging methods
 //
-- (void)changeFont:(id)sender;
+- (void)changeFont:(nullable id)sender;
 
 //
 // NSMenuItemValidation
@@ -100,7 +102,7 @@
 - (IBAction)paste:(id)sender;
 - (IBAction)undo:(id)sender;
 - (IBAction)redo:(id)sender;
-- (IBAction)selectAll:(id)sender;
+- (IBAction)selectAll:(nullable id)sender;
 
 //
 // MMTextStorage methods
@@ -186,3 +188,5 @@
 @interface MMCoreTextView (ToolTip)
 - (void)setToolTipAtMousePoint:(NSString *)string;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -434,7 +434,7 @@ static void grid_free(Grid *grid) {
     } else {
         font = [newFont retain];
     }
-    fontDescent = ceil(CTFontGetDescent((CTFontRef)font));
+    fontDescent = CTFontGetDescent((CTFontRef)font);
     fontAscent = CTFontGetAscent((CTFontRef)font);
     fontXHeight = CTFontGetXHeight((CTFontRef)font);
 

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -61,6 +61,7 @@ extern NSString *MMNonNativeFullScreenShowMenuKey;
 extern NSString *MMNonNativeFullScreenSafeAreaBehaviorKey;
 extern NSString *MMSmoothResizeKey;
 extern NSString *MMCmdLineAlignBottomKey;
+extern NSString *MMRendererClipToRowKey;
 extern NSString *MMAllowForceClickLookUpKey;
 extern NSString *MMUpdaterPrereleaseChannelKey;
 

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -57,6 +57,7 @@ NSString *MMNonNativeFullScreenShowMenuKey  = @"MMNonNativeFullScreenShowMenu";
 NSString *MMNonNativeFullScreenSafeAreaBehaviorKey = @"MMNonNativeFullScreenSafeAreaBehavior";
 NSString *MMSmoothResizeKey               = @"MMSmoothResize";
 NSString *MMCmdLineAlignBottomKey         = @"MMCmdLineAlignBottom";
+NSString *MMRendererClipToRowKey      = @"MMRendererClipToRow";
 NSString *MMAllowForceClickLookUpKey      = @"MMAllowForceClickLookUp";
 NSString *MMUpdaterPrereleaseChannelKey   = @"MMUpdaterPrereleaseChannel";
 


### PR DESCRIPTION
This fixes a couple outstanding CoreText rendering issues with more complicated characters. Separated them into separate commits to make the changes easier to identify.

---

# Rename the "preserve line spacing" setting to "use macOS calculation"

The setting was added to "preserve" the font's original line spacing intents, but after further investigation I cannot find why Apple's calculation for font line spacing to be so wide. Furthermore it's quite odd because the default line spacing is wide, but the only thing that setting does is by re-initializing the font under Core Text (instead of using NSFont like the default) using CTFont and somehow the issue is fixed. Inspecting font metrics (using ttx) also didn't seem to give any hints why the spacing are so wide (e.g. ascent / descent / line gap etc all look fine). A StackOverflow comment seems to suggest that Apple is simply adding a 1.2x scale to some fonts (https://stackoverflow.com/questions/5511830/how-does-line-spacing-work-in-core-text-and-why-is-it-different-from-nslayoutm) which seems to match the observation. My guess is that Apple looks at some fonts and think they are too aggressive in their font metrics design and "helpfully" introduces a 1.2x multiplier to space them out, where Core Text is lower level than AppKit and therefore does not have this auto-inflation.

By renaming the option it should make it clearer that this is a somewhat arbitrary distinction instead of it being an inherent property of the font.

---

# Remove the ceil() call around fontDescent in Core Text renderer

I have looked and I do not believe there is a good reason to do this rounding up at all. I believe the motivation is to align the baseline with the pixel boundary, but I don't believe that is necessary, given that Core Text will properly perform the correct antialiasing for us.  Most texts aren't directly aligned at the baseline anyway. Before, that ceil() option is a reason why sometimes fonts would feel pushed upwards, clipping emojis to the top, and creating a lopsided effect for fonts like Fira Code (h11), since we draw the boxes aligned to the line height at the bottom of the descender, meaning the ceil() has an effect of pushing the text up.

---

# Fix composing characters renderered at an offset

MacVim previously didn't really render composing characters with multiple glyphs correctly. For simple ones like 'â' it would work fine because Core Text just generates one glyph for it, but for more complicated ones like 'x⃗' the renderer didn't properly query the advance of the glyphs to put them at the correct position. Refactor the logic to keep track of the current cell/glyphs and make sure to track the advances fo the glyphs so the composing chars' glyphs would be laid out properly on top of the cell.

We need to be careful with the tracking, because in Vim we force the text rendering to be monospaced, and so we maintain the tracking within a single grapheme (which can consist of multiple glyphs), but when we move to the next grapheme we reset the position so we can get proper monospaced rendering even for non-monospaced texts like CJK or stylized texts.

Fix #995
Fix #1172


---

# Fix CoreText clipping issues with tall texts

This fixes the issue where particularly tall characters will get clipped at the row boundary. This happens because even though a font describes the line height with font metrics, individual glyphs do not have to respect them, and we can see with emoji rendering sometimes they can poke upwards past the line height. Also, it's trivially easy to construct composing characters that become really tall, e.g. "x゙̂⃗", or Tibetan scripts like "ཧཱུྃ".

To fix this, we do the following:

1. Remove the explicit clipping call at rendering.

2. Fix partial redraw to not lead to clipping / corruption. This is quite tricky, because let's say we have a character that is tall enough to touch other lines, if those lines are redraw but not the line with the tall char, the redraw will paint over the parts of the glyphs poking through. Alternatively if we redraw the line with the tall chars we also need to expand the redraw region to make sure other lines get repainted as well. To fix this properly, we should do a proper glyph calculation when we receive the draw command before we issue before we call `setNeedsDisplayInRect`, but since right now we only extract glyph info later (during drawRect call), it's too late.  We just do the hacky solution by storing a variable `redrawExpandRows` that tracks how many lines to expand for all lines. It's a little hacky since this will affect all lines permanently regardless if they have tall characters or not. The proper fix may come later as an optimization (or when we do hardware rendering via Metal).

3. Re-order the rendering so we have a two pass system, where we first draw the background fill color for all rows, then the text. This helps prevent things like Vim's window split or cursorline from obscuring the text.

4. Add a preference to turn on clipping (old behavior). This helps prevent odd issues with really tall texts (e.g. Zalgo text) making it hard to see what's going on. The preference `MMRendererClipToRow` is not exposed in UI for now as it's a relatively niche. It will be exposed later when we have a dedicated render tab in settings.

Note that a lot of these characters only show their full height by doing `set maxcombine=8` because the default (2) is quite low.

Part of the fix for #995

