### PR TITLE
ci: Upload failed MacVim tests artifacts, misc improvements

### DIFF
--- a/.github/actions/test_macvim_artifacts/action.yml
+++ b/.github/actions/test_macvim_artifacts/action.yml
@@ -1,0 +1,26 @@
+# This is a clone of test_artifacts for MacVim-specific files
+name: 'test_macvim_artifacts'
+description: "Upload failed MacVim test artifacts"
+runs:
+  using: "composite"
+  steps:
+    - name: Upload failed tests
+      uses: actions/upload-artifact@v4
+      with:
+        # Name of the artifact to upload.
+        name: ${{ github.workflow }}-${{ github.job }}-${{ join(matrix.*, '-') }}-failed-macvim-tests
+
+        # A file, directory or wildcard pattern that describes what
+        # to upload.
+        path: |
+         /Users/runner/Library/Developer/Xcode/DerivedData/MacVim-*/Logs/Test/*.xcresult
+        # The desired behavior if no files are found using the
+        # provided path.
+        if-no-files-found: ignore
+
+        # Duration after which artifact will expire in days. 0 means
+        # using repository settings.
+        retention-days: 0
+
+        # If true, an artifact with a matching name will be deleted
+        overwrite: true

--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -207,6 +207,7 @@ jobs:
           else
             CONFOPT+=(
               --disable-sparkle       # Disable Sparkle for testing that this flag builds and works
+              --enable-nls=no --enable-libsodium=no # Disable gettext and libsodium unless we built them ourselves for publish
             )
           fi
           if ${{ matrix.legacy == true }}; then
@@ -353,6 +354,10 @@ jobs:
         timeout-minutes: 10
         run: |
           make ${MAKE_BUILD_ARGS} -C src macvim-tests
+
+      - name: Upload failed MacVim test results
+        if: ${{ !cancelled() && failure() }}
+        uses: ./.github/actions/test_macvim_artifacts
 
       - name: Build Vim test binaries
         run: |


### PR DESCRIPTION
Add MacVim test failure results to the list of failed artifacts to upload. The xcresult folder can be opened in Xcode for inspection to help understand what went wrong. Also, fix the ordering so failed Vim GUI test artifacts can be uploaded as well.

When configuring Vim, be explicit to not build with sodium/gettext for the non-publish builds. This makes sure that even if the CI environment somehow has them installed by default, we won't use them by mistake. Those installed packages would be built for a different OS target anyway and throw out warnings (the ones we bundle with MacVim are custom built to target the proper OS versions).