### PR TITLE
Remove Homebrew no-auto-update env var from CI

### DIFF
--- a/.github/actions/universal-package/action.yml
+++ b/.github/actions/universal-package/action.yml
@@ -34,8 +34,6 @@ runs:
 
     - name: Install formula
       shell: bash
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: '1'
       run: |
         echo '::group::Install formula'
         formula=${{ inputs.formula }}

--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -115,8 +115,6 @@ jobs:
 
       - name: Install packages
         if: matrix.publish
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
           brew install python3
           brew install ruby


### PR DESCRIPTION
With the release of Homebrew 4, auto-update is supposed to be more efficient now. By removing the HOMEBREW_NO_AUTO_UPDATE env var from CI, this will make sure that all the packages that we link to in CI will be up to date instead of whatever just happens to be installed on the CI environment which can sometimes fluctuate.