### PR TITLE
Don't build/install non-UTF-8 and encoding-converted locales

### DIFF
--- a/src/po/Make_all.mak
+++ b/src/po/Make_all.mak
@@ -6,7 +6,6 @@ LANGUAGES = \
 		af \
 		ca \
 		cs \
-		cs.cp1250 \
 		da \
 		de \
 		en_GB \
@@ -17,40 +16,49 @@ LANGUAGES = \
 		ga \
 		it \
 		ja \
-		ja.euc-jp \
-		ja.sjis \
-		ko \
 		ko.UTF-8 \
 		lv \
 		nb \
 		nl \
 		no \
 		pl \
-		pl.UTF-8 \
-		pl.cp1250 \
 		pt_BR \
 		ru \
-		ru.cp1251 \
 		sk \
-		sk.cp1250 \
 		sr \
 		sv \
 		tr \
 		uk \
-		uk.cp1251 \
 		vi \
-		zh_CN \
 		zh_CN.UTF-8 \
-		zh_CN.cp936 \
-		zh_TW \
 		zh_TW.UTF-8 \
 
+# MacVim: Don't bundle non-UTF-8 or encoding converted locale files as we always have iconv
+		#cs.cp1250 \
+		#ja.euc-jp \
+		#ja.sjis \
+		#ko \
+		#pl.cp1250 \
+		#pl.UTF-8 \
+		#ru.cp1251 \
+		#sk.cp1250 \
+		#uk.cp1251 \
+		#zh_CN \
+		#zh_CN.cp936 \
+		#zh_TW \
+
+
+# MacVim: We removed the non-UTF-8 base locales for these, so we upgrade the
+# <locale>.UTF-8 ones as base locales.
+LANGUAGES_UTF8_ONLY = \
+		ko \
+		zh_CN \
+		zh_TW \
 
 POFILES = \
 		af.po \
 		ca.po \
 		cs.po \
-		cs.cp1250.po \
 		da.po \
 		de.po \
 		en_GB.po \
@@ -61,33 +69,36 @@ POFILES = \
 		ga.po \
 		it.po \
 		ja.po \
-		ja.euc-jp.po \
-		ja.sjis.po \
-		ko.po \
 		ko.UTF-8.po \
 		lv.po \
 		nb.po \
 		nl.po \
 		no.po \
 		pl.po \
-		pl.UTF-8.po \
-		pl.cp1250.po \
 		pt_BR.po \
 		ru.po \
-		ru.cp1251.po \
 		sk.po \
-		sk.cp1250.po \
 		sr.po \
 		sv.po \
 		tr.po \
 		uk.po \
-		uk.cp1251.po \
 		vi.po \
-		zh_CN.po \
 		zh_CN.UTF-8.po \
-		zh_CN.cp936.po \
-		zh_TW.po \
 		zh_TW.UTF-8.po \
+
+# MacVim: Don't bundle non-UTF-8 or encoding converted locale files as we always have iconv
+		#cs.cp1250.po \
+		#ja.euc-jp.po \
+		#ja.sjis.po \
+		#ko.po \
+		#pl.cp1250.po \
+		#pl.UTF-8.po \
+		#ru.cp1251.po \
+		#sk.cp1250.po \
+		#uk.cp1251.po \
+		#zh_CN.po \
+		#zh_CN.cp936.po \
+		#zh_TW.po \
 
 
 MOFILES = \
@@ -123,25 +134,26 @@ MOFILES = \
 
 
 MOCONVERTED = \
-		cs.cp1250.mo \
-		ja.euc-jp.mo \
-		ja.sjis.mo \
-		ko.mo \
-		pl.UTF-8.mo \
-		pl.cp1250.mo \
-		ru.cp1251.mo \
-		sk.cp1250.mo \
-		uk.cp1251.mo \
-		zh_CN.mo \
-		zh_CN.cp936.mo \
-		zh_TW.mo \
+
+# MacVim: Don't bundle non-UTF-8 or encoding converted locale files as we always have iconv
+		#cs.cp1250.mo \
+		#ja.euc-jp.mo \
+		#ja.sjis.mo \
+		#ko.mo \
+		#pl.cp1250.mo \
+		#pl.UTF-8.mo \
+		#ru.cp1251.mo \
+		#sk.cp1250.mo \
+		#uk.cp1251.mo \
+		#zh_CN.mo \
+		#zh_CN.cp936.mo \
+		#zh_TW.mo \
 
 
 CHECKFILES = \
 		af.ck \
 		ca.ck \
 		cs.ck \
-		cs.cp1250.ck \
 		da.ck \
 		de.ck \
 		en_GB.ck \
@@ -152,31 +164,34 @@ CHECKFILES = \
 		ga.ck \
 		it.ck \
 		ja.ck \
-		ja.euc-jp.ck \
-		ja.sjis.ck \
 		ko.UTF-8.ck \
-		ko.ck \
 		lv.ck \
 		nb.ck \
 		nl.ck \
 		no.ck \
-		pl.UTF-8.ck \
 		pl.ck \
-		pl.cp1250.ck \
 		pt_BR.ck \
 		ru.ck \
-		ru.cp1251.ck \
 		sk.ck \
-		sk.cp1250.ck \
 		sr.ck \
 		sv.ck \
 		tr.ck \
 		uk.ck \
-		uk.cp1251.ck \
 		vi.ck \
 		zh_CN.UTF-8.ck \
-		zh_CN.ck \
-		zh_CN.cp936.ck \
 		zh_TW.UTF-8.ck \
-		zh_TW.ck \
+
+# MacVim: Don't bundle non-UTF-8 or encoding converted locale files as we always have iconv
+		#cs.cp1250.ck \
+		#ja.euc-jp.ck \
+		#ja.sjis.ck \
+		#ko.ck \
+		#pl.cp1250.ck \
+		#pl.UTF-8.ck \
+		#ru.cp1251.ck \
+		#sk.cp1250.ck \
+		#uk.cp1251.ck \
+		#zh_CN.ck \
+		#zh_CN.cp936.ck \
+		#zh_TW.ck \
 

--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -55,6 +55,16 @@ install: $(MOFILES) $(MOCONVERTED)
 	    $(INSTALL_DATA) $$lang.mo $$dir/$(PACKAGE).mo; \
 	    chmod $(FILEMOD) $$dir/$(PACKAGE).mo; \
 	  fi; \
+	done; \
+	# MacVim: We remove non-UTF-8 locales as it does not make sense to ship \
+	# them on macOS. To make sure the base locales like "zh_TW" still works, we \
+	# move them from the encoding-specific ones like "zh_TW.UTF-8" to "zh_TW"
+	for lang_utf8_only in $(LANGUAGES_UTF8_ONLY); do \
+	  dir=$(LOCALEDIR)/$$lang_utf8_only; \
+	  if test -x "$$dir"; then \
+	    rm -rf "$$dir"; \
+	  fi; \
+	  mv "$$dir.UTF-8" "$$dir"; \
 	done
 
 uninstall:

--- a/src/po/ja.euc-jp.po
+++ b/src/po/ja.euc-jp.po
@@ -3503,10 +3503,6 @@ msgstr "with Photon GUI."
 msgid "with GUI."
 msgstr "with GUI."
 
-# MacVim only
-msgid "with MacVim GUI."
-msgstr "with MacVim GUI."
-
 msgid "  Features included (+) or not (-):\n"
 msgstr "  機能の一覧 有効(+)/無効(-)\n"
 
@@ -3587,10 +3583,6 @@ msgstr "終了するには           :q<Enter>              "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "オンラインヘルプは     :help<Enter> か <F1>   "
-
-# MacVim only
-msgid "type  :help macvim<Enter>     for MacVim help "
-msgstr "MacVim のオンラインヘルプは     :help macvim<Enter>             "
 
 msgid "type  :help version9<Enter>   for version info"
 msgstr "バージョン情報は       :help version9<Enter>  "

--- a/src/po/ja.sjis.po
+++ b/src/po/ja.sjis.po
@@ -3503,10 +3503,6 @@ msgstr "with Photon GUI."
 msgid "with GUI."
 msgstr "with GUI."
 
-# MacVim only
-msgid "with MacVim GUI."
-msgstr "with MacVim GUI."
-
 msgid "  Features included (+) or not (-):\n"
 msgstr "  機能\の一覧 有効(+)/無効(-)\n"
 
@@ -3587,10 +3583,6 @@ msgstr "終了するには           :q<Enter>              "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "オンラインヘルプは     :help<Enter> か <F1>   "
-
-# MacVim only
-msgid "type  :help macvim<Enter>     for MacVim help "
-msgstr "MacVim のオンラインヘルプは     :help macvim<Enter>             "
 
 msgid "type  :help version9<Enter>   for version info"
 msgstr "バージョン情報は       :help version9<Enter>  "

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -3474,10 +3474,6 @@ msgstr "带 Photon 图形界面。"
 msgid "with GUI."
 msgstr "带图形界面。"
 
-# MacVim only
-msgid "with MacVim GUI."
-msgstr "带 MacVim 图形界面。"
-
 msgid "  Features included (+) or not (-):\n"
 msgstr "  可使用(+)与不可使用(-)的功能:\n"
 
@@ -3558,10 +3554,6 @@ msgstr "输入  :q<Enter>               退出            "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "输入  :help<Enter>  或  <F1>  查看在线帮助    "
-
-# MacVim only
-msgid "type  :help macvim<Enter>     for MacVim help "
-msgstr "      输入  :help macvim<Enter>     查看 MacVim 的在线帮助"
 
 msgid "type  :help version9<Enter>   for version info"
 msgstr "输入  :help version9<Enter>   查看版本信息    "

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -3474,10 +3474,6 @@ msgstr "带 Photon 图形界面。"
 msgid "with GUI."
 msgstr "带图形界面。"
 
-# MacVim only
-msgid "with MacVim GUI."
-msgstr "带 MacVim 图形界面。"
-
 msgid "  Features included (+) or not (-):\n"
 msgstr "  可使用(+)与不可使用(-)的功能:\n"
 
@@ -3558,10 +3554,6 @@ msgstr "输入  :q<Enter>               退出            "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "输入  :help<Enter>  或  <F1>  查看在线帮助    "
-
-# MacVim only
-msgid "type  :help macvim<Enter>     for MacVim help "
-msgstr "      输入  :help macvim<Enter>     查看 MacVim 的在线帮助"
 
 msgid "type  :help version9<Enter>   for version info"
 msgstr "输入  :help version9<Enter>   查看版本信息    "

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -4714,10 +4714,6 @@ msgstr "使用 Carbon 圖型界面。"
 msgid "with Cocoa GUI."
 msgstr "使用 Cocoa 圖型界面。"
 
-# MacVim only
-msgid "with MacVim GUI."
-msgstr "使用 MacVim 圖型界面。"
-
 msgid "with (classic) GUI."
 msgstr "使用 (傳統) 圖型界面。"
 
@@ -4798,10 +4794,6 @@ msgstr "要離開請輸入                  :q<Enter>            "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "線上說明請輸入                :help<Enter>         "
-
-# MacVim only
-msgid "type  :help macvim<Enter>     for MacVim help "
-msgstr "MacVim 線上說明請輸入                :help<Enter>                "
 
 msgid "type  :help version9<Enter>   for version info"
 msgstr "新版本資訊請輸入              :help version9<Enter>"


### PR DESCRIPTION
Currently a lot of the .po locale files are generated using iconv to different encodings. This is only necessary if the version of Vim does not have iconv and cannot dynamically convert encoding, which isn't the case for MacVim. Furthermore, MacVim should only work in UTF-8 anyway, so it's not useful to have all the other non-UTF-8 locales (e.g. zh_CN.cp936.po) being built and bundled together, as they make the build process more complicated and bulk up the binary size of the app bundle.

Simply modify the Makefile to not install / build any of the duplicate locale files. For locales like ko/zh_CN/zh_TW, where the "base" version ko.po is in a non-UTF-8 locale and converted from a ko.UTF-8.po, we keep only the ko.UTF-8.po version, but during install we install the folder as "ko" instead of "ko.UTF-8". This way, if someone somehow set LANG=ko_KR, it will still work instead of having to set LANG=ko_KR.UTF-8.

Currently, pl.po is an odd one out because pl.UTF-8.po is actually generated from pl.po, instead of the other way round. We just use pl.po since that's the source version, instead of using the generated UTF-8 one for simplicity (MacVim can handle it fine).

Also, revert the MacVim-local translations made to these non-UTF8 locales like zh_CN.cp936.po, since we don't use them anymore in MacVim builds.

Saved ~2 MB in the app bundle, and ~1MB in the generated dmg.