### PR TITLE
GitHub CI don't show progress when checking out repo

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -71,6 +71,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Set up legacy build
         if: matrix.legacy


### PR DESCRIPTION
Use the new "show-progress" flag in checkout@v4 to suppress Git checkout progress to trim down on log size.