### PR TITLE
Fix Help menu searching Vim doc not working with special chars

### DIFF
--- a/src/MacVim/MacVim.xctestplan
+++ b/src/MacVim/MacVim.xctestplan
@@ -17,6 +17,7 @@
         "argument" : "-MMUntitledWindow 0"
       }
     ],
+    "testExecutionOrdering" : "random",
     "testTimeoutsEnabled" : true
   },
   "testTargets" : [


### PR DESCRIPTION
Previously Help menu's Vim doc search did not work with special key documentation like `<Down>` because when sending the input to Vim, Vim interpreted `:h <Down>` as physically pressing down arrow instead of typing the literal text in. Fix this by a somewhat manual process of splitting the strings up and using `:execute` and string concatenation. It's not pretty but works. Otherwise we would need to define another IPC call to be able to pass commands to Vim without escaping commands.

Also fix up XCText utility so we don't use a predicate to wait for Vim open/close which was previously kind of slow. The new method of just using swizzling is much faster.