### PR TITLE
Add MacVim-specific settings to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,3 +23,7 @@ trim_trailing_whitespace = false
 [runtime/doc/**.txt]
 # It can mess up some documentation by trying to strip trailing whitespaces
 trim_trailing_whitespace = false
+
+[src/MacVim/**]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Previously Xcode and other editors were silently picking up the new Vim .editorconfig which uses hard tabs. Add MacVim-specific settings to make tools play nice with MacVim code base.