### PR TITLE
Fix CI not handling Xcode version correctly with packages

### DIFF
--- a/.github/actions/universal-package/action.yml
+++ b/.github/actions/universal-package/action.yml
@@ -11,6 +11,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up formula
+      id: setup-formula
       shell: bash
       run: |
         echo '::group::Set up formula'
@@ -23,6 +24,11 @@ runs:
 
         # Uninstall the already installed formula because we want to build our own
         brew uninstall --ignore-dependencies ${formula} || true
+
+        # Extract Xcode version to serve as part of the key for caching
+        xcode_version=$(xcodebuild -version | tail -1 | sed -E 's/Build version (.*)/\1/')
+        echo "xcode_version=$xcode_version" >> $GITHUB_OUTPUT
+
         echo '::endgroup::'
 
     - name: Cache keg
@@ -30,7 +36,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: /usr/local/Cellar/${{ inputs.formula }}
-        key: ${{ inputs.formula }}-homebrew-cache-patched-unified-${{ hashFiles(format('{0}.rb', inputs.formula)) }}
+        key: ${{ inputs.formula }}-homebrew-cache-patched-unified-xcode${{ steps.setup-formula.outputs.xcode_version }}-${{ hashFiles(format('{0}.rb', inputs.formula)) }}
 
     - name: Install formula
       shell: bash

--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -62,7 +62,7 @@ jobs:
 
           # Most up to date OS and Xcode. Used to publish release for the main build.
           - os: macos-12
-            xcode: '14.1'
+            xcode: '14.2'
             publish: true
 
     runs-on: ${{ matrix.os }}
@@ -81,6 +81,13 @@ jobs:
           # Use Sparkle 1 because Sparkle 2 requires newer OS version than our legacy build.
           # Later, we pass the --enable-sparkle_1 flag to configure to set the corresponding ifdef.
           ln -fhs Sparkle_1.framework src/MacVim/Sparkle.framework
+
+      - name: Set up Xcode
+        if: matrix.xcode != ''
+        run: |
+          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+          xcode-select -p
+          xcodebuild -version
 
       # Set up, install, and cache gettext library for localization.
       #
@@ -130,12 +137,6 @@ jobs:
             # We just use system perl to reduce dependencies
             brew unlink perl
           fi
-
-      - name: Set up Xcode
-        if: matrix.xcode != ''
-        run: |
-          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
-          xcode-select -p
 
       # All set up steps are done. Build and test MacVim below.
 


### PR DESCRIPTION
In the CI setup, xcode-select is only called after the packages have been set up, but during setup we actually need to build the packages from source to have the correct deployment target linked correctly. This means we could potentially be building with the wrong configuration (e.g. when building for 10.9 legacy builds, we could be using an Xcode version that's too new for that) when building gettext/libsodium. This is compounded by the fact that our GitHub Action cache key for the libraries only include the formula, but not the active Xcode version itself so a cache could be propagated for a while until suddenly things break.

To fix this, first make sure we do Xcode configuration early on in the build, and to properly use the Xcode version as part of the cache key. This way, when Xcode version changes, we will invalidate the cache and rebuild gettext / libsodium with the correct configuration and if that's wrong we will immediately fail the build instead of using old stale caches.