### PR TITLE
Fix remaining tab crash from not clearing tracking tags correctly

### DIFF
--- a/src/MacVim/PSMTabBarControl/source/PSMTabBarControl.m
+++ b/src/MacVim/PSMTabBarControl/source/PSMTabBarControl.m
@@ -476,9 +476,11 @@
     [[NSNotificationCenter defaultCenter] removeObserver:cell];
     if([cell closeButtonTrackingTag] != 0){
         [self removeTrackingRect:[cell closeButtonTrackingTag]];
+        [cell setCloseButtonTrackingTag:0];
     }
     if([cell cellTrackingTag] != 0){
         [self removeTrackingRect:[cell cellTrackingTag]];
+        [cell setCellTrackingTag:0];
     }
 
     // pull from collection
@@ -665,9 +667,11 @@
         [[NSNotificationCenter defaultCenter] removeObserver:cell];
         if([cell closeButtonTrackingTag] != 0){
             [self removeTrackingRect:[cell closeButtonTrackingTag]];
+            [cell setCloseButtonTrackingTag:0];
         }
         if([cell cellTrackingTag] != 0){
             [self removeTrackingRect:[cell cellTrackingTag]];
+            [cell setCellTrackingTag:0];
         }
     }
 


### PR DESCRIPTION
Similar to #1334. The old PSMTabBarControl code has a lot of dubious straggling states regarding the tracking tags. Seems like previous macOS versions tolerated that but in the newer macOS versions, the tags seem to be reused for other purposes and so when you double-remove the tags, you get into trouble.

Related to #1333