### PR TITLE
Add security policy file / documentation

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+To report a security vulnerability for MacVim, please either email security@macvim.org, or visit https://github.com/macvim-dev/macvim/security/advisories/new.


### PR DESCRIPTION
GitHub has a security tab that allows repos to manage their security policy so it's not a bad idea ot be explicit in expectations. The policy is to either use GitHub's builtin reporting system, or email MacVim's team (in case that's the preferred method or the reporter does not want to have a GitHub account). The most important thing is to not use the public GitHub issue filing.

I don't think this will be used too much, but given that MacVim (and Vim) can read arbitrary file, there is always a potential for a security issue to pop up.