### PR TITLE
Dark mode improve docs for v:os_appearance and add tests

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2439,9 +2439,12 @@ v:operator	The last operator given in Normal mode.  This is a single
 		Read-only.
 
                                         *v:os_appearance* *os-appearance-variable*
-v:os_appearance The current OS appearance mode. Useful if you want to change
+v:os_appearance The current OS appearance mode.  Useful if you want to change
 		options |background| or |colorscheme| according to the
- 		appearance of the GUI frontend. See also |OSAppearanceChanged|.
+		appearance of the GUI frontend.  See also
+		|OSAppearanceChanged|.  If the "Dark mode selection" setting
+		is not set to "Automatic", then this value will reflect that
+		setting instead.
 			value   description ~
  			0       Light Mode (always 0 on unsupported platforms)
  			1       Dark Mode


### PR DESCRIPTION
Make sure docs for v:os_appearance make it clear that it is reflecting MacVim's appearance, not the OS, which matters when not using "automatic" in dark mode appearance.

Also add some unit tests to test this part of the functionality to add test coverage.

Also see #1479