### PR TITLE
Fix dragging GUI tabs resulting in a crash

### DIFF
--- a/src/MacVim/PSMTabBarControl/source/PSMTabDragAssistant.m
+++ b/src/MacVim/PSMTabBarControl/source/PSMTabDragAssistant.m
@@ -386,7 +386,7 @@ layout:
 
 - (void)removeAllPlaceholdersFromTabBar:(PSMTabBarControl *)control
 {
-    NSUInteger i, cellCount = [[control cells] count];
+    int i, cellCount = (int)[[control cells] count];
     for(i = (cellCount - 1); i >= 0; i--){
         PSMTabBarCell *cell = [[control cells] objectAtIndex:i];
         if([cell isPlaceholder])


### PR DESCRIPTION
This was introduced by #1457 which was supposed to be a simple compiler warning cleanup but it introduced a signed integer bug. Fix that here.

Fix #1473