### PR TITLE
CI: Update to Xcode 15 / macOS 13 in GitHub runner

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -22,16 +22,17 @@ env:
 
   VERSIONER_PERL_VERSION: '5.30'  # macOS default Perl installation uses this to determine which one to use
 
-  vi_cv_path_python: /usr/local/bin/python
+  vi_cv_path_python: /Library/Frameworks/Python.framework/Versions/2.7/bin/python
   vi_cv_path_python3: /usr/local/bin/python3
   vi_cv_path_plain_lua: /usr/local/bin/lua
   vi_cv_path_ruby: /usr/local/opt/ruby/bin/ruby
   vi_cv_dll_name_perl: /System/Library/Perl/%s/darwin-thread-multi-2level/CORE/libperl.dylib
-  vi_cv_dll_name_python: /usr/local/Frameworks/Python.framework/Versions/2.7/Python
+  vi_cv_dll_name_python: /Library/Frameworks/Python.framework/Versions/2.7/Python
   vi_cv_dll_name_python3: /usr/local/Frameworks/Python.framework/Versions/Current/Python
   vi_cv_dll_name_python3_arm64: /opt/homebrew/Frameworks/Python.framework/Versions/Current/Python
   vi_cv_dll_name_ruby: /usr/local/opt/ruby/lib/libruby.dylib
   vi_cv_dll_name_ruby_arm64: /opt/homebrew/opt/ruby/lib/libruby.dylib
+  vi_cv_dll_name_lua: /usr/local/lib/liblua.dylib
   vi_cv_dll_name_lua_arm64: /opt/homebrew/lib/liblua.dylib
 
   MACVIM_APP: src/MacVim/build/Release/MacVim.app
@@ -63,8 +64,8 @@ jobs:
             publish_postfix: '_10.9'
 
           # Most up to date OS and Xcode. Used to publish release for the main build.
-          - os: macos-12
-            xcode: '14.2'
+          - os: macos-13
+            xcode: '15.0'
             publish: true
 
     runs-on: ${{ matrix.os }}
@@ -129,12 +130,6 @@ jobs:
           brew install ruby
           brew install lua
 
-          # CI sometimes have custom installed Python instead of using Homebrew. Forcefully re-
-          # link Python, and then check that we are using the Homebrew version. This avoids us
-          # using a mystery Python installation that we don't control.
-          brew unlink python3 && brew link --overwrite python3
-          readlink -f $vi_cv_path_python3 | grep "^$(brew --cellar python3)"
-
           if [[ -d /usr/local/Cellar/perl ]]; then
             # We just use system perl to reduce dependencies
             brew unlink perl
@@ -142,6 +137,17 @@ jobs:
 
           # With Perl, we need to manually specify the version number because the dylib path depends on it.
           echo "vi_cv_dll_name_perl=$(printf $vi_cv_dll_name_perl $VERSIONER_PERL_VERSION)" >> $GITHUB_ENV
+
+          # New runner images (macos-13) no longer have Python2 installed. We
+          # need to install Python2 manually. Installing from the official
+          # installer is the easiest way as Homebrew no longer ships python@2
+          # and this way does not invole manual building from source. We
+          # mostly only need the headers to build a dynamic build anyway.
+          #
+          # This will be removed in the future as Python2 has been completely
+          # unsupported for years.
+          curl https://www.python.org/ftp/python/2.7.16/python-2.7.16-macosx10.9.pkg -o ~/Downloads/python-2.7.16-macosx10.9.pkg
+          sudo installer -pkg ~/Downloads/python-2.7.16-macosx10.9.pkg -target /
 
       # All set up steps are done. Build and test MacVim below.
 
@@ -273,7 +279,7 @@ jobs:
           macvim_excmd -c 'lang es_ES' -c 'version' | grep Enlazado
 
           # Check that libsodium is working
-          macvim_excmd -c 'set cryptmethod=xchacha20'
+          macvim_excmd -c 'set cryptmethod=xchacha20v2'
 
           # Make sure we are building universal x86_64 / arm64 builds and didn't accidentally create a thin app.
           check_arch() {

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -6001,17 +6001,23 @@ printf %s "checking if liblua${luajit}*.${ext}* can be found in $vi_cv_path_lua_
 	  done
 	  sover=""
 	done
-	if test "X$sover" = "X"; then
-	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+        # MacVim change: allow client to provide their own vi_cv_dll_name_lua
+        # as at runtime Vim will not be able to find the dylib if it's in
+        # /usr/local/lib which is not automatically searched by dlopen()
+        # without a full path.
+        if test "Xvi_cv_dll_name_lua" = "X"; then
+          if test "X$sover" = "X"; then
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
-	  lua_ok="no"
-	  vi_cv_dll_name_lua="liblua${luajit}.${ext}"
-	else
-	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+            lua_ok="no"
+            vi_cv_dll_name_lua="liblua${luajit}.${ext}"
+          else
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
-	  lua_ok="yes"
-	  vi_cv_dll_name_lua="liblua${luajit}${sover}$sover2"
-	fi
+            lua_ok="yes"
+            vi_cv_dll_name_lua="liblua${luajit}${sover}$sover2"
+          fi
+        fi
       fi
       printf "%s\n" "#define DYNAMIC_LUA 1" >>confdefs.h
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -851,15 +851,21 @@ if test "$enable_luainterp" = "yes" -o "$enable_luainterp" = "dynamic"; then
 	  done
 	  sover=""
 	done
-	if test "X$sover" = "X"; then
-	  AC_MSG_RESULT(no)
-	  lua_ok="no"
-	  vi_cv_dll_name_lua="liblua${luajit}.${ext}"
-	else
-	  AC_MSG_RESULT(yes)
-	  lua_ok="yes"
-	  vi_cv_dll_name_lua="liblua${luajit}${sover}$sover2"
-	fi
+        # MacVim change: allow client to provide their own vi_cv_dll_name_lua
+        # as at runtime Vim will not be able to find the dylib if it's in
+        # /usr/local/lib which is not automatically searched by dlopen()
+        # without a full path.
+        if test "Xvi_cv_dll_name_lua" = "X"; then
+          if test "X$sover" = "X"; then
+            AC_MSG_RESULT(no)
+            lua_ok="no"
+            vi_cv_dll_name_lua="liblua${luajit}.${ext}"
+          else
+            AC_MSG_RESULT(yes)
+            lua_ok="yes"
+            vi_cv_dll_name_lua="liblua${luajit}${sover}$sover2"
+          fi
+        fi
       fi
       AC_DEFINE(DYNAMIC_LUA)
       LUA_LIBS=""
@@ -4939,4 +4945,4 @@ dnl write output files
 AC_CONFIG_FILES(auto/config.mk:config.mk.in)
 AC_OUTPUT
 
-dnl vim: set sw=2 tw=78 fo+=l:
+dnl vim: set sw=2 tw=78 ts=8 fo+=l:

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -156,8 +156,7 @@ browse_save_fname(buf_T *buf)
  * "Save changes" dialog that conforms to the Apple HIG.
  */
     int
-vim_dialog_save_changes(buf)
-    buf_T	*buf;
+vim_dialog_save_changes(buf_T *buf)
 {
     char_u	buff[IOSIZE];
 
@@ -183,8 +182,7 @@ vim_dialog_save_changes(buf)
  * dialog for the case of several modified buffers.
  */
     int
-vim_dialog_save_all_changes(buf)
-    buf_T	*buf;
+vim_dialog_save_all_changes(buf_T *buf)
 {
     char_u	buff[IOSIZE];
 


### PR DESCRIPTION
Python2
- Python2 is no longer installed in the new GitHub hosted runners (macos-13) and so we need to manually download the installer from Python's website and install it. Since it seems to run quite fast, not caching the folder fow now.
- Had to change the default Python2 dynamic lib location to /Library/Framework/... which is where the installer installs to.
- Should warn users that Python2 support could be removed in the future.

Lua
- Previously dynamic lib loading implicitly relied on being able to find the lib from /usr/local/lib. Somehow Xcode 15 removed support for that folder when using dlopen(). Modified CI and configure script to allow manually specifying it.

Xcode / Legacy build
- GitHub's macos-13 image does not have Xcode 14.0.1 installed. This is the version we need for building legacy builds (targeting macOS 10.9 - 10.12). As such, we need to keep using macos-12 for building legacy builds. Hopefully it won't be deprecated soon as we would need to investigate options for how to build legacy builds.

Fix deprecated C functions using old style declarations to handle new compiler warnings.