### PR TITLE
Report better version in About MacVim, and store last used version

### DIFF
--- a/src/MacVim/MMApplication.m
+++ b/src/MacVim/MMApplication.m
@@ -53,7 +53,7 @@
     NSString *marketingVersion = [[NSBundle mainBundle]
             objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     NSString *title = [NSString stringWithFormat:
-            @"Custom Version %@ (%@)", marketingVersion, version];
+            @"Vim %@ (MacVim r%@)", marketingVersion, version];
 
     [self orderFrontStandardAboutPanelWithOptions:
             [NSDictionary dictionaryWithObjectsAndKeys:

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -64,6 +64,7 @@ extern NSString *MMCmdLineAlignBottomKey;
 extern NSString *MMRendererClipToRowKey;
 extern NSString *MMAllowForceClickLookUpKey;
 extern NSString *MMUpdaterPrereleaseChannelKey;
+extern NSString *MMLastUsedBundleVersionKey;    // The last used version of MacVim before this launch
 
 
 // Enum for MMUntitledWindowKey

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -60,6 +60,7 @@ NSString *MMCmdLineAlignBottomKey         = @"MMCmdLineAlignBottom";
 NSString *MMRendererClipToRowKey      = @"MMRendererClipToRow";
 NSString *MMAllowForceClickLookUpKey      = @"MMAllowForceClickLookUp";
 NSString *MMUpdaterPrereleaseChannelKey   = @"MMUpdaterPrereleaseChannel";
+NSString *MMLastUsedBundleVersionKey        = @"MMLastUsedBundleVersion";
 
 
 @implementation NSIndexSet (MMExtras)


### PR DESCRIPTION
Use a better format for the version reporting in the "About MacVim" page to be clear what's the Vim version, and what's specifically the MacVim release number. It will now say something like "Vim 9.0.1234 (MacVim r123)".

Also, store the last used MacVim version number. This isn't used right now but may be used later for showing up a "What's New" page when updating to a new version, primarily for non-Sparkle users (e.g. Homebrew builds) so they can still be notified when something changed. Storing this number now allows us to know in a later build whether the user has upgraded to the build or starting a new build from fresh (where we may not want to show the "What's New" page as everything would be new).

Part of addressing #1293