### PR TITLE
Fix non-native full screen show menu with notch, and changing resolution

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -370,11 +370,14 @@ MacVim can be used in full screen mode, see 'fullscreen'.
 
 There are two types of full screen modes.  By default, MacVim uses macOS'
 native full screen functionality, which creates a separate space in Mission
-Control.  MacVim also provides a non-native full screen mode, which can be set
-by disabling native full screen in the settings panel, or by setting
-|MMNativeFullScreen| to `NO` manually.  If you have a MacBook with a "notch"
-at the top of the screen, you can set |MMNonNativeFullScreenShowMenu| to `NO`
-and |MMNonNativeFullScreenSafeAreaBehavior| to 1 to utilitize the whole screen
+Control.
+
+MacVim also provides a non-native full screen mode, which can be set by
+disabling native full screen in the settings panel (see |MMNativeFullScreen|).
+Use 'fuoptions' to configure the background color and whether to maximize the
+rows/columns.  If you have a MacBook with a camera housing ("notch") at the
+top of the screen, you can set |MMNonNativeFullScreenShowMenu| to `NO` and
+|MMNonNativeFullScreenSafeAreaBehavior| to 1 to utilitize the whole screen
 (this will cause some of the content to be obscured by the notch).
 
 ==============================================================================

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1278,7 +1278,17 @@
     // Calling setFrameSizeKeepGUISize: instead of setFrameSize: prevents a
     // degenerate case where frameSizeMayHaveChanged: ends up resizing the window
     // *again* causing windowDidResize: to be called.
-    [vimView setFrameSizeKeepGUISize:[self contentSize]];
+    if (fullScreenWindow == nil) {
+        [vimView setFrameSizeKeepGUISize:[self contentSize]];
+    } else {
+        // Non-native full screen mode is more complicated and needs to
+        // re-layout the Vim view to properly account for the menu bar / notch,
+        // and misc fuopt configuration.
+        // This code is similar to what's done in processInputQueueDidFinish.
+        NSRect desiredFrame = [fullScreenWindow getDesiredFrame];
+        [vimView setFrameOrigin:desiredFrame.origin];
+        [vimView setFrameSizeKeepGUISize:desiredFrame.size];
+    }
 }
 
 - (void)windowDidChangeBackingProperties:(NSNotification *)notification


### PR DESCRIPTION
Currently MacVim's "show menu bar" option for non-native full screen does not work properly on newer MacBook's with a notch, as macOS's API for menu bar height for some reason does not return the full height of the menu bar (it only returns the height of the "normal" menu bar). We need to manually use visibleArea instead but that API also has an issue where it's for some reason 1 pixel less, meaning you see a black bar at the top, so we have to hack it to add 1 pixel. This is really not ideal and hopefully Apple fixes it with a new API.

Also fix it so changing resolution when MacVim is in non-native full screen will work properly.

When working on this, identified an issue that the dock detection logic doesn't really work, as we don't really know if the current screen has the dock visible or not due to lack of API to query it. Just left a comment for future reference.