### PR TITLE
Install Vim runtime to the MacVim app bundle properly

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -34,6 +34,7 @@ env:
   vi_cv_dll_name_ruby_arm64: /opt/homebrew/opt/ruby/lib/libruby.dylib
   vi_cv_dll_name_lua_arm64: /opt/homebrew/lib/liblua.dylib
 
+  MACVIM_APP: src/MacVim/build/Release/MacVim.app
   VIM_BIN: src/MacVim/build/Release/MacVim.app/Contents/MacOS/Vim
   MACVIM_BIN: src/MacVim/build/Release/MacVim.app/Contents/MacOS/MacVim
 
@@ -245,6 +246,12 @@ jobs:
               echo 'Found references to Sparkle even when using --disable-sparkle'; false
             fi
           fi
+
+          # Make sure man pages were bundled
+          man -M `pwd`/${MACVIM_APP}/Contents/man -w mvim
+
+          # Make sure xxd was bundled
+          echo "AB" | ${MACVIM_APP}/Contents/bin/xxd | grep "4142"
 
       - name: Smoketest (publish)
         if: matrix.publish

--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -205,15 +205,17 @@ After that, type "mvim" to start MacVim from Terminal. >
 	$ mvim
 You can also specify files to open with. >
 	$ mvim file ...
-Also the bin folder has convenient scripts for diffing and opening file as the
-file is read-only. >
-	* Diff:		mvimdiff
-	* Read-only:	mview
-<
+The bin folder also contains `mvimdiff` and `mview` that work as alias of
+|gvimdiff| and |gview|, as well as `xxd` for |hex-editing|.
+
 You can still use the normal "vim", "vimdiff", and "view" commands if you want
 to use non-GUI Vim, and "gvim" to launch MacVim ("gvim" works the same way as
 "mvim").
 
+If you would like to have man pages with the command-line tools, you can add
+the following to `~/.zprofile`: >
+	export MANPATH="/Applications/MacVim.app/Contents/man:$MANPATH"
+<
 Going from terminal to GUI mode ~
 
 Once in terminal Vim it is possible to start the MacVim GUI by using the

--- a/runtime/doc/vim.1
+++ b/runtime/doc/vim.1
@@ -20,6 +20,7 @@ vim \- Vi IMproved, a programmer's text editor
 .br
 .B view
 .br
+.B mvim
 .B gvim
 .B gview
 .B evim
@@ -111,8 +112,8 @@ view
 Start in read-only mode.  You will be protected from writing the files.
 Can also be done with the "\-R" argument.
 .TP
-gvim gview
-The GUI version.
+mvim gvim gview
+The GUI version (MacVim).
 Starts a new window.
 Can also be done with the "\-g" argument.
 .TP

--- a/runtime/doc/vim.man
+++ b/runtime/doc/vim.man
@@ -13,7 +13,7 @@ SYNOPSIS
 
        ex
        view
-       gvim gview evim eview
+       mvim gvim gview evim eview
        rvim rview rgvim rgview
 
 DESCRIPTION
@@ -78,9 +78,9 @@ DESCRIPTION
        view      Start in read-only mode.  You will be protected from  writing
                  the files.  Can also be done with the "-R" argument.
 
-       gvim gview
-                 The GUI version.  Starts a new window.  Can also be done with
-                 the "-g" argument.
+       mvim gvim gview
+                 The GUI version (MacVim).  Starts a new window.  Can also be
+                 done with the "-g" argument.
 
        evim eview
                  The GUI version in easy mode.  Starts a new window.  Can also

--- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
+++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
@@ -51,16 +51,15 @@
 		1DCD00D20E50B2B700460166 /* TagJump.png in Resources */ = {isa = PBXBuildFile; fileRef = 1DCD00BD0E50B2B700460166 /* TagJump.png */; };
 		1DCD00D30E50B2B700460166 /* Undo.png in Resources */ = {isa = PBXBuildFile; fileRef = 1DCD00BE0E50B2B700460166 /* Undo.png */; };
 		1DD04DEC0C529C5E006CDC2B /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 1DD04DEB0C529C5E006CDC2B /* Credits.rtf */; };
-		1DD0C20C0C60FFB4008CD84A /* gvimrc in Copy Vim Runtime Files */ = {isa = PBXBuildFile; fileRef = 1DD0C20A0C60FF9A008CD84A /* gvimrc */; };
+		1DD0C20C0C60FFB4008CD84A /* gvimrc in Copy default vimrc files */ = {isa = PBXBuildFile; fileRef = 1DD0C20A0C60FF9A008CD84A /* gvimrc */; };
 		1DD3D51E0D82D4C9006E4320 /* ibeam.png in Resources */ = {isa = PBXBuildFile; fileRef = 1DD3D51D0D82D4C9006E4320 /* ibeam.png */; };
 		1DD66ECE0C803D3600EBDAB3 /* MMApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD66ECC0C803D3600EBDAB3 /* MMApplication.m */; };
 		1DD9F5E50C85D60500E8D5A5 /* SystemColors.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1DD9F5E40C85D60500E8D5A5 /* SystemColors.plist */; };
 		1DE3F8EB0D50F84600052B9E /* MMPreferenceController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DE3F8E90D50F84600052B9E /* MMPreferenceController.m */; };
-		1DE608B40C587FDA0055263D /* runtime in Copy Vim Runtime Files */ = {isa = PBXBuildFile; fileRef = 1DE602470C587FD10055263D /* runtime */; };
 		1DE63FFB0E71820F00959BDB /* MMCoreTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DE63FFA0E71820F00959BDB /* MMCoreTextView.m */; };
 		1DE8CC620C5E2AAD003F56E3 /* Actions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1DE8CC610C5E2AAD003F56E3 /* Actions.plist */; };
 		1DE9B9500D341AB8008FEDD4 /* MMWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DE9B94E0D341AB8008FEDD4 /* MMWindow.m */; };
-		1DED78600C6DE43D0079945F /* vimrc in Copy Vim Runtime Files */ = {isa = PBXBuildFile; fileRef = 1DED785F0C6DE43D0079945F /* vimrc */; };
+		1DED78600C6DE43D0079945F /* vimrc in Copy default vimrc files */ = {isa = PBXBuildFile; fileRef = 1DED785F0C6DE43D0079945F /* vimrc */; };
 		1DFE25A50C527BC4003000F7 /* PSMTabBarControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D493DB90C52533B00AB718C /* PSMTabBarControl.framework */; };
 		52818B031C1C08CE00F59085 /* QLStephen.qlgenerator in Copy QuickLookPlugin */ = {isa = PBXBuildFile; fileRef = 52818AFF1C1C075300F59085 /* QLStephen.qlgenerator */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		528DA66A1426D4F9003380F1 /* macvim-askpass in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 528DA6691426D4EB003380F1 /* macvim-askpass */; };
@@ -133,17 +132,16 @@
 			name = "Copy Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1DE608B80C58807F0055263D /* Copy Vim Runtime Files */ = {
+		1DE608B80C58807F0055263D /* Copy default vimrc files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = vim;
 			dstSubfolderSpec = 7;
 			files = (
-				1DED78600C6DE43D0079945F /* vimrc in Copy Vim Runtime Files */,
-				1DD0C20C0C60FFB4008CD84A /* gvimrc in Copy Vim Runtime Files */,
-				1DE608B40C587FDA0055263D /* runtime in Copy Vim Runtime Files */,
+				1DED78600C6DE43D0079945F /* vimrc in Copy default vimrc files */,
+				1DD0C20C0C60FFB4008CD84A /* gvimrc in Copy default vimrc files */,
 			);
-			name = "Copy Vim Runtime Files";
+			name = "Copy default vimrc files";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		52818B021C1C088000F59085 /* Copy QuickLookPlugin */ = {
@@ -880,8 +878,9 @@
 				1D0DCAD80BA3604D00B6CCFA /* Copy Executables */,
 				1D9EB2840C366D7B0074B739 /* Copy Frameworks */,
 				52818B021C1C088000F59085 /* Copy QuickLookPlugin */,
-				1DE608B80C58807F0055263D /* Copy Vim Runtime Files */,
-				90BD4EF224E0E8B700BF29F2 /* Copy locale message translation files */,
+				1DE608B80C58807F0055263D /* Copy default vimrc files */,
+				9050374C2AAEFA2500E9846A /* Generate runtime folder list */,
+				90BD4EF224E0E8B700BF29F2 /* Copy Vim runtime / localization files */,
 				1D1C31F00EFFBFD6003FE9A5 /* Make Document Icons */,
 				528DA6671426D456003380F1 /* Copy Scripts */,
 				52283AB71EBA200C00A6F6B9 /* Copy mvim scripts */,
@@ -1054,6 +1053,27 @@
 			shellScript = "BINPATH=$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/bin\nmkdir -p \"${BINPATH}\"\ncp -a \"${SRCROOT}/mvim\" \"${BINPATH}/mvim\"\nchmod 755 \"${BINPATH}/mvim\"\n(cd \"${BINPATH}\"; for f in vim vimdiff view gvim gvimdiff gview mvimdiff mview; do ln -fs mvim $f; done)\n";
 			showEnvVarsInLog = 0;
 		};
+		9050374C2AAEFA2500E9846A /* Generate runtime folder list */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Generate runtime folder list";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(OBJROOT)/runtime_folder_list.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Generate a list of folders that will affect the runtime folder output, so\n# that incremental build can use it to only install them if the runtime folders\n# have changed. The main reason we have to manually generate it is because\n# Xcode's \"Input File Lists\" doesn't support recursion/wildcards.\n\nfind -s ../../runtime -type d > \"${OBJROOT}\"/runtime_folder_list_new.xcfilelist\n\nif cmp -s \"${OBJROOT}\"/runtime_folder_list.xcfilelist \"${OBJROOT}\"/runtime_folder_list_new.xcfilelist; then\n    rm \"${OBJROOT}\"/runtime_folder_list_new.xcfilelist\nelse\n    mv -f \"${OBJROOT}\"/runtime_folder_list_new.xcfilelist \"${OBJROOT}\"/runtime_folder_list.xcfilelist\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		9099B3CA2914B272005C9F32 /* Clean up build */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -1074,25 +1094,27 @@
 			shellScript = "./scripts/cleanup-after-build \"$BUILT_PRODUCTS_DIR/$WRAPPER_NAME\" \"$REMOVE_SPARKLE\"\n";
 			showEnvVarsInLog = 0;
 		};
-		90BD4EF224E0E8B700BF29F2 /* Copy locale message translation files */ = {
+		90BD4EF224E0E8B700BF29F2 /* Copy Vim runtime / localization files */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
+				$OBJROOT/runtime_folder_list.xcfilelist,
 			);
 			inputPaths = (
+				"$(SRCROOT)/../xxd/xxd",
 				"$(SRCROOT)/../po",
 			);
-			name = "Copy locale message translation files";
+			name = "Copy Vim runtime / localization files";
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/vim/runtime/lang",
+				$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/vim/runtime,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Copy all the locale translation files from the po folder to\n# runtime/lang/<lang>/LC_MESSAGES/vim.mo. Need to do this because unlike normal\n# Vim, MacVim is distributed as a standalone app package and therefore we don't\n# want to install these files to a global location (e.g.\n# /usr/local/share/locale/). This is similar to how Windows installation\n# (po/Make_mvc.mak) works.\ncd \"${SRCROOT}\"/..\nmake macvim-install-languages DEST_LANG=\"${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/vim/runtime/lang\"\n";
+			shellPath = /bin/zsh;
+			shellScript = "# Copy the runtime files to the app bundle, under Resources/vim/runtime folder.\n# We cannot do a direct copy of the runtime folder as it contains misc test\n# scripts and also man pages and we should use the Vim's defined rules to\n# install them properly.\n\n# Note that this will also install man pages, under a \"man\" folder. This is\n# useful if the user really wants to point their man page to MacVim's verison\n# instead of builtin Vim, using MANPATH=/Applications/MacVim.app/Contents/man).\n\n# prefix: Reset to empty as it's set to /Applications for fallback rt-folder\n# VIMNAME: Use the default \"vim\" to make sure man pages use that instead of \"Vim\"\n# VIMRTDIR: Make sure to use \"runtime\" as by default it uses a \"vim90\" style folder which is mostly a relic.\n\ncd \"${SRCROOT}\"/..\nmake \\\n    DESTDIR=\"${TARGET_BUILD_DIR}\" \\\n    prefix= \\\n    VIMNAME=vim \\\n    VIMRTDIR=/runtime \\\n    macvim-install-runtime\n\n# Also add man pages for \"mvim\"\nfor curdir in \"$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH\"/man/**/man1; do\n    (cd $curdir; ln -f -s gvim.1 mvim.1)\ndone\n";
 			showEnvVarsInLog = 0;
 		};
 		90C052E1251E889500E2D81E /* Copy vimtutor */ = {
@@ -1112,10 +1134,11 @@
 			outputPaths = (
 				$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/bin/vimtutor,
 				$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/bin/gvimtutor,
+				$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/bin/mvimtutor,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "BINPATH=$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/bin\nmkdir -p \"${BINPATH}\"\ncp -a \"${SRCROOT}/../vimtutor\" \"${BINPATH}/vimtutor\"\ncp -a \"${SRCROOT}/../gvimtutor\" \"${BINPATH}/gvimtutor\"\nchmod 755 \"${BINPATH}/vimtutor\"\nchmod 755 \"${BINPATH}/gvimtutor\"\ncd \"${BINPATH}\"\nln -fs gvimtutor mvimtutor \n";
+			shellScript = "# We could potentially use make installtutorbin installgtutorbin\n# but this works and we need to do the symlink anyway.\nBINPATH=$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/bin\nmkdir -p \"${BINPATH}\"\ncp -a \"${SRCROOT}/../vimtutor\" \"${BINPATH}/vimtutor\"\ncp -a \"${SRCROOT}/../gvimtutor\" \"${BINPATH}/gvimtutor\"\nchmod 755 \"${BINPATH}/vimtutor\"\nchmod 755 \"${BINPATH}/gvimtutor\"\ncd \"${BINPATH}\"\nln -fs gvimtutor mvimtutor \n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/src/MacVim/scripts/cleanup-after-build
+++ b/src/MacVim/scripts/cleanup-after-build
@@ -35,16 +35,3 @@ else
         rm "$sparkle_xpcservices_symlink")
     fi
 fi
-
-# This is a temporary measure to remove unnecessary files in the runtime
-# folder. Ideally we should move to use Vim's built-in `make install` mechanism
-# instead of copying all the files from the runtime over to the app blindly.
-# See https://github.com/macvim-dev/macvim/issues/1417
-set -x
-rm -rf $macvim_path/Contents/Resources/vim/runtime/indent/testdir
-rm -rf $macvim_path/Contents/Resources/vim/runtime/syntax/testdir
-rm -f $macvim_path/Contents/Resources/vim/runtime/doc/Makefile
-rm -f $macvim_path/Contents/Resources/vim/runtime/indent/Makefile
-rm -f $macvim_path/Contents/Resources/vim/runtime/lang/Makefile
-rm -f $macvim_path/Contents/Resources/vim/runtime/syntax/Makefile
-rm -f $macvim_path/Contents/Resources/vim/runtime/tutor/Makefile

--- a/src/MacVim/scripts/sign-developer-id
+++ b/src/MacVim/scripts/sign-developer-id
@@ -42,6 +42,7 @@ else
     set -x
     codesign -f -s "Developer ID Application" -o runtime --timestamp "$macvim_path/Contents/Frameworks/PSMTabBarControl.framework"
     codesign -f -s "Developer ID Application" -o runtime --timestamp "$macvim_path/Contents/Library/QuickLook/QLStephen.qlgenerator/Contents/MacOS/QLStephen"
+    codesign -f -s "Developer ID Application" -o runtime --timestamp --entitlements $entitlements "$macvim_path/Contents/bin/xxd"
     codesign -f -s "Developer ID Application" -o runtime --timestamp --entitlements $entitlements "$macvim_path/Contents/MacOS/Vim"
     codesign -f -s "Developer ID Application" -o runtime --timestamp --entitlements $entitlements "$macvim_path"
 fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -1297,7 +1297,7 @@ MACVIMGUI_LIBS1	=
 MACVIMGUI_LIBS2	=
 MACVIMGUI_INSTALL = install_normal
 MACVIMGUI_TARGETS =
-MACVIMGUI_MAN_TARGETS =
+MACVIMGUI_MAN_TARGETS = yes
 MACVIMGUI_TESTTARGET = gui
 MACVIMGUI_BUNDLE = macvim
 MACVIMGUI_TESTARG = VIMPROG=../$(RELEASEDIR)/MacVim.app/Contents/MacOS/$(VIMTARGET)
@@ -2365,13 +2365,17 @@ installrtbase: $(HELPSOURCE)/vim.1 $(DEST_VIM) $(VIMTARGET) $(DEST_RT) \
 # Generate the help tags with ":helptags" to handle all languages.
 # Move the distributed tags file aside and restore it, to avoid it being
 # different from the repository.
-	cd $(HELPSOURCE); if test -z "$(CROSS_COMPILING)" -a -f tags; then \
-		mv -f tags tags.dist; fi
-	@echo generating help tags
-	# We can assume Vim was build, but it may not have been installed,
-	# thus use the executable in the current directory.
-	-@BUILD_DIR="`pwd`"; cd $(HELPSOURCE); if test -z "$(CROSS_COMPILING)"; then \
-		$(MAKE) VIMEXE="$$BUILD_DIR/$(VIMTARGET)" vimtags; fi
+## MacVim: Commented out as we don't need to generate vim tags at runtime
+## anymore as we are guaranteed by CI that vim tags are correct. This step will
+## change the mod dates of the doc/ folder which makes dependency analysis think
+## something has changed.
+##	cd $(HELPSOURCE); if test -z "$(CROSS_COMPILING)" -a -f tags; then \
+##		mv -f tags tags.dist; fi
+##	@echo generating help tags
+##	# We can assume Vim was build, but it may not have been installed,
+##	# thus use the executable in the current directory.
+##	-@BUILD_DIR="`pwd`"; cd $(HELPSOURCE); if test -z "$(CROSS_COMPILING)"; then \
+##		$(MAKE) VIMEXE="$$BUILD_DIR/$(VIMTARGET)" vimtags; fi
 	cd $(HELPSOURCE); \
 		files=`ls *.txt tags`; \
 		files="$$files `ls *.??x tags-?? 2>/dev/null || true`"; \
@@ -2380,7 +2384,8 @@ installrtbase: $(HELPSOURCE)/vim.1 $(DEST_VIM) $(VIMTARGET) $(DEST_RT) \
 		chmod $(HELPMOD) $$files
 	$(INSTALL_DATA)  $(HELPSOURCE)/*.pl $(DEST_HELP)
 	chmod $(SCRIPTMOD) $(DEST_HELP)/*.pl
-	cd $(HELPSOURCE); if test -f tags.dist; then mv -f tags.dist tags; fi
+## MacVim: See above for why we shouldn't build vimtags anymore
+##	cd $(HELPSOURCE); if test -f tags.dist; then mv -f tags.dist tags; fi
 # install the menu files
 	$(INSTALL_DATA) $(SCRIPTSOURCE)/menu.vim $(SYS_MENU_FILE)
 	chmod $(VIMSCRIPTMOD) $(SYS_MENU_FILE)
@@ -2620,7 +2625,8 @@ install-languages: languages $(DEST_LANG) $(DEST_KMAP)
 	fi
 	if test -d $(LANGSOURCE); then \
 	   $(INSTALL_DATA) $(LANGSOURCE)/README.txt $(LANGSOURCE)/*.vim $(DEST_LANG); \
-	   chmod $(FILEMOD) $(DEST_LANG)/README.txt $(DEST_LANG)/*.vim; \
+	   $(INSTALL_DATA_R) $(LANGSOURCE)/macvim_menu $(DEST_LANG); \
+	   chmod $(FILEMOD) $(DEST_LANG)/README.txt $(DEST_LANG)/*.vim $(DEST_LANG)/macvim_menu/*.vim; \
 	fi
 	if test -d $(KMAPSOURCE); then \
 	   $(INSTALL_DATA) $(KMAPSOURCE)/README.txt $(KMAPSOURCE)/*.vim $(DEST_KMAP); \
@@ -3634,7 +3640,9 @@ Makefile:
 
 ##############################################################################
 ### MacVim GUI
-.PHONY: macvim macvim-dmg macvimclean macvim-signed macvim-dmg-release macvim-install-languages
+.PHONY: macvim macvim-dmg macvim-dmg-legacy macvimclean macvim-signed macvim-dmg-release macvim-dmg-release-legacy macvim-install-runtime
+
+RUNTIME_FOLDER_LIST = MacVim/build/runtime_folder_list.xcfilelist
 
 RELEASEDIR = MacVim/build/Release
 DMGDIR = MacVim/build/dmg
@@ -3645,7 +3653,14 @@ ENTITLEMENTS = MacVim/MacVim.entitlements
 DMGFILESYSTEM = APFS
 DMGFORMAT = ULFO
 
-macvim: $(VIMTARGET)
+$(RUNTIME_FOLDER_LIST):
+	# Generate a stub runtime folder list, used for incremental builds.
+	# Xcode's dependnecy management requires this file to exist at start
+	# of build, even though this file is only generated during build time.
+	mkdir -p MacVim/build
+	touch $(RUNTIME_FOLDER_LIST)
+
+macvim: $(VIMTARGET) $(RUNTIME_FOLDER_LIST)
 	xcodebuild -project MacVim/MacVim.xcodeproj $(XCODEFLAGS)
 
 macvim-signed:
@@ -3690,12 +3705,7 @@ macvim-dmg-release-legacy: macvim-signed macvim-dmg-legacy
 	@echo "----------------------------------------"
 	@echo "Release MacVim (legacy format) built!"
 
-# Install only language files to a dest folder. Subset of "install-languages".
-macvim-install-languages:
-	@if test -n "$(MAKEMO)" -a -f $(PODIR)/Makefile; then \
-	   cd $(PODIR); $(MAKE) prefix=$(DESTDIR)$(prefix) LOCALEDIR=$(DEST_LANG) \
-	   INSTALL_DATA=$(INSTALL_DATA) FILEMOD=$(FILEMOD) install; \
-	fi
+macvim-install-runtime: installruntime installmanlinks installtools $(INSTALL_LANGS)
 
 ###############################################################################
 #

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -10121,6 +10121,8 @@ printf %s "checking for MacVim GUI... " >&6; }
 printf "%s\n" "yes" >&6; };
     GUITYPE=MACVIMGUI
         datadir='${prefix}/MacVim.app/Contents/Resources'
+    mandir='${prefix}/MacVim.app/Contents/man'
+    bindir='${prefix}/MacVim.app/Contents/bin'
   elif test -z "$SKIP_CARBON" -a "x$CARBON" = "xyes"; then
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for Carbon GUI" >&5
 printf %s "checking for Carbon GUI... " >&6; }

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2778,6 +2778,8 @@ if test "x$MACOS_X" = "xyes"; then
     GUITYPE=MACVIMGUI
     dnl Sorry for the hard coded default
     datadir='${prefix}/MacVim.app/Contents/Resources'
+    mandir='${prefix}/MacVim.app/Contents/man'
+    bindir='${prefix}/MacVim.app/Contents/bin'
   elif test -z "$SKIP_CARBON" -a "x$CARBON" = "xyes"; then
     AC_MSG_CHECKING(for Carbon GUI)
     dnl already did the check, just give the message


### PR DESCRIPTION
Previously, MacVim's build process simply used an Xcode post-build script to copy the runtime folder to the target app bundle's Contents/Resources/vim/runtime folder and called it a day. However, that's actually not the correct procedure because the runtime folder contains misc files (e.g. Makefile/testdir for testing) and they should go through a install step using `make install` to properly deploy the proper files to the target folder.

Fix this by changing the post-build script to call the relevant make targets instead of just blindly copying it over. We still copy the vim/view/etc and vimtutor binaries separately for now, because the mvim script is a custom script for MacVim, although that could change in future.

One of the corollary of using the builtin installation scripts is that man pages (for CLI vim/gvim usage) are now properly generated. They are now stored under `MacVim.app/Contents/man`, and a user can set MANPATH to it if they so wish.

Another corollary is that we now bundle xxd with MacVim like most Vim distributions. It was probably an oversight before, and now it's built and bundled in the `MacVim.app/Contents/bin` folder like the vim/view/mvim scripts.

One annoying thing with Xcode is that in order for incremental builds to work properly we want it to only run this installation step if the runtime folder has changed (it takes a couple secs to finish) and Xcode's input file lists doesn't support recursive folder search. To fix this, add a build step to manually generate the list of all runtime folders called runtime_folder_list.xcfilelist which we pass to the build step.

Fix #1417