### PR TITLE
Fix warning build failures, fix README GitHub Action badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Vim - the text editor - for macOS
 
 - Vim README: [README_vim.md](README_vim.md)
 
-- [![MacVim GitHub CI](https://github.com/macvim-dev/macvim/workflows/MacVim%20GitHub%20CI/badge.svg)](https://github.com/macvim-dev/macvim/actions?query=workflow%3A%22MacVim+GitHub+CI%22)
+- [![MacVim GitHub CI](https://github.com/macvim-dev/macvim/actions/workflows/ci-macvim.yaml/badge.svg)](https://github.com/macvim-dev/macvim/actions/workflows/ci-macvim.yaml)
 
 - Packaged in [![Homebrew package](https://repology.org/badge/version-for-repo/homebrew/macvim.svg)](https://repology.org/metapackage/macvim/versions) [![MacPorts package](https://repology.org/badge/version-for-repo/macports/macvim.svg)](https://repology.org/metapackage/macvim/versions)
 

--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -28,6 +28,7 @@
  */
 
 #import "MMBackend.h"
+#include "gui_macvim.pro"
 
 
 
@@ -55,11 +56,6 @@ static int eventButtonNumberToVimMouseButton(int buttonNumber);
 vimmenu_T *menu_for_descriptor(NSArray *desc);
 
 static id evalExprCocoa(NSString * expr, NSString ** errstr);
-
-void im_preedit_start_macvim();
-void im_preedit_end_macvim();
-void im_preedit_abandon_macvim();
-void im_preedit_changed_macvim(char *preedit_string, int cursor_index);
 
 enum {
     MMBlinkStateNone = 0,
@@ -147,9 +143,6 @@ static struct specialkey
     /* End of list marker: */
     {0, 0, 0}
 };
-
-
-extern GuiFont gui_mch_retain_font(GuiFont font);
 
 
 @interface NSString (MMServerNameCompare)
@@ -1375,7 +1368,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
 /// Extracts the text currently selected in visual mode, and returns it.
 ///
 /// @return the string representing the selected text, or NULL if failure.
-static char_u *extractSelectedText()
+static char_u *extractSelectedText(void)
 {
     // Note: Most of the functionality in Vim that allows for extracting useful
     // text from a selection are in the register & clipboard utility functions.

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -505,7 +505,7 @@ extern NSString *VimFindPboardType;
 
 extern int ASLogLevel;
 
-void ASLInit();
+void ASLInit(void);
 
 #if defined(MM_USE_ASL)
 

--- a/src/MacVim/MacVim.m
+++ b/src/MacVim/MacVim.m
@@ -253,7 +253,7 @@ debugStringForMessageQueue(NSArray *queue)
 
 
     void
-ASLInit()
+ASLInit(void)
 {
     NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
 

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -49,7 +49,7 @@ vimmenu_T *menu_for_descriptor(NSArray *desc);
 // -- Initialization --------------------------------------------------------
 
     void
-macvim_early_init()
+macvim_early_init(void)
 {
     NSBundle *bundle = [NSBundle mainBundle];
     if (bundle) {
@@ -145,7 +145,7 @@ gui_mch_prepare(int *argc, char **argv)
 
 /* Called directly after forking (even if we didn't fork). */
     void
-gui_macvim_after_fork_init()
+gui_macvim_after_fork_init(void)
 {
     ASLInit();
     ASLogDebug(@"");
@@ -606,7 +606,7 @@ gui_mch_set_sp_color(guicolor_T color)
  * Set default colors.
  */
     void
-gui_mch_def_colors()
+gui_mch_def_colors(void)
 {
     MMBackend *backend = [MMBackend sharedInstance];
 
@@ -1385,8 +1385,6 @@ mch_set_mouse_shape(int shape)
 // -- Input Method ----------------------------------------------------------
 
 #if defined(FEAT_EVAL)
-void call_imactivatefunc(int active);
-int call_imstatusfunc(void);
 # ifdef FEAT_GUI
 #  define USE_IMACTIVATEFUNC (!gui.in_use && *p_imaf != NUL)
 #  define USE_IMSTATUSFUNC (!gui.in_use && *p_imsf != NUL)
@@ -1819,7 +1817,7 @@ gui_mch_set_shellsize(
  * adding / removing a toolbar) when guioptions 'k' is set.
  */
     void
-gui_mch_resize_view()
+gui_mch_resize_view(void)
 {
     [[MMBackend sharedInstance] resizeView];
 }
@@ -1892,14 +1890,14 @@ gui_mch_enter_fullscreen(guicolor_T bg)
 
 
     void
-gui_mch_leave_fullscreen()
+gui_mch_leave_fullscreen(void)
 {
     [[MMBackend sharedInstance] leaveFullScreen];
 }
 
 
     void
-gui_mch_fuopt_update()
+gui_mch_fuopt_update(void)
 {
     if (!gui.in_use)
         return;
@@ -1916,7 +1914,7 @@ gui_mch_fuopt_update()
 
 
     void
-gui_macvim_update_modified_flag()
+gui_macvim_update_modified_flag(void)
 {
     [[MMBackend sharedInstance] updateModifiedFlag];
 }
@@ -1983,7 +1981,7 @@ gui_macvim_set_thinstrokes(int thinStrokes)
 }
 
     void
-gui_macvim_wait_for_startup()
+gui_macvim_wait_for_startup(void)
 {
     MMBackend *backend = [MMBackend sharedInstance];
     if ([backend waitForAck])
@@ -2006,7 +2004,7 @@ gui_macvim_get_window_layout(int *count, int *layout)
 }
 
     void *
-gui_macvim_new_autoreleasepool()
+gui_macvim_new_autoreleasepool(void)
 {
     return (void *)[[NSAutoreleasePool alloc] init];
 }

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -155,7 +155,7 @@ browse_save_fname(buf_T *buf)
 /*
  * "Save changes" dialog that conforms to the Apple HIG.
  */
-    int
+    static int
 vim_dialog_save_changes(buf_T *buf)
 {
     char_u	buff[IOSIZE];
@@ -181,7 +181,7 @@ vim_dialog_save_changes(buf_T *buf)
  * "Save all changes" dialog that tries to emulate the above "Save changes"
  * dialog for the case of several modified buffers.
  */
-    int
+    static int
 vim_dialog_save_all_changes(buf_T *buf)
 {
     char_u	buff[IOSIZE];

--- a/src/gui_xim.c
+++ b/src/gui_xim.c
@@ -634,7 +634,7 @@ im_commit_cb(GtkIMContext *context UNUSED,
 im_preedit_start_cb(GtkIMContext *context UNUSED, gpointer data UNUSED)
 # else
     void
-im_preedit_start_macvim()
+im_preedit_start_macvim(void)
 # endif
 {
 #ifdef XIM_DEBUG
@@ -655,7 +655,7 @@ im_preedit_start_macvim()
 im_preedit_end_cb(GtkIMContext *context UNUSED, gpointer data UNUSED)
 # else
     void
-im_preedit_end_macvim()
+im_preedit_end_macvim(void)
 # endif
 {
 #ifdef XIM_DEBUG
@@ -681,7 +681,7 @@ im_preedit_end_macvim()
 
 #ifdef FEAT_GUI_MACVIM
     void
-im_preedit_abandon_macvim()
+im_preedit_abandon_macvim(void)
 {
     /* Abandon preedit text, don't send any backspace sequences. */
     im_preedit_cursor = 0;

--- a/src/os_macosx.m
+++ b/src/os_macosx.m
@@ -524,7 +524,7 @@ sound_mch_free(void)
 #endif
 
     void
-macosx_fork()
+macosx_fork(void)
 {
     pid_t pid;
     int   i;

--- a/src/proto.h
+++ b/src/proto.h
@@ -344,7 +344,4 @@ int clip_mch_own_selection(Clipboard_T *cbd);
 void clip_mch_request_selection(Clipboard_T *cbd);
 void clip_mch_set_selection(Clipboard_T *cbd);
 # endif
-# if defined(MACOS_X) && defined(FEAT_GUI)
-void macosx_fork();
-# endif
 #endif // !PROTO && !NOPROTO

--- a/src/proto/gui_macvim.pro
+++ b/src/proto/gui_macvim.pro
@@ -1,6 +1,6 @@
-void macvim_early_init();
+void macvim_early_init(void);
 void gui_mch_prepare(int *argc, char **argv);
-void gui_macvim_after_fork_init();
+void gui_macvim_after_fork_init(void);
 int gui_mch_init_check(void);
 int gui_mch_init(void);
 void gui_mch_exit(int rc);
@@ -35,6 +35,7 @@ void gui_mch_draw_menubar(void);
 void gui_mch_enable_menu(int flag);
 void gui_mch_show_toolbar(int showit);
 void gui_mch_free_font(GuiFont font);
+GuiFont gui_mch_retain_font(GuiFont font);
 GuiFont gui_mch_get_font(char_u *name, int giveErrorIfMissing);
 char_u *gui_mch_get_fontname(GuiFont font, char_u *name);
 int gui_mch_init_font(char_u *font_name, int fontset);
@@ -72,7 +73,7 @@ int gui_mch_get_scrollbar_xpadding(void);
 int gui_mch_get_scrollbar_ypadding(void);
 void gui_mch_set_scrollbar_thumb(scrollbar_T *sb, long val, long size, long max);
 void gui_mch_set_shellsize(int width, int height, int min_width, int min_height, int base_width, int base_height, int direction);
-void gui_mch_resize_view();
+void gui_mch_resize_view(void);
 void gui_mch_set_sp_color(guicolor_T color);
 void gui_mch_set_text_area_pos(int x, int y, int w, int h);
 void gui_mch_set_winpos(int x, int y);
@@ -83,7 +84,7 @@ void gui_mch_start_blink(void);
 void gui_mch_stop_blink(int may_call_gui_update_cursor);
 void gui_mch_toggle_tearoffs(int enable);
 void mch_set_mouse_shape(int shape);
-void gui_mch_def_colors();
+void gui_mch_def_colors(void);
 void ex_macaction(exarg_T *eap);
 void gui_make_popup(char_u *path_name, int mouse_pos);
 
@@ -99,7 +100,7 @@ void gui_mch_enter_fullscreen(guicolor_T bg);
 void gui_mch_leave_fullscreen(void);
 void gui_mch_fuopt_update(void);
 
-void gui_macvim_update_modified_flag();
+void gui_macvim_update_modified_flag(void);
 void gui_macvim_add_to_find_pboard(char_u *pat);
 void gui_macvim_set_antialias(int antialias);
 void gui_macvim_set_ligatures(int ligatures);
@@ -115,7 +116,7 @@ void odb_end(void);
 char_u *get_macaction_name(expand_T *xp, int idx);
 int is_valid_macaction(char_u *action);
 
-void gui_macvim_wait_for_startup();
+void gui_macvim_wait_for_startup(void);
 void gui_macvim_get_window_layout(int *count, int *layout);
 
 void gui_mch_find_dialog(exarg_T *eap);
@@ -132,7 +133,7 @@ void *gui_mch_register_sign(char_u *signfile);
 
 void gui_mch_destroy_sign(void *sign);
 
-void *gui_macvim_new_autoreleasepool();
+void *gui_macvim_new_autoreleasepool(void);
 void gui_macvim_release_autoreleasepool(void *pool);
 
 void f_showdefinition(typval_T *argvars, typval_T *rettv);

--- a/src/proto/gui_xim.pro
+++ b/src/proto/gui_xim.pro
@@ -18,4 +18,12 @@ int preedit_get_status(void);
 int im_is_preediting(void);
 void xim_set_status_area(void);
 int xim_get_status_area_height(void);
+
+// MacVim
+void call_imactivatefunc(int active);
+int call_imstatusfunc(void);
+void im_preedit_start_macvim(void);
+void im_preedit_end_macvim(void);
+void im_preedit_abandon_macvim(void);
+void im_preedit_changed_macvim(char *preedit_string, int cursor_index);
 /* vim: set ft=c : */

--- a/src/proto/os_macosx.pro
+++ b/src/proto/os_macosx.pro
@@ -4,4 +4,7 @@ bool sound_mch_play(const char_u* event, long sound_id, soundcb_T *callback, boo
 void sound_mch_stop(long sound_id);
 void sound_mch_clear(void);
 void sound_mch_free(void);
+
+// MacVim
+void macosx_fork(void);
 /* vim: set ft=c : */


### PR DESCRIPTION
Upstream Vim has added strict-prototypes and missing-prototypes warnings to CI, which is useful but need to clean up MacVim code to avoid build failures. There should be no more magic extern function declarations from now on as they are quite fragile. Just put them in a prototype header.

Also fix GitHub Action badge on README. For some reason the format has changed and the badge was always reporting we have passed even if CI is failing.