### PR TITLE
Add option to only scroll in one direction when using trackpad

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -260,9 +260,9 @@ The ODB editor protocol is documented at:
 3. Settings		    *macvim-prefs* *macvim-preferences* *macvim-settings*
 
 Some settings are global to the MacVim application and would not make sense as
-Vim options.  These settings are stored in the user defaults database and can
-be accessed via the "MacVim.Settings…" ("MacVim.Preferences…" in macOS 12
-Monterey and older) menu item.
+Vim options (see |macvim-options|).  These settings are stored in the user
+defaults database and can be accessed via the "MacVim.Settings…"
+("MacVim.Preferences…" in macOS 12 Monterey and older) menu item.
 
 							*macvim-user-defaults*
 Not all entries in the user defaults database are exposed via the settings
@@ -299,6 +299,7 @@ KEY				VALUE ~
 *MMTitlebarAppearsTransparent*	enable a transparent titlebar [bool]
 *MMAppearanceModeSelection*	dark mode selection (|macvim-dark-mode|)[bool]
 *MMRendererClipToRow*		clip tall characters to the row they are on [bool]
+*MMScrollOneDirectionOnly*	scroll along one axis only when using trackpad [bool]
 *MMSmoothResize*		allow smooth resizing of MacVim window [bool]
 *MMShareFindPboard*		share search text to Find Pasteboard [bool]
 *MMShowAddTabButton*		enable "add tab" button on tabline [bool]

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5586,6 +5586,7 @@ MMNoTitleBarWindow	gui_mac.txt	/*MMNoTitleBarWindow*
 MMNonNativeFullScreenSafeAreaBehavior	gui_mac.txt	/*MMNonNativeFullScreenSafeAreaBehavior*
 MMNonNativeFullScreenShowMenu	gui_mac.txt	/*MMNonNativeFullScreenShowMenu*
 MMRendererClipToRow	gui_mac.txt	/*MMRendererClipToRow*
+MMScrollOneDirectionOnly	gui_mac.txt	/*MMScrollOneDirectionOnly*
 MMShareFindPboard	gui_mac.txt	/*MMShareFindPboard*
 MMShowAddTabButton	gui_mac.txt	/*MMShowAddTabButton*
 MMShowWhatsNewOnStartup	gui_mac.txt	/*MMShowWhatsNewOnStartup*

--- a/src/MacVim/Base.lproj/Preferences.xib
+++ b/src/MacVim/Base.lproj/Preferences.xib
@@ -495,11 +495,11 @@
             <point key="canvasLocation" x="137.5" y="435"/>
         </customView>
         <customView id="Bnq-Nx-GJH" userLabel="Input">
-            <rect key="frame" x="0.0" y="0.0" width="483" height="84"/>
+            <rect key="frame" x="0.0" y="0.0" width="483" height="110"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <customView id="DAP-Yi-QU0" userLabel="Trackpad">
-                    <rect key="frame" x="20" y="46" width="433" height="18"/>
+                    <rect key="frame" x="20" y="72" width="433" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="f18-Wr-EgZ">
@@ -526,10 +526,10 @@
                     </subviews>
                 </customView>
                 <customView id="GZa-RH-fza" userLabel="Mouse">
-                    <rect key="frame" x="20" y="20" width="433" height="18"/>
+                    <rect key="frame" x="20" y="46" width="433" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
-                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="3Tx-8j-zQR">
+                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="3Tx-8j-zQR">
                             <rect key="frame" x="-2" y="0.0" width="187" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Mouse:" id="imK-Tr-YuD">
@@ -551,8 +551,35 @@
                         </button>
                     </subviews>
                 </customView>
+                <customView id="aUx-jX-mJJ" userLabel="Scrolling">
+                    <rect key="frame" x="20" y="20" width="433" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <subviews>
+                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="8cr-OB-jXX" userLabel="Scrolling:">
+                            <rect key="frame" x="-2" y="0.0" width="187" height="17"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Scrolling" id="UFM-zM-qC7" userLabel="Scrolling:">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <button id="Cdy-wF-SD6">
+                            <rect key="frame" x="189" y="-1" width="187" height="18"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <string key="toolTip">When set, will only scroll along either the vertical or horizontal axis when using trackpad. This prevents horizontal drift when scrolling vertically on a trackpad.</string>
+                            <buttonCell key="cell" type="check" title="Scroll in one direction only" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="psN-UG-I7i">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <binding destination="58" name="value" keyPath="values.MMScrollOneDirectionOnly" id="EHQ-Yi-7ou"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                </customView>
             </subviews>
-            <point key="canvasLocation" x="137.5" y="692"/>
+            <point key="canvasLocation" x="137.5" y="705"/>
         </customView>
         <customView id="620" userLabel="Advanced">
             <rect key="frame" x="0.0" y="0.0" width="483" height="367"/>

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -268,6 +268,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         [NSNumber numberWithBool:NO],     MMUpdaterPrereleaseChannelKey,
         @"",                              MMLastUsedBundleVersionKey,
         [NSNumber numberWithBool:YES],    MMShowWhatsNewOnStartupKey,
+        [NSNumber numberWithBool:0],      MMScrollOneDirectionOnlyKey,
         nil];
 
     [[NSUserDefaults standardUserDefaults] registerDefaults:dict];

--- a/src/MacVim/MMTextViewHelper.h
+++ b/src/MacVim/MMTextViewHelper.h
@@ -22,6 +22,12 @@
 
 
 @interface MMTextViewHelper : NSObject {
+    enum ScrollingDirection {
+        ScrollingDirectionUnknown = 0,
+        ScrollingDirectionVertical,
+        ScrollingDirectionHorizontal,
+    };
+
     id                  textView;
     BOOL                isDragging;
     int                 dragRow;
@@ -38,6 +44,7 @@
     NSDate              *mouseDownTime;
     CGFloat             scrollingDeltaX;
     CGFloat             scrollingDeltaY;
+    enum ScrollingDirection scrollingDirection; ///< The fixed scrolling direction when using track pad (if configured to use it)
 
     // Input Manager
     NSRange             imRange;

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -66,6 +66,7 @@ extern NSString *MMAllowForceClickLookUpKey;
 extern NSString *MMUpdaterPrereleaseChannelKey;
 extern NSString *MMLastUsedBundleVersionKey;    // The last used version of MacVim before this launch
 extern NSString *MMShowWhatsNewOnStartupKey;
+extern NSString *MMScrollOneDirectionOnlyKey;
 
 
 // Enum for MMUntitledWindowKey

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -53,15 +53,16 @@ NSString *MMSuppressTerminationAlertKey   = @"MMSuppressTerminationAlert";
 NSString *MMNativeFullScreenKey           = @"MMNativeFullScreen";
 NSString *MMUseMouseTimeKey               = @"MMUseMouseTime";
 NSString *MMFullScreenFadeTimeKey         = @"MMFullScreenFadeTime";
-NSString *MMNonNativeFullScreenShowMenuKey  = @"MMNonNativeFullScreenShowMenu";
-NSString *MMNonNativeFullScreenSafeAreaBehaviorKey = @"MMNonNativeFullScreenSafeAreaBehavior";
+NSString *MMNonNativeFullScreenShowMenuKey          = @"MMNonNativeFullScreenShowMenu";
+NSString *MMNonNativeFullScreenSafeAreaBehaviorKey  = @"MMNonNativeFullScreenSafeAreaBehavior";
 NSString *MMSmoothResizeKey               = @"MMSmoothResize";
 NSString *MMCmdLineAlignBottomKey         = @"MMCmdLineAlignBottom";
-NSString *MMRendererClipToRowKey      = @"MMRendererClipToRow";
+NSString *MMRendererClipToRowKey          = @"MMRendererClipToRow";
 NSString *MMAllowForceClickLookUpKey      = @"MMAllowForceClickLookUp";
 NSString *MMUpdaterPrereleaseChannelKey   = @"MMUpdaterPrereleaseChannel";
-NSString *MMLastUsedBundleVersionKey        = @"MMLastUsedBundleVersion";
-NSString *MMShowWhatsNewOnStartupKey        = @"MMShowWhatsNewOnStartup";
+NSString *MMLastUsedBundleVersionKey      = @"MMLastUsedBundleVersion";
+NSString *MMShowWhatsNewOnStartupKey      = @"MMShowWhatsNewOnStartup";
+NSString *MMScrollOneDirectionOnlyKey     = @"MMScrollOneDirectionOnly";
 
 
 @implementation NSIndexSet (MMExtras)


### PR DESCRIPTION
This will pin the scrolling direction to the one at the beginning of a trackpad scrolling gesture, which helps prevent horizontal drift when the user is simply trying to scroll vertically up and down. At the beginning of the next scroll gesture the scrolling direction will be reset. This is the same as Visual Studio Code's "Scroll Predominant Axis" setting.