### PR TITLE
Fix misc MacVim project warnings in Xcode

### DIFF
--- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
+++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
@@ -890,6 +890,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 0710;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "MacVim" */;

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -4792,7 +4792,21 @@ rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
   else
     if test -z "$MACOSX_DEPLOYMENT_TARGET"; then
-      macosx_deployment_target=`/usr/bin/sw_vers -productVersion|/usr/bin/sed -e 's/^\([0-9]*\.[0-9]*\).*/\1/'`
+      # Deployment target not specified. We use the current OS' version. We
+      # only want to extract the main OS version but not the minor version for
+      # multiple reasons: it's more predictable if this is built from a CI to
+      # be deployed out (e.g. Homebrew), and sometimes deployment target
+      # that is too new will cause Xcode to complain (e.g. macOS is 13.2 while
+      # Xcode may only support up to 13.1)
+      macosx_major_version=`/usr/bin/sw_vers -productVersion|/usr/bin/sed -e 's/^\([0-9]*\)\.[0-9]*.*/\1/'`
+      macosx_minor_version=`/usr/bin/sw_vers -productVersion|/usr/bin/sed -e 's/^[0-9]*\.\([0-9]*\).*/\1/'`
+      if test "$macosx_major_version" = "10"; then
+        # Older versions look like 10.X.Y form where X is the main version.
+        macosx_deployment_target="$macosx_major_version.$macosx_minor_version"
+      else
+        # Since 11.0, We have X.Y.Z, where X is the main version.
+        macosx_deployment_target="$macosx_major_version.0"
+      fi
       XCODEFLAGS="$XCODEFLAGS MACOSX_DEPLOYMENT_TARGET=$macosx_deployment_target"
     else
       XCODEFLAGS="$XCODEFLAGS MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -298,7 +298,21 @@ if test "$vim_cv_uname_output" = Darwin; then
         LDFLAGS="$save_ldflags" ])
   else
     if test -z "$MACOSX_DEPLOYMENT_TARGET"; then
-      macosx_deployment_target=`/usr/bin/sw_vers -productVersion|/usr/bin/sed -e 's/^\([[0-9]]*\.[[0-9]]*\).*/\1/'`
+      # Deployment target not specified. We use the current OS' version. We
+      # only want to extract the main OS version but not the minor version for
+      # multiple reasons: it's more predictable if this is built from a CI to
+      # be deployed out (e.g. Homebrew), and sometimes deployment target
+      # that is too new will cause Xcode to complain (e.g. macOS is 13.2 while
+      # Xcode may only support up to 13.1)
+      macosx_major_version=`/usr/bin/sw_vers -productVersion|/usr/bin/sed -e 's/^\([[0-9]]*\)\.[[0-9]]*.*/\1/'`
+      macosx_minor_version=`/usr/bin/sw_vers -productVersion|/usr/bin/sed -e 's/^[[0-9]]*\.\([[0-9]]*\).*/\1/'`
+      if test "$macosx_major_version" = "10"; then
+        # Older versions look like 10.X.Y form where X is the main version.
+        macosx_deployment_target="$macosx_major_version.$macosx_minor_version"
+      else
+        # Since 11.0, We have X.Y.Z, where X is the main version.
+        macosx_deployment_target="$macosx_major_version.0"
+      fi
       XCODEFLAGS="$XCODEFLAGS MACOSX_DEPLOYMENT_TARGET=$macosx_deployment_target"
     else
       XCODEFLAGS="$XCODEFLAGS MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET"


### PR DESCRIPTION
Turn on parallel building, to remove the "Building targets in manual order is deprecated" project warning.

Also, fix configure to only set macOS deployment target to the major version of macOS when automatically setting it from the client OS version. E.g. On macOS 13.2 it will set deployment to 13.0. This is useful because usually we don't want it to be as granular as the minor version which had caused issues in Homebrew before (https://github.com/Homebrew/homebrew-core/issues/111693) where they had to fix on their end, and also 13.2 ends up being too new for Xcode which only expects to see up to 13.1 as deployment target.

- Note that the logic used to work in OSX 10.X days because the "minor" version of X is actually the OS version, whereas in macOS 11/12/13 we now have versions like 13.2 where the first number is now the OS version. The configure script will now detect whether it's 10.X.Y or X.Y (X != 10) and set the correct target correspondingly.