### PR TITLE
Fix misc build issues: cleaning build folder and --with-macsdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ src/MacVim/qlstephen/QuickLookStephen.xcodeproj/*.pbxuser
 src/MacVim/qlstephen/QuickLookStephen.xcodeproj/xcuserdata
 src/MacVim/qlstephen/build
 src/MacVim/build
+src/MacVim/auto
 src/MacVim/DerivedData
 src/TAGS
 src/Vim

--- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
+++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
@@ -1075,7 +1075,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Generate a list of folders that will affect the runtime folder output, so\n# that incremental build can use it to only install them if the runtime folders\n# have changed. The main reason we have to manually generate it is because\n# Xcode's \"Input File Lists\" doesn't support recursion/wildcards.\n\nfind -s ../../runtime -type d > \"${OBJROOT}\"/runtime_folder_list_new.xcfilelist\n\nif cmp -s \"${OBJROOT}\"/runtime_folder_list.xcfilelist \"${OBJROOT}\"/runtime_folder_list_new.xcfilelist; then\n    rm \"${OBJROOT}\"/runtime_folder_list_new.xcfilelist\nelse\n    mv -f \"${OBJROOT}\"/runtime_folder_list_new.xcfilelist \"${OBJROOT}\"/runtime_folder_list.xcfilelist\nfi\n";
+			shellScript = "# Generate a list of folders that will affect the runtime folder output, so\n# that incremental build can use it to only install them if the runtime folders\n# have changed. The main reason we have to manually generate it is because\n# Xcode's \"Input File Lists\" doesn't support recursion/wildcards.\n\nfind -s ../../runtime -type d > \"${OBJROOT}\"/runtime_folder_list_new.xcfilelist\n\nif cmp -s \"${SRCROOT}\"/auto/runtime_folder_list.xcfilelist \"${OBJROOT}\"/runtime_folder_list_new.xcfilelist; then\n    rm \"${OBJROOT}\"/runtime_folder_list_new.xcfilelist\nelse\n    mv -f \"${OBJROOT}\"/runtime_folder_list_new.xcfilelist \"${SRCROOT}\"/auto/runtime_folder_list.xcfilelist\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		9099B3CA2914B272005C9F32 /* Clean up build */ = {
@@ -1104,7 +1104,7 @@
 			files = (
 			);
 			inputFileListPaths = (
-				$OBJROOT/runtime_folder_list.xcfilelist,
+				$SRCROOT/auto/runtime_folder_list.xcfilelist,
 			);
 			inputPaths = (
 				"$(SRCROOT)/../xxd/xxd",

--- a/src/Makefile
+++ b/src/Makefile
@@ -3642,7 +3642,7 @@ Makefile:
 ### MacVim GUI
 .PHONY: macvim macvim-dmg macvim-dmg-legacy macvimclean macvim-signed macvim-dmg-release macvim-dmg-release-legacy macvim-install-runtime
 
-RUNTIME_FOLDER_LIST = MacVim/build/runtime_folder_list.xcfilelist
+RUNTIME_FOLDER_LIST = MacVim/auto/runtime_folder_list.xcfilelist
 
 RELEASEDIR = MacVim/build/Release
 DMGDIR = MacVim/build/dmg
@@ -3657,7 +3657,7 @@ $(RUNTIME_FOLDER_LIST):
 	# Generate a stub runtime folder list, used for incremental builds.
 	# Xcode's dependnecy management requires this file to exist at start
 	# of build, even though this file is only generated during build time.
-	mkdir -p MacVim/build
+	mkdir -p MacVim/auto
 	touch $(RUNTIME_FOLDER_LIST)
 
 macvim: $(VIMTARGET) $(RUNTIME_FOLDER_LIST)
@@ -3689,7 +3689,7 @@ macvim-dmg:
 
 macvimclean:
 	if test -d MacVim; then \
-		rm -rf MacVim/build MacVim/qlstephen/build xxd/xxd.dSYM; \
+		rm -rf MacVim/auto MacVim/build MacVim/qlstephen/build xxd/xxd.dSYM; \
 	fi
 
 # Create a release DMG image that is signed and notaraized

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -4960,13 +4960,18 @@ fi
 printf %s "checking if SDK is supported... " >&6; }
     save_cflags="$CFLAGS"
     save_ldflags="$LDFLAGS"
-    sdkflags="$DEVELOPER_DIR/SDKs/MacOSX$MACSDK"
+
+        sdkflags="$DEVELOPER_DIR/SDKs/MacOSX$MACSDK"
     if test "x$MACSDK" = "x10.4"; then
       sdkflags="$sdkflags""u"
     fi
+    if ! test -d "$sdkflags.sdk"; then
+            sdkflags="$DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$MACSDK"
+    fi
     sdkflags="$sdkflags.sdk -mmacosx-version-min=$MACSDK"
+
     CFLAGS="$CFLAGS -isysroot $sdkflags"
-    LDFLAGS="$LDFLAGS -Wl,-syslibroot,$sdkflags"
+    LDFLAGS="$LDFLAGS -isysroot $sdkflags"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -280,13 +280,20 @@ if test "$vim_cv_uname_output" = Darwin; then
     AC_MSG_CHECKING(if SDK is supported)
     save_cflags="$CFLAGS"
     save_ldflags="$LDFLAGS"
+
+    dnl Old location of SDKs and also in Command-Line Tools
     sdkflags="$DEVELOPER_DIR/SDKs/MacOSX$MACSDK"
     if test "x$MACSDK" = "x10.4"; then
       sdkflags="$sdkflags""u"
     fi
+    if ! test -d "$sdkflags.sdk"; then
+      dnl Location of SDKs in Xcode
+      sdkflags="$DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$MACSDK"
+    fi
     sdkflags="$sdkflags.sdk -mmacosx-version-min=$MACSDK"
+
     CFLAGS="$CFLAGS -isysroot $sdkflags"
-    LDFLAGS="$LDFLAGS -Wl,-syslibroot,$sdkflags"
+    LDFLAGS="$LDFLAGS -isysroot $sdkflags"
     AC_LINK_IFELSE([AC_LANG_PROGRAM([ ], [ ])],
       [ AC_MSG_RESULT([yes])
         XCODEFLAGS="$XCODEFLAGS -sdk macosx$MACSDK MACOSX_DEPLOYMENT_TARGET=$MACSDK" ],


### PR DESCRIPTION
Fix cleaning the build folder causing incrementally building in Xcode to not work, by moving the runtime_folder_list.xcfilelist file to a separate MacVim/auto folder instead. This way, Xcode can have full control over its build folder and can clean / rebuild it.

Fix configure --with-macsdk to work, by updating to use modern Xcode folder structures and linker flags.