### PR TITLE
Make sign-developer-id work if Sparkle is disabled

### DIFF
--- a/src/MacVim/scripts/sign-developer-id
+++ b/src/MacVim/scripts/sign-developer-id
@@ -35,8 +35,11 @@ else
         codesign -f -s "Developer ID Application" -o runtime --timestamp "$macvim_path/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate"
         codesign -f -s "Developer ID Application" -o runtime --timestamp "$macvim_path/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app")
     fi
+    if [ -d $macvim_path/Contents/Frameworks/Sparkle.framework ]; then
+        (set -x
+        codesign -f -s "Developer ID Application" -o runtime --timestamp "$macvim_path/Contents/Frameworks/Sparkle.framework")
+    fi
     set -x
-    codesign -f -s "Developer ID Application" -o runtime --timestamp "$macvim_path/Contents/Frameworks/Sparkle.framework"
     codesign -f -s "Developer ID Application" -o runtime --timestamp "$macvim_path/Contents/Frameworks/PSMTabBarControl.framework"
     codesign -f -s "Developer ID Application" -o runtime --timestamp "$macvim_path/Contents/Library/QuickLook/QLStephen.qlgenerator/Contents/MacOS/QLStephen"
     codesign -f -s "Developer ID Application" -o runtime --timestamp --entitlements $entitlements "$macvim_path/Contents/MacOS/Vim"


### PR DESCRIPTION
Currently it Sparkle is disabled we remove it from the bundle. Make code signing resilient to that. This isn't used in our CI, but useful for testing or if some other people want to bundle MacVim without Sparkle.