### PR TITLE
Use more descriptive version string in Sparkle 2

### DIFF
--- a/src/MacVim/MMSparkle2Delegate.h
+++ b/src/MacVim/MMSparkle2Delegate.h
@@ -8,14 +8,23 @@
 
 #import "Sparkle.framework/Headers/Sparkle.h"
 
-@interface MMSparkle2Delegate : NSObject <SPUUpdaterDelegate, SPUStandardUserDriverDelegate>;
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MMSparkle2Delegate : NSObject <SPUUpdaterDelegate, SPUStandardUserDriverDelegate, SUVersionDisplay>;
 
 // SPUUpdaterDelegate
-- (nonnull NSSet<NSString *> *)allowedChannelsForUpdater:(nonnull SPUUpdater *)updater;
+- (NSSet<NSString *> *)allowedChannelsForUpdater:(SPUUpdater *)updater;
 
 // SPUStandardUserDriverDelegate
-// No need to implement anything for now. Default behaviors work fine.
+- (_Nullable id <SUVersionDisplay>)standardUserDriverRequestsVersionDisplayer;
+
+// SUVersionDisplay
+- (NSString *)formatUpdateDisplayVersionFromUpdate:(SUAppcastItem *)update andBundleDisplayVersion:(NSString * _Nonnull __autoreleasing * _Nonnull)inOutBundleDisplayVersion withBundleVersion:(NSString *)bundleVersion;
+
+- (NSString *)formatBundleDisplayVersion:(NSString *)bundleDisplayVersion withBundleVersion:(NSString *)bundleVersion matchingUpdate:(SUAppcastItem * _Nullable)matchingUpdate;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif

--- a/src/MacVim/MMSparkle2Delegate.m
+++ b/src/MacVim/MMSparkle2Delegate.m
@@ -24,6 +24,35 @@
     return [NSSet<NSString *> set];
 }
 
+- (_Nullable id <SUVersionDisplay>)standardUserDriverRequestsVersionDisplayer
+{
+    return self;
+}
+
+/// MacVim has a non-standard way of using "bundle version" and "display version",
+/// where the display version is the upstream Vim version, and the bundle version
+/// is the release number of MacVim itself. The release number is more useful to
+/// know when updating MacVim, but both should be displayed. Format them nicely so
+/// it's clear to the user which is which. By default Sparkle would only show display
+/// version which is problematic as that wouldn't show the release number which we
+/// care about.
+NSString* formatVersionString(NSString* bundleVersion, NSString* displayVersion)
+{
+    return [NSString stringWithFormat:@"r%@ (Vim %@)", bundleVersion, displayVersion];
+}
+
+- (NSString *)formatUpdateDisplayVersionFromUpdate:(SUAppcastItem *)update andBundleDisplayVersion:(NSString * _Nonnull __autoreleasing * _Nonnull)inOutBundleDisplayVersion withBundleVersion:(NSString *)bundleVersion
+{
+    *inOutBundleDisplayVersion = formatVersionString(bundleVersion, *inOutBundleDisplayVersion);
+    return formatVersionString(update.versionString, update.displayVersionString);
+}
+
+- (NSString *)formatBundleDisplayVersion:(NSString *)bundleDisplayVersion withBundleVersion:(NSString *)bundleVersion matchingUpdate:(SUAppcastItem * _Nullable)matchingUpdate
+{
+    return formatVersionString(bundleVersion, bundleDisplayVersion);
+}
+
+
 @end;
 
 #endif


### PR DESCRIPTION
Sparkle 2.4 added support for customizing the displayed version string instead of just showing the "display version" from the manifest (see https://github.com/sparkle-project/Sparkle/issues/2267). Since MacVim has a somewhat non-standard usage of bundle vs display version (bundle is release number, and display version is the upstream Vim version), we really want to show both to the user, in a concise manner. Support this customization so it looks like "r123 (Vim 9.1.2345)" (here, "123" is the bundle version / release number, and "9.1.2345" is the display version / Vim version).

Fix #1293