### PR TITLE
Fix MacVim code signing script to work with Sparkle 1

### DIFF
--- a/src/MacVim/scripts/sign-developer-id
+++ b/src/MacVim/scripts/sign-developer-id
@@ -27,6 +27,7 @@ else
     # explicit and sign everything in order to be clear what we are doing.
     if [ -d "$macvim_path/Contents/Frameworks/Sparkle.framework/Versions/A" ]; then
         (set -x
+        codesign -f -s "Developer ID Application" -o runtime --timestamp "$macvim_path/Contents/Frameworks/Sparkle.framework/Versions/A/Resources/Autoupdate.app/Contents/MacOS/fileop"
         codesign -f -s "Developer ID Application" -o runtime --timestamp "$macvim_path/Contents/Frameworks/Sparkle.framework/Versions/A/Resources/Autoupdate.app")
     fi
     if [ -d $macvim_path/Contents/Frameworks/Sparkle.framework/Versions/B ]; then


### PR DESCRIPTION
We previously removed the --deep flag from signing, which missed one of the executable within Sparkle 1 that we need to sign expicitly (Sparkle 1 is still used for legacy builds).