### PR TITLE
Remove unnecessary MacVim-specific window clear

### DIFF
--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1282,13 +1282,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE, NULL,
 #endif
 			    {(char_u *)50L, (char_u *)0L} SCTX_INIT},
-    {"guioptions",  "go",   P_STRING|P_VI_DEF|P_RALL|P_FLAGLIST
-# ifdef FEAT_GUI_MACVIM
-	/* Scrollbars etc. may change the view, if this happens without a
-	 * redraw the display may get corrupted, so always redraw. */
-			    |P_RCLR
-# endif
-			    ,
+    {"guioptions",  "go",   P_STRING|P_VI_DEF|P_RALL|P_FLAGLIST,
 #if defined(FEAT_GUI)
 			    (char_u *)&p_go, PV_NONE, did_set_guioptions,
 # ifdef FEAT_GUI_MACVIM

--- a/src/window.c
+++ b/src/window.c
@@ -1386,12 +1386,6 @@ win_split_ins(
      // Both windows need redrawing.  Update all status lines, in case they
      // show something related to the window count or position.
     redraw_win_later(wp, UPD_NOT_VALID);
-#ifdef FEAT_GUI_MACVIM
-    if (gui.in_use)
-	// The view may have moved, so clear all or display may get corrupted.
-	redraw_win_later(oldwin, UPD_CLEAR);
-    else
-#endif
     redraw_win_later(oldwin, UPD_NOT_VALID);
     status_redraw_all();
 
@@ -7053,10 +7047,6 @@ scroll_to_fraction(win_T *wp, int prev_height)
     void
 win_new_width(win_T *wp, int width)
 {
-#ifdef FEAT_GUI_MACVIM
-    int		resized = wp->w_width != width;
-#endif
-
     // Should we give an error if width < 0?
     wp->w_width = width < 0 ? 0 : width;
     wp->w_lines_valid = 0;
@@ -7066,12 +7056,6 @@ win_new_width(win_T *wp, int width)
     if (wp == curwin && *p_spk == 'c')
 	curs_columns(TRUE);	// validate w_wrow
 
-#ifdef FEAT_GUI_MACVIM
-    if (resized && gui.in_use)
-	// The view may have moved, so clear all or display may get corrupted.
-	redraw_win_later(wp, UPD_CLEAR);
-    else
-#endif
     redraw_win_later(wp, UPD_NOT_VALID);
     wp->w_redr_status = TRUE;
 }


### PR DESCRIPTION
During merging from upstream Vim, I noticed that MacVim is doing some unnecessary clears. From looking at them, I don't think they are really necessary (at least with the current source revision). Such MacVim-specific changes add merge conflicts and makes it difficult to diagnose issues (as we need to determine if they are MacVim-specific or Vim). Just remove it for now. Can always add back if we see issues.

The change was introduced in c6218461601.