### PR TITLE
Fix legacy builds crashing in 10.9-10.11 by disabling clock_gettime

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -237,6 +237,7 @@ jobs:
       - name: Check version
         run: |
           ${VIM_BIN} --version
+          ${VIM_BIN} -u NONE -i NONE --not-a-term -esNX -V1 -c 'echo "\nprof_nsec:" .. has("prof_nsec") .. "\n"' -c quit
           ${VIM_BIN} -u NONE -i NONE --not-a-term -esNX -V1 -S ci/if_ver-1.vim -c quit
           ${VIM_BIN} -u NONE -i NONE --not-a-term -esNX -V1 -S ci/if_ver-2.vim -c quit
 

--- a/src/os_mac.h
+++ b/src/os_mac.h
@@ -264,6 +264,14 @@ typedef int clockid_t;
 #  define CLOCK_MONOTONIC 1
 # endif
 
+# if !defined(MAC_OS_X_VERSION_10_12) \
+	|| (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12)
+// This happens when building on a newer machine for a min deployment lower
+// than 10.12. The build environment supports clock_gettime(), but the target
+// runtime doesn't.
+#  undef HAVE_CLOCK_GETTIME
+# endif
+
 struct itimerspec
 {
     struct timespec it_interval;  // timer period


### PR DESCRIPTION
Recent Vim builds introduced the use of clock_gettime(), which on macOS was only introduced in 10.12. In Vim, we added a configure check to detect its existence (https://github.com/vim/vim/issues/12242) but it only works to detect the build-time environment. For MacVim builds we build on new machines but deploy on old machines by using MACOSX_DEPLOYMENT_TARGET=10.9 when building. This means that the configure script will detect clock_gettime() exists and includes it, but at runtime the app will crash when running MacVim (legacy builds) in 10.9-10.11.

To fix this, add explicit checks to make sure we undef HAVE_CLOCK_GETTIME if deployment target is below 10.12. Unfortunately there isn't really a way to detect such things automatically in a configure script as it requires knowledge of historical releases.