### PR TITLE
Fix Xcode 8 build breaks

### DIFF
--- a/src/MacVim/MMFindReplaceController.m
+++ b/src/MacVim/MMFindReplaceController.m
@@ -8,6 +8,7 @@
  * See README.txt for an overview of the Vim source code.
  */
 
+#import "MacVim.h"
 #import "MMFindReplaceController.h"
 
 

--- a/src/MacVim/MMTextViewHelper.m
+++ b/src/MacVim/MMTextViewHelper.m
@@ -1072,7 +1072,7 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
     static NSCursor *ibeamCursor = nil;
 
     if (!ibeamCursor) {
-        if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_14)
+        if (AVAILABLE_MAC_OS(10, 14))
         {
             // macOS 10.14 (Mojave) introduced dark mode, and seems to have
             // added a thick white border around the system I-beam cursor,

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -177,7 +177,7 @@ static BOOL isUnsafeMessage(int msgid);
     popupMenuItems = [[NSMutableArray alloc] init];
     toolbarItemDict = [[NSMutableDictionary alloc] init];
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
-    if (@available(macos 10.12.2, *)) {
+    if (AVAILABLE_MAC_OS_PATCH(10, 12, 2)) {
         touchbarInfo = [[MMTouchBarInfo alloc] init];
     }
 #endif
@@ -1425,7 +1425,7 @@ static BOOL isUnsafeMessage(int msgid);
 
     if ([rootName isEqual:MMTouchbarMenuName]) {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
-        if (@available(macos 10.12.2, *)) {
+        if (AVAILABLE_MAC_OS_PATCH(10, 12, 2)) {
             if ([desc count] < 2) // Cannot be 1, as we need at least TouchBar.<menu_name>
                 return;
             if ([desc count] >= 3) // Unfortunately currently Apple does not support nested popover's so we can only do one level nesting
@@ -1509,7 +1509,7 @@ static BOOL isUnsafeMessage(int msgid);
         if ([desc count] >= 4) // Unfortunately currently Apple does not support nested popover's so we can only do one level nesting
             return;
 
-        if (@available(macos 10.12.2, *)) {
+        if (AVAILABLE_MAC_OS_PATCH(10, 12, 2)) {
             MMTouchBarInfo *submenuTouchbar = nil;
             if (![self touchBarItemForDescriptor:desc touchBar:&submenuTouchbar touchBarItem:nil]) {
                 return;
@@ -1597,7 +1597,7 @@ static BOOL isUnsafeMessage(int msgid);
     }
     if ([rootName isEqual:MMTouchbarMenuName]){
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
-        if (@available(macos 10.12.2, *)) {
+        if (AVAILABLE_MAC_OS_PATCH(10, 12, 2)) {
             MMTouchBarInfo *submenuTouchbar = nil;
             if (![self touchBarItemForDescriptor:desc touchBar:&submenuTouchbar touchBarItem:nil]) {
                 return;
@@ -1651,7 +1651,7 @@ static BOOL isUnsafeMessage(int msgid);
 
     if ([rootName isEqual:MMTouchbarMenuName]) {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
-        if (@available(macos 10.12.2, *)) {
+        if (AVAILABLE_MAC_OS_PATCH(10, 12, 2)) {
             MMTouchBarItemInfo *touchbarItem = nil;
             if (![self touchBarItemForDescriptor:desc touchBar:nil touchBarItem:&touchbarItem]) {
                 return;
@@ -1695,7 +1695,7 @@ static BOOL isUnsafeMessage(int msgid);
 
     if ([rootName isEqual:MMTouchbarMenuName]) {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
-        if (@available(macos 10.12.2, *)) {
+        if (AVAILABLE_MAC_OS_PATCH(10, 12, 2)) {
             MMTouchBarItemInfo *touchbarItem = nil;
             if (![self touchBarItemForDescriptor:desc touchBar:nil touchBarItem:&touchbarItem]) {
                 return;

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -142,7 +142,7 @@
     // setting it in macOS 11+.
     BOOL usingTexturedBackground = NO;
 #if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_VERSION_11_0
-    if (@available(macos 11.0, *)) {
+    if (AVAILABLE_MAC_OS(11, 0)) {
         // Don't set the textured background because it's been completely deprecated and won't do anything.
     } else {
         styleMask = styleMask | NSWindowStyleMaskTexturedBackground;
@@ -592,7 +592,7 @@
     
     // Transparent title bar setting
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
-    if (@available(macos 10.10, *)) {
+    if (AVAILABLE_MAC_OS(10, 10)) {
         decoratedWindow.titlebarAppearsTransparent = [ud boolForKey:MMTitlebarAppearsTransparentKey];
     }
 #endif
@@ -1800,7 +1800,7 @@
     // See initWithVimController: for textured background deprecation notes.
     BOOL windowTextured = NO;
 #if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_VERSION_11_0
-    if (@available(macos 11.0, *)) {
+    if (AVAILABLE_MAC_OS(11, 0)) {
     } else {
         windowTextured = ([decoratedWindow styleMask] &
                           NSWindowStyleMaskTexturedBackground) != 0;

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -62,11 +62,33 @@
 #ifndef NSAppKitVersionNumber10_12
 # define NSAppKitVersionNumber10_12 1504
 #endif
+#ifndef NSAppKitVersionNumber10_12_2
+# define NSAppKitVersionNumber10_12_2 1504.76
+#endif
 #ifndef NSAppKitVersionNumber10_13
 # define NSAppKitVersionNumber10_13 1561
 #endif
 #ifndef NSAppKitVersionNumber10_14
 # define NSAppKitVersionNumber10_14 1671
+#endif
+#ifndef NSAppKitVersionNumber11_0
+# define NSAppKitVersionNumber11_0 2022
+#endif
+
+// Macro to detect runtime OS version. Ideally, we would just like to use
+// @available to test for this because the compiler can optimize it out
+// depending on your min/max OS configuration. However, it was added in Xcode 9
+// (macOS 10.13 SDK). For any code that we want to be compilable for Xcode 8
+// (macOS 10.12) or below, we need to use the macro below which will
+// selectively use NSAppKitVersionNumber instead.
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_13
+// Xcode 9+, can use @available, which is more efficient.
+# define AVAILABLE_MAC_OS(MAJOR, MINOR) @available(macos MAJOR##.##MINOR, *)
+# define AVAILABLE_MAC_OS_PATCH(MAJOR, MINOR, PATCH) @available(macos MAJOR##.##MINOR##.##PATCH, *)
+#else
+// Xcode 8 or below. Use the old-school NSAppKitVersionNumber check.
+# define AVAILABLE_MAC_OS(MAJOR, MINOR) NSAppKitVersionNumber >= NSAppKitVersionNumber##MAJOR##_##MINOR
+# define AVAILABLE_MAC_OS_PATCH(MAJOR, MINOR, PATCH) NSAppKitVersionNumber >= NSAppKitVersionNumber##MAJOR##_##MINOR##_##PATCH
 #endif
 
 // Deprecated constants. Since these are constants, we just need the compiler,
@@ -111,6 +133,10 @@
 // Deprecated constants in 10.13 SDK
 #define NSControlStateValueOn NSOnState
 #define NSControlStateValueOff NSOffState
+
+// Newly introduced symbols in 10.13 SDK
+typedef NSString* NSPasteboardType;
+typedef NSString* NSAttributedStringKey;
 #endif
 
 // Deprecated runtime values. Since these are runtime values, we need to use the

--- a/src/os_mac.h
+++ b/src/os_mac.h
@@ -272,7 +272,8 @@
 
 # include <dispatch/dispatch.h>
 
-# ifndef MAC_OS_X_VERSION_10_12
+# if !defined(MAC_OS_X_VERSION_10_12) || \
+	(MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_12)
 typedef int clockid_t;
 # endif
 # ifndef CLOCK_REALTIME


### PR DESCRIPTION
This fixes build breaks on older Xcode versions (e.g. Xcode 8, on macOS 10.11). Fixes a couple issues:

- Vim's os_mac.h has an improperly specified backwards compatibility ifdef (https://github.com/vim/vim/pull/10549). It's just checking for existence of `MAC_OS_X_VERSION_10_12` instead of actually comparing it against `MAC_OS_X_VERSION_MAX_ALLOWED`. The previous code that it was fixing was comparing it against `MAC_OS_X_VERSION_MIN_REQUIRED` which was also wrong as the "min" just means the deploy target, whereas the "max" indicates the SDK you are compiling against.
- Unfortunately, the `@available` syntax for checking runtime version was only introduced in Xcode 9. To make the code compilable in earlier Xcode versions, introduce a new macro `AVAILABLE_MAC_OS` which will use `@available` if compiling on Xcode 9+ (which is the vast majority of cases), and use NSAppKitVersion checks on Xcode 8 or below. We would like to still use `@available` checks if possible because the compiler can optimize that out if it detects that you are deploying to a higher target than what you are checking.
- Some typedefs in MacVim are also introduced in 10.13+. Add those typedefs to MacVim.h

Fix #1342