### PR TITLE
Fix `set fullscreen` not working after upstream Vim merge

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -3505,7 +3505,7 @@ did_set_textmode(optset_T *args)
     char *
 did_set_fullscreen(optset_T *args)
 {
-    long old_value = args->os_oldval.number;
+    int old_value = args->os_oldval.boolean;
     if (p_fullscreen && !old_value)
     {
 	guicolor_T fg, bg;


### PR DESCRIPTION
The recent upstream Vim merge (v9.0.1365) contained a lot of refactoring in the option setting code. Handling option setting was now done via a standardized callback, with a struct `optset_T`. In resolving the upstream merge conflicts, `did_set_fullscreen` was erroneously using the wrong value from the union (should be using boolean instead of number) which leads to it occasionally giving unpredictable results. Fix the bug.

Note that the bug seems a little unpredictable since it depends on compiler specifics. The only way it was known to trigger was by `set diff` followed by `set fullscreen`.

Fix #1378