### PR TITLE
Update CI to build using Xcode 15.1

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -67,7 +67,7 @@ jobs:
 
           # Most up to date OS and Xcode. Used to publish release for the main build.
           - os: macos-13
-            xcode: '15.0'
+            xcode: '15.1'
             publish: true
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Update Xcode to latest version before release, as 15.1 seems to contain some bug fixes in the linker that may matter.