### PR TITLE
Fix tabs drawing over rest of MacVim in macOS 14 Sonoma

### DIFF
--- a/src/MacVim/PSMTabBarControl/source/PSMTabBarControl.m
+++ b/src/MacVim/PSMTabBarControl/source/PSMTabBarControl.m
@@ -147,6 +147,10 @@
         }
         [_addTabButton setNeedsDisplay:YES];
     }
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
+    [self setClipsToBounds:YES];
+#endif
 }
 
 - (id)initWithFrame:(NSRect)frame


### PR DESCRIPTION
macOS 14 now defaults clipsToBounds to false, which works in most places in MacVim but seems to cause issues with PSMTabBar which relies on clipping to work. Since we are replacing it soon, simply set clipsToBounds to true for the control.

Fix #1439