### PR TITLE
Proposal: change x to × in title bar resize message

### DIFF
--- a/src/MacVim/MMVimView.m
+++ b/src/MacVim/MMVimView.m
@@ -982,7 +982,7 @@ enum {
         // We only want to set the window title if this resize came from
         // a live-resize, not (for example) setting 'columns' or 'lines'.
         if ([self inLiveResize]) {
-            [[self window] setTitle:[NSString stringWithFormat:@"%dx%d",
+            [[self window] setTitle:[NSString stringWithFormat:@"%d × %d",
                     constrained[1], constrained[0]]];
         }
     }


### PR DESCRIPTION
This is really minor... I changed the 'x' (lowercase X) to '×' (multiplication sign) in the title bar resize message. It just looks a little bit nicer, that's all.

<img width="390" alt="Screenshot 2024-04-29 at 5 15 56 PM" src="https://github.com/macvim-dev/macvim/assets/118104/fcff1531-5929-4a73-a429-644a81258ec2">
