### PR TITLE
Fix non-native fullscreen quit to black screen bug

### DIFF
--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -58,7 +58,6 @@
 - (id)initWithVimController:(MMVimController *)controller;
 - (MMVimController *)vimController;
 - (MMVimView *)vimView;
-- (NSWindow *)window;
 - (NSString *)windowAutosaveKey;
 - (void)setWindowAutosaveKey:(NSString *)key;
 - (void)cleanup;

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -291,11 +291,6 @@
     return vimView;
 }
 
-- (NSWindow *)window
-{
-    return decoratedWindow;
-}
-
 - (NSString *)windowAutosaveKey
 {
     return windowAutosaveKey;


### PR DESCRIPTION
A previous change #1510 introduced a piece of debug code that erroneously overrode the `window` property to always return the normal window whereas in normal behavior it should return the full screen window when in non-native full screen. This property was only added for supporting unit tests and also completely unnecessary because the superclass `NSWindowController` already provides it (the one that we accidentally overrode). Just remove this.

Fix #1515