### PR TITLE
Fix resizing MacVim window occasionally result in a stale wrong Vim size

### DIFF
--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     // From MMTextStorage
     int                         maxRows, maxColumns;
+    int                         pendingMaxRows, pendingMaxColumns;
     NSColor                     *defaultBackgroundColor;
     NSColor                     *defaultForegroundColor;
     NSSize                      cellSize;
@@ -112,6 +113,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (int)maxColumns;
 - (void)getMaxRows:(int*)rows columns:(int*)cols;
 - (void)setMaxRows:(int)rows columns:(int)cols;
+- (int)pendingMaxRows;
+- (int)pendingMaxColumns;
+- (void)setPendingMaxRows:(int)rows columns:(int)cols;
 - (void)setDefaultColorsBackground:(NSColor *)bgColor
                         foreground:(NSColor *)fgColor;
 - (NSColor *)defaultBackgroundColor;

--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -309,6 +309,24 @@ static void grid_free(Grid *grid) {
     grid_resize(&grid, rows, cols);
     maxRows = rows;
     maxColumns = cols;
+    pendingMaxRows = rows;
+    pendingMaxColumns = cols;
+}
+
+- (int)pendingMaxRows
+{
+    return pendingMaxRows;
+}
+
+- (int)pendingMaxColumns
+{
+    return pendingMaxColumns;
+}
+
+- (void)setPendingMaxRows:(int)rows columns:(int)cols
+{
+    pendingMaxRows = rows;
+    pendingMaxColumns = cols;
 }
 
 - (void)setDefaultColorsBackground:(NSColor *)bgColor

--- a/src/MacVim/MMTextView.h
+++ b/src/MacVim/MMTextView.h
@@ -25,6 +25,9 @@
     NSRect              *invertRects;
     int                 numInvertRects;
 
+    int                 pendingMaxRows;
+    int                 pendingMaxColumns;
+
     MMTextViewHelper    *helper;
 }
 
@@ -57,6 +60,9 @@
 - (int)maxColumns;
 - (void)getMaxRows:(int*)rows columns:(int*)cols;
 - (void)setMaxRows:(int)rows columns:(int)cols;
+- (int)pendingMaxRows;
+- (int)pendingMaxColumns;
+- (void)setPendingMaxRows:(int)rows columns:(int)cols;
 - (NSRect)rectForRowsInRange:(NSRange)range;
 - (NSRect)rectForColumnsInRange:(NSRange)range;
 - (void)setDefaultColorsBackground:(NSColor *)bgColor

--- a/src/MacVim/MMTextView.m
+++ b/src/MacVim/MMTextView.m
@@ -401,7 +401,25 @@
 
 - (void)setMaxRows:(int)rows columns:(int)cols
 {
+    pendingMaxRows = rows;
+    pendingMaxColumns = cols;
     return [(MMTextStorage*)[self textStorage] setMaxRows:rows columns:cols];
+}
+
+- (int)pendingMaxRows
+{
+    return pendingMaxRows;
+}
+
+- (int)pendingMaxColumns
+{
+    return pendingMaxColumns;
+}
+
+- (void)setPendingMaxRows:(int)rows columns:(int)cols
+{
+    pendingMaxRows = rows;
+    pendingMaxColumns = cols;
 }
 
 - (NSRect)rectForRowsInRange:(NSRange)range

--- a/src/MacVim/MMVimView.h
+++ b/src/MacVim/MMVimView.h
@@ -28,7 +28,8 @@
 }
 
 @property BOOL pendingPlaceScrollbars;
-@property BOOL pendingLiveResize;
+@property BOOL pendingLiveResize; ///< An ongoing live resizing message to Vim is active
+@property BOOL pendingLiveResizeQueued; ///< A new size has been queued while an ongoing live resize is already active
 
 - (MMVimView *)initWithFrame:(NSRect)frame vimController:(MMVimController *)c;
 


### PR DESCRIPTION
First issue was that if you resize MacVim quickly (could be simulated by stalling Vim by calling `:sleep 5`), the existing logic for caching the size was wrong. It was using `maxRows`/`maxColumns` from the text view to decide if we send an updated message to Vim, but those are only updated after Vim has responded back to us. That means if we have two resize events before Vim could respond, that could lead to wrong results. One example would be quickly resizing Vim, then resizing it back to original size. To fix this, add a new "pending" rows/cols whenever we update Vim, and use that for caching instead as it always reflects what we want Vim's size to be.

Another issue was that in live resizing, if the user resizes Vim quickly (which again could be simulated by stalling Vim), the rate limiting logic would not send Vim with the latest size until the live event has finished (the user let go of the mouse button). This feels weird when it happens. Instead, fix it so that whenever we have rate limited the IPC commands, we immediately send the updated resize message once Vim has handled the last one, instead of waiting to do it in `liveResizeDidEnd`.