### PR TITLE
Fix macos-12 CI runner not being able to build gettext

### DIFF
--- a/.github/actions/universal-package/action.yml
+++ b/.github/actions/universal-package/action.yml
@@ -66,6 +66,12 @@ runs:
         echo '::group::Install formula'
         formula=${{ inputs.formula }}
 
+        # We don't want brew to go upgrade all our dependents for now. They are
+        # time consuming and sometimes cause problems with the CI environment
+        # where they fail to link in random binaries (e.g. Python's 2to3),
+        # which cause brew install to return non-zero and fail the build.
+        export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+
         # This will be a no-op if formula was cached
         brew install --quiet --formula -s ./${formula}.rb
 


### PR DESCRIPTION
When building gettext, Homebrew tries to upgrade all dependencies, and Python is somehow a downstream dependency and it fails link in certain binaries like 2to3 which GitHub's CI environment already installed separately. This is a messy situation in general, but to fix it, just set `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK` so Homebrew doesn't go helpfully upgrade our dependencies when all we want is to build the package itself. For the most part it should not cause any issues.