### PR TITLE
Fix MacVim localized intro text, and don't hide the `:h version9` prompt

### DIFF
--- a/src/po/es.po
+++ b/src/po/es.po
@@ -3700,7 +3700,7 @@ msgstr "escriba  :help<Intro>  o  <F1>  para obtener ayuda     "
 
 # MacVim only
 msgid "type  :help macvim<Enter>     for MacVim help "
-msgstr "       escriba  «:help macvim<Enter>»  para obtener ayuda para MacVim"
+msgstr "escriba  :help macvim<Enter>  para obtener ayuda para MacVim"
 
 msgid "type  :help version9<Enter>   for version info"
 msgstr "escriba  :help version9<Intro>  para obtener información de la versión"

--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -3561,7 +3561,7 @@ msgstr "输入  :help<Enter>  或  <F1>  查看在线帮助    "
 
 # MacVim only
 msgid "type  :help macvim<Enter>     for MacVim help "
-msgstr "     输入  :help macvim<Enter>     查看 MacVim 的在线帮助"
+msgstr "      输入  :help macvim<Enter>     查看 MacVim 的在线帮助"
 
 msgid "type  :help version9<Enter>   for version info"
 msgstr "输入  :help version9<Enter>   查看版本信息    "

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -3561,7 +3561,7 @@ msgstr "输入  :help<Enter>  或  <F1>  查看在线帮助    "
 
 # MacVim only
 msgid "type  :help macvim<Enter>     for MacVim help "
-msgstr "     输入  :help macvim<Enter>     查看 MacVim 的在线帮助"
+msgstr "      输入  :help macvim<Enter>     查看 MacVim 的在线帮助"
 
 msgid "type  :help version9<Enter>   for version info"
 msgstr "输入  :help version9<Enter>   查看版本信息    "

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -3561,7 +3561,7 @@ msgstr "输入  :help<Enter>  或  <F1>  查看在线帮助    "
 
 # MacVim only
 msgid "type  :help macvim<Enter>     for MacVim help "
-msgstr "     输入  :help macvim<Enter>     查看 MacVim 的在线帮助"
+msgstr "      输入  :help macvim<Enter>     查看 MacVim 的在线帮助"
 
 msgid "type  :help version9<Enter>   for version info"
 msgstr "输入  :help version9<Enter>   查看版本信息    "

--- a/src/po/zh_TW.UTF-8.po
+++ b/src/po/zh_TW.UTF-8.po
@@ -4799,7 +4799,7 @@ msgstr "線上說明請輸入                :help<Enter>         "
 
 # MacVim only
 msgid "type  :help macvim<Enter>     for MacVim help "
-msgstr "MacVim 線上說明請輸入                :help<Enter>               "
+msgstr "MacVim 線上說明請輸入                :help<Enter>                "
 
 msgid "type  :help version9<Enter>   for version info"
 msgstr "新版本資訊請輸入              :help version9<Enter>"

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -4792,7 +4792,7 @@ msgstr "線上說明請輸入                :help<Enter>         "
 
 # MacVim only
 msgid "type  :help macvim<Enter>     for MacVim help "
-msgstr "MacVim 線上說明請輸入                :help<Enter>               "
+msgstr "MacVim 線上說明請輸入                :help<Enter>                "
 
 msgid "type  :help version9<Enter>   for version info"
 msgstr "新版本資訊請輸入              :help version9<Enter>"

--- a/src/version.c
+++ b/src/version.c
@@ -3933,11 +3933,10 @@ intro_message(
 	"",
 	N_("type  :q<Enter>               to exit         "),
 	N_("type  :help<Enter>  or  <F1>  for on-line help"),
+	N_("type  :help version9<Enter>   for version info"),
 #ifdef FEAT_GUI_MACVIM
         // TODO: Don't steal the show from version8 help?
 	N_("type  :help macvim<Enter>     for MacVim help "),
-#else
-	N_("type  :help version9<Enter>   for version info"),
 #endif
 	NULL,
 	"",


### PR DESCRIPTION
The Chinese alignment was slightly wrong when `columns` is even numbered. Add an additional space to make sure it will line up right. Also, for Spanish, just fix up the text to fit how the other intro help texts look.

Also, don't hide the `:help version9` prompt in intro. For some reason MacVim hides that prompt and shows the `:help macvim` prompt instead which makes no sense. Just show both.

Fix #1380