### PR TITLE
Support native macOS monospace font (SF Mono)

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -1129,11 +1129,22 @@ That's all.  XLFDs are not used.  For Chinese this is reported to work well: >
 <
 (Replace gui_gtk2 with gui_gtk3 for the GTK+ 3 GUI)
 
-For Mac OSX you can use something like this: >
-    :set guifont=Monaco:h10
-Also see 'macatsui', it can help fix display problems {not in MacVim}.
-In MacVim, fonts with spaces are set like this: >
+MacVim							*macvim-guifont*
+
+For MacVim you can use something like this: >
+    :set guifont=Menlo:h10
+Fonts with spaces are set like this: >
     :set guifont=DejaVu\ Sans\ Mono:h13
+To use bold/italic fonts, use the fully specified PostScript name of the
+font, like so: >
+    :set guifont=Menlo-Bold:h13
+To use the system native monospace font (which is SF Mono in new macOS
+versions), use the `-monospace-` keyword: >
+    :set guifont=-monospace-:h12
+You can also specify the font weight of the native monospace font (refer to
+Apple documentation for `NSFontWeight` for possible values): >
+    :set guifont=-monospace-Light:h11
+    :set guifont=-monospace-Medium:h11
 <
 Mono-spaced fonts					*E236*
 

--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -118,6 +118,9 @@ These are the non-standard options that MacVim supports:
 	'fuoptions'	'macligatures'	'macmeta'	'macthinstrokes'
 	'toolbariconsize'	'transparency'
 
+These are GUI-related Vim options that have MacVim-specific behaviors:
+	'guifont'
+
 							*macvim-commands*
 These are the non-standard commands that MacVim supports:
 	|:macaction|	|:macmenu|

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -8622,6 +8622,7 @@ macvim-encoding	gui_mac.txt	/*macvim-encoding*
 macvim-find	gui_mac.txt	/*macvim-find*
 macvim-full-screen	gui_mac.txt	/*macvim-full-screen*
 macvim-gestures	gui_mac.txt	/*macvim-gestures*
+macvim-guifont	gui.txt	/*macvim-guifont*
 macvim-help-menu	gui_mac.txt	/*macvim-help-menu*
 macvim-hints	gui_mac.txt	/*macvim-hints*
 macvim-internal-variables	gui_mac.txt	/*macvim-internal-variables*

--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -87,6 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
 // NSFontChanging methods
 //
 - (void)changeFont:(nullable id)sender;
+- (NSFontPanelModeMask)validModesForFontPanel:(NSFontPanel *)fontPanel;
 
 //
 // NSMenuItemValidation

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -900,7 +900,44 @@ static BOOL isUnsafeMessage(int msgid);
             NSString *name = [[NSString alloc]
                     initWithBytes:(void*)bytes length:len
                          encoding:NSUTF8StringEncoding];
-            NSFont *font = [NSFont fontWithName:name size:size];
+            NSFont *font = nil;
+            if ([name hasPrefix:MMSystemFontAlias]) {
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_15
+                if (@available(macos 10.15, *)) {
+                    NSFontWeight fontWeight = NSFontWeightRegular;
+                    if (name.length > MMSystemFontAlias.length) {
+                        const NSRange cmpRange = NSMakeRange(MMSystemFontAlias.length, name.length - MMSystemFontAlias.length);
+                        if ([name compare:@"UltraLight" options:NSCaseInsensitiveSearch range:cmpRange] == NSOrderedSame)
+                            fontWeight = NSFontWeightUltraLight;
+                        else if ([name compare:@"Thin" options:NSCaseInsensitiveSearch range:cmpRange] == NSOrderedSame)
+                            fontWeight = NSFontWeightThin;
+                        else if ([name compare:@"Light" options:NSCaseInsensitiveSearch range:cmpRange] == NSOrderedSame)
+                            fontWeight = NSFontWeightLight;
+                        else if ([name compare:@"Regular" options:NSCaseInsensitiveSearch range:cmpRange] == NSOrderedSame)
+                            fontWeight = NSFontWeightRegular;
+                        else if ([name compare:@"Medium" options:NSCaseInsensitiveSearch range:cmpRange] == NSOrderedSame)
+                            fontWeight = NSFontWeightMedium;
+                        else if ([name compare:@"Semibold" options:NSCaseInsensitiveSearch range:cmpRange] == NSOrderedSame)
+                            fontWeight = NSFontWeightSemibold;
+                        else if ([name compare:@"Bold" options:NSCaseInsensitiveSearch range:cmpRange] == NSOrderedSame)
+                            fontWeight = NSFontWeightBold;
+                        else if ([name compare:@"Heavy" options:NSCaseInsensitiveSearch range:cmpRange] == NSOrderedSame)
+                            fontWeight = NSFontWeightHeavy;
+                        else if ([name compare:@"Black" options:NSCaseInsensitiveSearch range:cmpRange] == NSOrderedSame)
+                            fontWeight = NSFontWeightBlack;
+                    }
+                    font = [NSFont monospacedSystemFontOfSize:size weight:fontWeight];
+                }
+                else
+#endif
+                {
+                    // Fallback to Menlo on older macOS versions that don't support the system monospace font API
+                    font = [NSFont fontWithName:@"Menlo-Regular" size:size];
+                }
+            }
+            else {
+                font = [NSFont fontWithName:name size:size];
+            }
             if (!font) {
                 // This should only happen if the system default font has changed
                 // name since MacVim was compiled in which case we fall back on

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -433,7 +433,8 @@ enum {
 
 extern NSString *VimFindPboardType;
 
-
+// Alias for system monospace font name
+extern NSString *MMSystemFontAlias;
 
 
 @interface NSString (MMExtras)

--- a/src/MacVim/MacVim.m
+++ b/src/MacVim/MacVim.m
@@ -40,6 +40,8 @@ NSString *MMRendererKey	       = @"MMRenderer";
 // Vim find pasteboard type (string contains Vim regex patterns)
 NSString *VimFindPboardType = @"VimFindPboardType";
 
+NSString *MMSystemFontAlias = @"-monospace-";
+
 int ASLogLevel = MM_ASL_LEVEL_DEFAULT;
 
 

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -153,7 +153,8 @@ enum {
 
 
 @interface NSNumber (MMExtras)
-// HACK to allow font size to be changed via menu (bound to Cmd+/Cmd-)
+// Used by modifyFont:/convertFont: to allow font size to be changed via menu
+// (bound to Cmd+/Cmd-) or using macaction fontSizeUp:/fontSizeDown:.
 - (NSInteger)tag;
 @end
 

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -433,6 +433,28 @@ func Test_set_guifont()
   let &guifont = guifont_saved
 endfunc
 
+func Test_set_guifont_macvim()
+  CheckFeature gui_macvim
+  let guifont_saved = &guifont
+  let guifontwide_saved = &guifontwide
+
+  set guifont=-monospace-
+  call assert_equal('-monospace-:h11', getfontname())
+  set guifont=-monospace-Semibold
+  call assert_equal('-monospace-Semibold:h11', getfontname())
+
+  call assert_fails('set guifont=-monospace-SemiboldInvalidWeight', 'E596')
+
+  set guifont=Menlo\ Regular
+  call assert_equal('Menlo Regular:h11', getfontname())
+
+  set guifont=
+  call assert_equal('Menlo-Regular:h11', getfontname())
+
+  let &guifontwide = guifontwide_saved
+  let &guifont     = guifont_saved
+endfunc
+
 func Test_set_guifontset()
   CheckFeature xfontset
   let skipped = ''
@@ -640,6 +662,13 @@ func Test_expand_guifont()
     " Test auto-completion working for font names
     call assert_equal(['Menlo-Regular'], getcompletion('set guifont=Menl*lar$', 'cmdline'))
     call assert_equal(['Menlo-Regular'], getcompletion('set guifontwide=Menl*lar$', 'cmdline'))
+
+    " Test system monospace font option. It's always the first option after
+    " the existing font.
+    call assert_equal('-monospace-', getcompletion('set guifont=', 'cmdline')[1])
+    call assert_equal('-monospace-', getcompletion('set guifont=-monospace-', 'cmdline')[0])
+    call assert_equal('-monospace-UltraLight', getcompletion('set guifont=-monospace-', 'cmdline')[1])
+    call assert_equal(['-monospace-Medium'], getcompletion('set guifont=-monospace-Med', 'cmdline'))
 
     " Make sure non-monospace fonts are filtered out only in 'guifont'
     call assert_equal([], getcompletion('set guifont=Hel*tica$', 'cmdline'))


### PR DESCRIPTION
Can now set guifont to `-monospace-` to use the system default monospace font, which is SF Mono on recent macOS versions (but could be updated to other fonts in future macOS releases). The reason why this is necessary instead of specifying the actual font name is that Apple does not expose the SF Mono font for the user and instead only exposes an AppKit API `monospacedSystemFontOfSize:weight:` to access it. The actual font name (`.AppleSystemUIFontMonospaced` in macOS 14) is internal and subject to change in different OS versions.

In older macOS versions, setting `-monospace-` will just use `Menlo-Regular` just like the default font.

Also allow specifying the font weight for the font, e.g. `-monospace-Semibold` / `-monospace-Light`. The list of weights follows the NSFontWeight enum, but not all values yield unique fonts. E.g. "UltraLight", "Thin", "Light" will all use the "Light" version of SF Mono. The list of all font weights can be tab-completed but only if the user has already filled in `-monospace-` in `:set guifont=`. This helps prevents showing too many options when the user does tab completion just to see the list of all fonts.

Note that SF Mono is currently available to be downloaded from Apple's website as a standalone for testing. That font is mostly the same but seems to have slightly different line spacing behavior, and when using bold it uses the "Bold" font variant, whereas the system monospace font uses "Semibold" variant instead.

Also make font panel not show misc formatting options like underline as they aren't used by MacVim. Keep the background/foreground option just so the font preview colors in the panel can be adjusted.

Also fix an existing potential buffer overflow issue in the Core Text renderer in that `changeFont:` (when setting a new font using font panel or using font size up/down) isn't setting `wideLen` which could cause an unsafe memory access in Vim side.

Notes:
- Known issue: When using macaction `fontSizeUp:`/`fontSizeDown:` (Cmd +/-), `-monospace-` will get replaced by the internal font name (e.g. `.AppleSystemUIFontMonospaced-Regular`) instead due to how the `changeFont:` currently works. This could be fixed but it's low enough priority that it's ok for now.
- In the future, this may become the default font instead of Menlo, to make MacVim more consistent with Apple software like Terminal and Xcode.