### PR TITLE
Fix macOS 14 Sonoma non-native full screen background color

### DIFF
--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -52,6 +52,9 @@
 #ifndef MAC_OS_VERSION_13_0
 # define MAC_OS_VERSION_13_0 130000
 #endif
+#ifndef MAC_OS_VERSION_14_0
+# define MAC_OS_VERSION_14_0 140000
+#endif
 
 #ifndef NSAppKitVersionNumber10_10
 # define NSAppKitVersionNumber10_10 1343


### PR DESCRIPTION
Non-native full screen's configured background color (default to black) stopped working when building using macOS 14 SDK, because the main CoreText view was now drawing over it in drawRect, due to the new clipToBounds property defaulting to false in macOS 14 SDK.

We could just fix this issue by setting clipToBounds to true on the text view, but we would lose the benefits of the new behavior which allows us to show tall texts (e.g. Tibetan texts or other characters with composing chars) on the first line and not have it be clipped at the top. Currently with the unclipped behavior, the character can be drawn and poke up into the window frame or the notch area.

To properly fix this, just clip the background color fill in drawRect, and allow texts etc to still draw outside the rect.