### PR TITLE
Refactor MacVim tests and add startup delayed full screen tests

### DIFF
--- a/src/MacVim/MMAppController.h
+++ b/src/MacVim/MMAppController.h
@@ -88,6 +88,7 @@
 - (void)refreshAllResizeConstraints;
 - (void)refreshAllTextViews;
 
+- (void)openNewWindow:(enum NewWindowMode)mode activate:(BOOL)activate extraArgs:(NSArray *)args;
 - (void)openNewWindow:(enum NewWindowMode)mode activate:(BOOL)activate;
 
 //


### PR DESCRIPTION
Add test suite utility functions to set/restore defaults, adding/tearing down a new Vim window, making temp files, wait for full screen transition. This helps simplify per-test code and prevent mistakes.

Add new tests for delayed full screen on startup. This happens when a vimrc/gvimrc sets 'fullscreen' on startup and MacVim has to delay entering full screen until the window has been presented. This incidentally regression tests a bug (fixed in #1521) where simply having 'set fuopt= fullscreen' in a gvimrc would cause MacVim to crash on startup due to bad interaction with window resize messages.