### PR TITLE
Remove Sparkle 2's XPCServices symlink

### DIFF
--- a/src/MacVim/scripts/cleanup-after-build
+++ b/src/MacVim/scripts/cleanup-after-build
@@ -11,6 +11,7 @@ set -e
 
 macvim_path=$1
 
+sparkle_xpcservices_symlink="$macvim_path/Contents/Frameworks/Sparkle.framework/XPCServices"
 sparkle_xpcservices="$macvim_path/Contents/Frameworks/Sparkle.framework/Versions/Current/XPCServices"
 
 if [ -d "$sparkle_xpcservices" ]; then
@@ -19,4 +20,5 @@ if [ -d "$sparkle_xpcservices" ]; then
     # otherwise. See https://sparkle-project.org/documentation/sandboxing/.
     set -x
     rm -rf "$sparkle_xpcservices"
+    rm "$sparkle_xpcservices_symlink"
 fi


### PR DESCRIPTION
We are already removing the XPCServices folder in Sparkle 2 because it's unnecessary for us, but there's a top-level symlink that still refers to the folder, and its existence could potentially break automated scripts and whatnot. Just clean it up and remove it as well in the cleanup script.

Fix #1366