### PR TITLE
Fix MacVim CI breakage in Test_mouse_shape_after_cancelling_gr

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -418,6 +418,9 @@ normal_cmd_get_more_chars(
 #ifdef CURSOR_SHAPE
 	    ui_cursor_shape();	// show different cursor shape
 #endif
+#ifdef FEAT_MOUSESHAPE
+	    update_mouseshape(-1);
+#endif
 	}
 	if (lang && curbuf->b_p_iminsert == B_IMODE_LMAP)
 	{


### PR DESCRIPTION
Set mouseshape correctly when using 'r' or 'gr'. Otherwise Vim will only do it when mouse moves or window receives focus, which is a little random. This change will be ported upstream.