### PR TITLE
Fix non-native full screen misc background color and transparency issues

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3981,15 +3981,19 @@ A jump table for the options with a short description can be found at |Q_op|.
 		of columns fitting on the screen in fullscreen mode. If unset,
 		'columns' will be unchanged when entering fullscreen mode.
 	background:color
-		When entering fullscreen, 'color' defines the color of the part
-		of the screen that is not occupied by the Vim control. If
-		'color' is an 8-digit hexadecimal number preceded by '#',
-		it is interpreted as an explicit color value '#aarrggbb', with
-		one byte each for the alpha, red, green, and blue values.
-		Otherwise, 'color' is interpreted as a highlight group name,
+		When entering fullscreen, "color" defines the color of the part
+		of the screen that is not occupied by the Vim control,
+		including the "notch" area for MacBook laptops.
+		If "color" is a 6 or 8-digit hexadecimal number preceded by
+		'#', it is interpreted as an explicit color value '#rrggbb' /
+		'#aarrggbb', with one byte each for the alpha, red, green, and
+		blue values. The alpha value is ignored (use 'transparency'
+		instead for a translucent window).
+		Otherwise, "color" is interpreted as a highlight group name,
 		and the fullscreen background is filled with that highlight
 		group's background color, as defined by the current color
 		scheme.
+		If unset, the default value is black (#FF000000).
 
 	Examples:
 	Don't change size when entering fullscreen: >

--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -1188,7 +1188,7 @@ static struct specialkey
 - (void)setFullScreenBackgroundColor:(int)color
 {
     NSMutableData *data = [NSMutableData data];
-    color = MM_COLOR(color);
+    color = MM_COLOR_WITH_TRANSP(color,p_transp);
     [data appendBytes:&color length:sizeof(int)];
 
     [self queueMessage:SetFullScreenColorMsgID data:data];

--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -831,7 +831,7 @@ static void grid_free(Grid *grid) {
 
     // Function to draw all rows
     void (^drawAllRows)(void (^)(CGContextRef,CGRect,int)) = ^(void (^drawFunc)(CGContextRef,CGRect,int)){
-        for (size_t r = 0; r < grid.rows; r++) {
+        for (int r = 0; r < grid.rows; r++) {
             const CGRect rowRect = [self rectForRow:(int)r
                                              column:0
                                             numRows:1
@@ -1276,6 +1276,9 @@ static void grid_free(Grid *grid) {
         if (fh < 1.0f) fh = 1.0f;
 
         desiredRows = floor((size.height - ih)/fh);
+        // Sanity checking in case unusual window sizes lead to degenerate results
+        if (desiredRows < 1)
+            desiredRows = 1;
         desiredSize.height = fh*desiredRows + ih;
     }
 
@@ -1285,6 +1288,9 @@ static void grid_free(Grid *grid) {
         if (fw < 1.0f) fw = 1.0f;
 
         desiredCols = floor((size.width - iw)/fw);
+        // Sanity checking in case unusual window sizes lead to degenerate results
+        if (desiredCols < 1)
+            desiredCols = 1;
         desiredSize.width = fw*desiredCols + iw;
     }
 

--- a/src/MacVim/MMTextStorage.m
+++ b/src/MacVim/MMTextStorage.m
@@ -895,6 +895,9 @@ static NSString *MMWideCharacterAttributeName = @"MMWideChar";
         if (fh < 1.0f) fh = 1.0f;
 
         fitRows = floor(size.height/fh);
+        // Sanity checking in case unusual window sizes lead to degenerate results
+        if (fitRows < 1)
+            fitRows = 1;
         fitSize.height = fh*fitRows;
     }
 
@@ -903,6 +906,9 @@ static NSString *MMWideCharacterAttributeName = @"MMWideChar";
         if (fw < 1.0f) fw = 1.0f;
 
         fitCols = floor(size.width/fw);
+        // Sanity checking in case unusual window sizes lead to degenerate results
+        if (fitCols < 1)
+            fitCols = 1;
         fitSize.width = fw*fitCols;
     }
 

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -1129,7 +1129,7 @@ static BOOL isUnsafeMessage(int msgid);
         case SetFullScreenColorMsgID:
         {
             const int *bg = (const int*)[data bytes];
-            NSColor *color = [NSColor colorWithRgbInt:*bg];
+            NSColor *color = [NSColor colorWithArgbInt:*bg];
 
             [windowController setFullScreenBackgroundColor:color];
         }

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1307,9 +1307,7 @@
     // Calling setFrameSizeKeepGUISize: instead of setFrameSize: prevents a
     // degenerate case where frameSizeMayHaveChanged: ends up resizing the window
     // *again* causing windowDidResize: to be called.
-    if (fullScreenWindow == nil) {
-        [vimView setFrameSizeKeepGUISize:[self contentSize]];
-    } else {
+    if (fullScreenEnabled && fullScreenWindow != nil) {
         // Non-native full screen mode is more complicated and needs to
         // re-layout the Vim view to properly account for the menu bar / notch,
         // and misc fuopt configuration.
@@ -1317,6 +1315,9 @@
         NSRect desiredFrame = [fullScreenWindow getDesiredFrame];
         [vimView setFrameOrigin:desiredFrame.origin];
         [vimView setFrameSizeKeepGUISize:desiredFrame.size];
+    }
+    else {
+        [vimView setFrameSizeKeepGUISize:[self contentSize]];
     }
 }
 

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -699,25 +699,32 @@
         // window, so we need to set a transparency color here to make the
         // transparency show through.
         if ([back alphaComponent] == 1) {
-            // Here, any solid color would do, but setting it with "back" has an
-            // interesting effect where the title bar gets subtly tinted by it
-            // as well, so do that. (Note that this won't play well in <=10.12
-            // since we are using the deprecated
-            // NSWindowStyleMaskTexturedBackground which makes the titlebars
-            // transparent in those. Consider not using textured background.)
+            // The window's background color affects the title bar tint and
+            // if we are using a transparent title bar this color will show
+            // up as well.
+            // (Note that this won't play well in <=10.12 since we are using
+            // the deprecated NSWindowStyleMaskTexturedBackground which makes
+            // the titlebars transparent in those. Consider not using textured
+            // background.)
             [decoratedWindow setBackgroundColor:back];
+
+            // Note: We leave the full screen window's background color alone
+            // because it is affected by 'fuoptions' instead. We just change the
+            // alpha back to 1 in case it was changed previously because transparency
+            // was set.
             if (fullScreenWindow) {
-                [fullScreenWindow setBackgroundColor:back];
+                [fullScreenWindow setBackgroundColor:
+                 [fullScreenWindow.backgroundColor colorWithAlphaComponent:1]];
             }
         } else {
             // HACK! We really want a transparent background color to avoid
             // double blending the transparency, but setting alpha=0 leads to
             // the window border disappearing and also drag-to-resize becomes a
             // lot slower. So hack around it by making it virtually transparent.
-            NSColor *clearColor = [back colorWithAlphaComponent:0.001];
-            [decoratedWindow setBackgroundColor:clearColor];
+            [decoratedWindow setBackgroundColor:[back colorWithAlphaComponent:0.001]];
             if (fullScreenWindow) {
-                [fullScreenWindow setBackgroundColor:clearColor];
+                [fullScreenWindow setBackgroundColor:
+                 [fullScreenWindow.backgroundColor colorWithAlphaComponent:0.001]];
             }
         }
     }
@@ -1046,9 +1053,17 @@
     }
 }
 
+/// Called when the window is in non-native full-screen mode and the user has
+/// updated the background color.
 - (void)setFullScreenBackgroundColor:(NSColor *)back
 {
     if (fullScreenWindow)
+        // See setDefaultColorsBackground: for why set a transparent
+        // background color, and why 0.001 instead of 0.
+        if ([back alphaComponent] != 1) {
+            back = [back colorWithAlphaComponent:0.001];
+        }
+
         [fullScreenWindow setBackgroundColor:back];
 }
 

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -633,6 +633,14 @@ gui_mch_new_colors(void)
 
     ASLogDebug(@"back=%ld norm=%ld", gui.def_back_pixel, gui.def_norm_pixel);
 
+    // If using a highlight group for fullscreen background color we need to
+    // update the app when a new color scheme has been picked. This function
+    // technically wouldn't be called if a user manually set the relevant
+    // highlight group to another color but works in most use cases when they
+    // just change the color scheme.
+    if (fuoptions_flags & FUOPT_BGCOLOR_HLGROUP)
+        gui_mch_fuopt_update();
+
     [[MMBackend sharedInstance]
         setDefaultColorsBackground:gui.def_back_pixel
                         foreground:gui.def_norm_pixel];

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -4839,16 +4839,16 @@ check_fuoptions(void)
 		return FAIL;
 	    if (p[i] == '#')
 	    {
-		// explicit color (#aarrggbb)
+		// explicit color (#aarrggbb or #rrggbb)
 		i++;
 		for (j = i; j < i + 8 && vim_isxdigit(p[j]); ++j)
 		    ;
-		if (j < i + 8)
-		    return FAIL;    // less than 8 digits
+		if (j != (i + 8) && j != (i + 6))
+		    return FAIL; // has to be either 6 or 8 digits
 		if (p[j] != NUL && p[j] != ',')
 		    return FAIL;
 		new_fuoptions_bgcolor = 0;
-		for (k = 0; k < 8; ++k)
+		for (k = 0; k < (j - i); ++k)
 		    new_fuoptions_bgcolor = new_fuoptions_bgcolor * 16
 							   + hex2nr(p[i + k]);
 		i = j;


### PR DESCRIPTION
Fixed misc bugs:

- Previously, setting a colorscheme while in non-native full screen would override the background color specified in 'fuoptions' (default is black). It also wouldn't update the specified color if it's specified to a highlight group (e.g. `set fuopts=background:Normal`).

- Transparency and background colors and setting colorscheme also didn't work well togehter. Changing a background color while in fullscreen would reset transparency back to 0.

Also, 'fuoptions' can now specify background color in 6-digit hex number now, in addition to the old 8-digit format. Also update docs to elaborate that when using 8-digit, the alpha component is ignored (since we use the 'transparency' setting instead).

Add new tests to test 'fuoptions' work.

---

Also include the following commits:

## Fix non-native full screen bad interaction with window delegate

This issue was detected when adding new tests for non-native full screen. When setting 'fuoptions' to empty and going full screen, the code would fail but also crash, due to a number of issues:

1. `enterFullScreen`'s setting of presentationOptions somehow triggers a window resize on the normal window, which leads to `windowDidResize` delegate being called. This is a degenerate situation as the window controller thinks we are already in full screen even though we haven't finished setting up yet, and in particular `nonFuVimViewSize` is still 0. This leads to the desired desired frame size being set incorrectly to 0.
2. `constrainRows:columns:toSize` does not sanity check the results when we have such degenerate small sizes, and end up calculating a desired rows to -1, which makes no sense. This leads to various wrong calculations.
3. MMCoreTextView loops through the grid using a size_t even though grid.rows is an int. This is a poor code practice in general and results in a crash as the loop comparison cast the -1 to size_t and the loop didn't correctly terminate.

Fix 1 (the root cause) by making sure we detact the window delegate immediately when entering full screen to prevent any stray window messages from causing issues. Also safeguard `windowDidResize` so it only handles the full screen path if we have `fullScreenEnabled` set.

For 2 and 3, add the sanity checks and also fix the size_t to use int when looping.

For some reason this issue only showed up in CI but not in local testing, probably due to different screen environments.

## Add tests for full screen code

Also, add some additional tests for full screen mode in general.

Basic tests to validate different full screen functionalities. Help prevents regressions such as https://github.com/macvim-dev/macvim/issues/1515 where full screen simply stops working.

Not an exhaustive test for now. Some functionalities (e.g. multi-monitor, MacBook notch) are hard to mock up and validate in tests. Some other functionalities like restoring window size, delayed full screen on startup (when setting it from gvimrc) will be added later.