### PR TITLE
Update CI to use macos-14 / Apple Silicon runners

### DIFF
--- a/.github/actions/universal-package/action.yml
+++ b/.github/actions/universal-package/action.yml
@@ -47,14 +47,18 @@ runs:
         xcode_version=$(xcodebuild -version | tail -1 | sed -E 's/Build version (.*)/\1/')
         echo "xcode_version=$xcode_version" >> $GITHUB_OUTPUT
 
+        # Find Homebrew's install location which could be /usr/local or /opt/homebrew
+        brew_prefix=$(brew --prefix)
+        echo "brew_prefix=$brew_prefix" >> $GITHUB_OUTPUT
+
         echo '::endgroup::'
 
     - name: Cache keg
       id: cache-keg
       uses: actions/cache@v3
       with:
-        path: /usr/local/Cellar/${{ inputs.formula }}
-        key: ${{ inputs.formula }}-homebrew-cache-custom-unified-xcode${{ steps.setup-formula.outputs.xcode_version }}-${{ hashFiles(format('{0}.rb', inputs.formula)) }}
+        path: ${{ steps.setup-formula.outputs.brew_prefix }}/Cellar/${{ inputs.formula }}
+        key: ${{ inputs.formula }}-homebrew-cache-custom-unified-prefix${{ steps.setup-formula.outputs.brew_prefix }}-xcode${{ steps.setup-formula.outputs.xcode_version }}-${{ hashFiles(format('{0}.rb', inputs.formula)) }}
 
     - name: Install formula
       shell: bash
@@ -65,7 +69,7 @@ runs:
         # This will be a no-op if formula was cached
         brew install --formula -s ./${formula}.rb
 
-        # If formula was cached, this step is necessary to relink it to /usr/local/
+        # If formula was cached, this step is necessary to relink it to brew prefix (e.g. /usr/local)
         brew unlink ${formula} && brew link ${formula}
         echo '::endgroup::'
 
@@ -74,11 +78,11 @@ runs:
 
         for content in "${contents[@]}"; do
           # Print out the archs and verify they are universal fat binary.
-          lipo -info /usr/local/${content} | grep 'x86_64 arm64'
+          lipo -info $(brew --prefix)/${content} | grep 'x86_64 arm64'
 
           # Make sure deployment target is correct. Later macOS versions have a different binary format (just search for
           # "minos") but for 10.13 we need to look for LC_VERSION_MIN_MACOSX.
-          otool -l /usr/local/${content} | grep -A 2 LC_VERSION_MIN_MACOSX | tail -1 | grep "${MACOSX_DEPLOYMENT_TARGET}"
+          otool -l $(brew --prefix)/${content} | grep -A 2 LC_VERSION_MIN_MACOSX | tail -1 | grep "${MACOSX_DEPLOYMENT_TARGET}"
         done
 
         echo '::endgroup::'

--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -25,9 +25,9 @@ env:
   VERSIONER_PERL_VERSION: '5.30'  # macOS default Perl installation uses this to determine which one to use
 
   vi_cv_path_python: /Library/Frameworks/Python.framework/Versions/2.7/bin/python
-  vi_cv_path_python3: /usr/local/bin/python3
-  vi_cv_path_plain_lua: /usr/local/bin/lua
-  vi_cv_path_ruby: /usr/local/opt/ruby/bin/ruby
+  vi_cv_path_python3: "%s/bin/python3"
+  vi_cv_path_plain_lua: "%s/bin/lua"
+  vi_cv_path_ruby: "%s/opt/ruby/bin/ruby"
   vi_cv_dll_name_perl: /System/Library/Perl/%s/darwin-thread-multi-2level/CORE/libperl.dylib
   vi_cv_dll_name_python: /Library/Frameworks/Python.framework/Versions/2.7/Python
   vi_cv_dll_name_python3: /usr/local/Frameworks/Python.framework/Versions/Current/Python
@@ -65,10 +65,16 @@ jobs:
             legacy: true
             publish_postfix: '_10.9'
 
-          # Most up to date OS and Xcode. Used to publish release for the main build.
           - os: macos-13
-            xcode: '15.1'
+            xcode: '15.2'
+            optimized: true
+
+          # Most up to date OS and Xcode. Used to publish release for the main build.
+          # This runner uses Apple Silicon.
+          - os: macos-14
+            xcode: '15.2'
             publish: true
+            optimized: true
 
     runs-on: ${{ matrix.os }}
 
@@ -120,6 +126,10 @@ jobs:
       # Set up remaining packages and tools
 
       - name: Install packages
+        run: |
+          brew install libtool
+
+      - name: Install scripting runtimes
         if: matrix.publish
         run: |
           # We no longer need to install/update Python 3, as it's guaranteed to
@@ -129,10 +139,14 @@ jobs:
           brew install ruby
           brew install lua
 
-          if [[ -d /usr/local/Cellar/perl ]]; then
+          if [[ -d $(brew --prefix)/Cellar/perl ]]; then
             # We just use system perl to reduce dependencies
             brew unlink perl
           fi
+
+          echo "vi_cv_path_python3=$(printf $vi_cv_path_python3 $(brew --prefix))" >> $GITHUB_ENV
+          echo "vi_cv_path_plain_lua=$(printf $vi_cv_path_plain_lua $(brew --prefix))" >> $GITHUB_ENV
+          echo "vi_cv_path_ruby=$(printf $vi_cv_path_ruby $(brew --prefix))" >> $GITHUB_ENV
 
           # With Perl, we need to manually specify the version number because the dylib path depends on it.
           echo "vi_cv_dll_name_perl=$(printf $vi_cv_dll_name_perl $VERSIONER_PERL_VERSION)" >> $GITHUB_ENV
@@ -155,6 +169,7 @@ jobs:
           set -o verbose
 
           CONFOPT=(
+            --with-local-dir=$(brew --prefix)
             --with-features=huge
             --enable-netbeans
             --with-tlib=ncurses
@@ -170,12 +185,11 @@ jobs:
               --with-python3-stable-abi=3.9 # macOS and Xcode currently ships 3.9, so we don't want go higher than that.
               --enable-rubyinterp=dynamic
               --enable-luainterp=dynamic
-              --with-lua-prefix=/usr/local
+              --with-lua-prefix=$(brew --prefix)
               --with-macarchs="$MACVIM_ARCHS"
             )
           else
             CONFOPT+=(
-              --with-macarchs=x86_64
               --disable-sparkle       # Disable Sparkle for testing that this flag builds and works
             )
           fi
@@ -193,10 +207,8 @@ jobs:
             sed -i.bak -f ci/config.mk.clang-12.sed src/auto/config.mk
           fi
 
-          if ${{ matrix.publish == true && ! matrix.legacy }}; then
-            # Only do O3/link-time optimizations for publish builds, so the other ones can still finish quickly to give
-            # quick feedbacks. Only do this for non-legacy builds now as it seems the older toolchain doesn't work as
-            # well for this.
+          if ${{ matrix.optimized == true }}; then
+            # Additional optimizations like link-time optimizations that are a bit slower to build.
             sed -i.bak -f ci/config.mk.optimized.sed src/auto/config.mk
           fi
 
@@ -276,9 +288,15 @@ jobs:
           # Smoketest scripting languages
           macvim_excmd -c 'lua print("Test")'     | grep Test
           macvim_excmd -c 'perl VIM::Msg("Test")' | grep Test
-          macvim_excmd -c 'py print "Test"'       | grep Test
           macvim_excmd -c 'py3 print("Test")'     | grep Test
           macvim_excmd -c 'ruby puts("Test")'     | grep Test
+
+          if [[ "$(uname -m)" == "x86_64" ]]; then
+            macvim_excmd -c 'py print "x86 Test"' | grep Test
+          else
+            # Python2 doesn't work in Apple Silicon, test under Rosetta
+            (VIM_BIN="arch -x86_64 ${VIM_BIN}"; macvim_excmd -c 'py print "rosetta Test"' | grep Test)
+          fi
 
           # Check that localized messages work by printing ':version' and checking against localized word
           macvim_excmd -c 'lang es_ES' -c 'version' | grep Enlazado


### PR DESCRIPTION
GitHub Actions has recently added support for macos-14 runners which run on top of Apple Silicon. Switch CI to using it for publishing binary builds. Keep running the other OSes for now to test compatibility.

Close #1263