### PR TITLE
Allow Sparkle release notes to use JavaScript so videos work

### DIFF
--- a/src/MacVim/Info.plist
+++ b/src/MacVim/Info.plist
@@ -1309,6 +1309,8 @@
 			</dict>
 		</dict>
 	</array>
+	<key>SUEnableJavaScript</key>
+	<string>YES</string>
 	<key>SUFeedURL</key>
 	<string>https://macvim.org/appcast/latest.xml</string>
 	<key>SUPublicEDKey</key>


### PR DESCRIPTION
Currently, it's hard to embed video in the release notes shown to Sparkle, because by default it disables JavaScript, which video tags need in order to work properly for the WebKit embedded browser. Turn it on, so that we can show video instead of animated GIF's in the future for release notes.

I don't think there should be any serious security issues after thinking about it. The browser is sandboxed and we are serving this through https anyway.