### PR TITLE
Add cmdline completion for MacVim options: 'fuoptions', 'guifont(wide)'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3873,7 +3873,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	In non-native fullscreen mode, MacVim can be configured to either show
 	all the content filling up the whole screen, or only use part of the
 	screen to show the content, centered.  This option controls the size
-	of the Vim control as well as the color of the unused screen area.
+	of the Vim control as well as the color of the unused screen area.  It
+	is a comma-separated list of values as follows:
+
 	value	effect	~
         maxvert	When entering fullscreen, 'lines' is set to the maximum number
 		of lines fitting on the screen in fullscreen mode. If unset,

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1175,9 +1175,9 @@ static struct vimoption options[] =
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
 			    SCTX_INIT},
-    {"fuoptions",  "fuopt", P_STRING|P_COMMA|P_NODUP|P_VI_DEF,
+    {"fuoptions",  "fuopt", P_STRING|P_COMMA|P_NODUP|P_VI_DEF|P_COLON,
 #ifdef FEAT_FULLSCREEN
-			    (char_u *)&p_fuoptions, PV_NONE, did_set_fuoptions, NULL,
+			    (char_u *)&p_fuoptions, PV_NONE, did_set_fuoptions, expand_set_fuoptions,
 			    {(char_u *)"maxvert,maxhorz", (char_u *)0L}
 #else
 			    (char_u *)NULL, PV_NONE, NULL, NULL,

--- a/src/proto/gui_macvim.pro
+++ b/src/proto/gui_macvim.pro
@@ -40,6 +40,7 @@ GuiFont gui_mch_get_font(char_u *name, int giveErrorIfMissing);
 char_u *gui_mch_get_fontname(GuiFont font, char_u *name);
 int gui_mch_init_font(char_u *font_name, int fontset);
 void gui_mch_set_font(GuiFont font);
+void gui_mch_expand_font(optexpand_T *args, void *param, int (*add_match)(char_u *val));
 int gui_mch_adjust_charheight(void);
 int gui_mch_adjust_charwidth(void);
 void gui_mch_beep(void);

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -156,6 +156,7 @@ int expand_set_foldclose(optexpand_T *args, int *numMatches, char_u ***matches);
 int expand_set_foldmethod(optexpand_T *args, int *numMatches, char_u ***matches);
 int expand_set_foldopen(optexpand_T *args, int *numMatches, char_u ***matches);
 int expand_set_formatoptions(optexpand_T *args, int *numMatches, char_u ***matches);
+int expand_set_fuoptions(optexpand_T *args, int *numMatches, char_u ***matches);
 int expand_set_guifont(optexpand_T *args, int *numMatches, char_u ***matches);
 int expand_set_guioptions(optexpand_T *args, int *numMatches, char_u ***matches);
 int expand_set_highlight(optexpand_T *args, int *numMatches, char_u ***matches);

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -625,6 +625,28 @@ func Test_expand_guifont()
 
     let &guifontwide = guifontwide_saved
     let &guifont     = guifont_saved
+  elseif has('gui_macvim')
+    let guifont_saved = &guifont
+    let guifontwide_saved = &guifontwide
+
+    " Test recalling default and existing option, and suggesting current font
+    " size
+    set guifont=
+    call assert_equal('Menlo-Regular:h11', getcompletion('set guifont=', 'cmdline')[0])
+    set guifont=Monaco:h12
+    call assert_equal('Monaco:h12', getcompletion('set guifont=', 'cmdline')[0])
+    call assert_equal('h12', getcompletion('set guifont=Menlo\ Italic:', 'cmdline')[0])
+
+    " Test auto-completion working for font names
+    call assert_equal(['Menlo-Regular'], getcompletion('set guifont=Menl*lar$', 'cmdline'))
+    call assert_equal(['Menlo-Regular'], getcompletion('set guifontwide=Menl*lar$', 'cmdline'))
+
+    " Make sure non-monospace fonts are filtered out only in 'guifont'
+    call assert_equal([], getcompletion('set guifont=Hel*tica$', 'cmdline'))
+    call assert_equal(['Helvetica'], getcompletion('set guifontwide=Hel*tica$', 'cmdline'))
+
+    let &guifontwide = guifontwide_saved
+    let &guifont     = guifont_saved
   else
     call assert_equal([], getcompletion('set guifont=', 'cmdline'))
   endif

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -569,6 +569,13 @@ func Test_set_completion_string_values()
   call assert_equal([], getcompletion('set hl+=8'..hl_display_modes, 'cmdline'))
 
   "
+  " MacVim options
+  "
+  call assert_equal(getcompletion('set fuoptions+=', 'cmdline')[0], 'maxvert')
+  call assert_equal(getcompletion('set fuoptions+=maxvert,background:', 'cmdline')[0], '#')
+  call assert_equal(getcompletion('set fuoptions+=maxvert,background:No*ext', 'cmdline')[0], 'NonText')
+
+  "
   " Test flag lists
   "
 


### PR DESCRIPTION
Vim just added command-line completion for option setting (vim/vim#13182), including guifont (vim/vim#13264). Add support for MacVim-specific options and also guifont.