### PR TITLE
Fix macOS 14 Sonoma printing to use ps2pdf instead

### DIFF
--- a/runtime/autoload/macvim.vim
+++ b/runtime/autoload/macvim.vim
@@ -88,7 +88,19 @@ enddef
 #   PreviewConvertPostScript doesn't work.
 export def PreviewConvertPostScript(deltimer = 10000): number
   # Convert PS to PDF because Preview can't use PS files in macOS 13+
-  system($"pstopdf {v:fname_in} -o {v:fname_in}.pdf")
+  if executable('/usr/bin/pstopdf')
+    system($"/usr/bin/pstopdf {v:fname_in} -o {v:fname_in}.pdf")
+  else
+    # Starting in macOS 14, pstopdf is no longer bundled. We just require the
+    # user to install ps2pdf as it's the simplest solution for a relatively
+    # niche feature today (printing).
+    if executable('ps2pdf')
+      system($"ps2pdf {v:fname_in} {v:fname_in}.pdf")
+    else
+      echoerr 'Cannot find ps2pdf. You can install it by installing Ghostscript. This is necessary in macOS 14+ for printing to work.'
+      return 1
+    endif
+  endif
   if v:shell_error != 0
     return v:shell_error
   endif


### PR DESCRIPTION
Fix broken printing in macOS 14. It was broken because the OS stopped supporting Postscript and removed the `pstopdf` tool. Fix the printexpr to detect when `pstopdf` doesn't exist and try to use `ps2pdf` instead. This is a third-party tool and it's not guaranteed to exist. If it doesn't exist, give an error prompt for the user to suggest installing Ghostscript first. Settled on this solution as printing is a relatively niche feature and it's not worth spending too much effort fixing this.

Related:
- #1390 / #1347: macOS 13 Ventura broke printing by removing Preview support for PostScript. The fix was to use `pstopdf`, which eventually got removed in macOS 14.