### PR TITLE
About MacVim show "pre-release" when running a pre-release build

### DIFF
--- a/src/MacVim/MMApplication.m
+++ b/src/MacVim/MMApplication.m
@@ -52,8 +52,12 @@
             @"CFBundleVersion"];
     NSString *marketingVersion = [[NSBundle mainBundle]
             objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+
+    BOOL isPrerelease = [version containsSubstring:@"."];
+    NSString *prerelease = isPrerelease ? @"\npre-release" : @"";
+
     NSString *title = [NSString stringWithFormat:
-            @"Vim %@ (MacVim r%@)", marketingVersion, version];
+            @"MacVim r%@ (Vim %@)%@", version, marketingVersion, prerelease];
 
     [self orderFrontStandardAboutPanelWithOptions:
             [NSDictionary dictionaryWithObjectsAndKeys:


### PR DESCRIPTION
This helps the user know whether they are using a relatively untested build and should consider going back to a main release. We currently just define "pre-release" build as any release version with a minor version, e.g. r176.1 is a pre-release, but r176 isn't.

Also, move the order around so we show "MacVim r123 (Vim 9.0.1234)" instead of "Vim 9.0.1234 (MacVim r123)" which is more consistent with other ways we show version numbers, and this will be how we show version number when we upgrade to Sparkle 2.4 as well.