### PR TITLE
Fix full screen window restore / multi-screen / misc issues

### DIFF
--- a/src/MacVim/MMFullScreenWindow.h
+++ b/src/MacVim/MMFullScreenWindow.h
@@ -17,13 +17,9 @@
 @interface MMFullScreenWindow : NSWindow {
     NSWindow    *target;
     MMVimView   *view;
-    NSPoint     oldPosition;
     NSString    *oldTabBarStyle;
     int         options;
     int         state;
-
-    // These are only valid in full-screen mode and store pre-fu vim size 
-    int         nonFuRows, nonFuColumns;
 
     /// The non-full-screen size of the Vim view. Used for non-maxvert/maxhorz options.
     NSSize      nonFuVimViewSize;
@@ -32,6 +28,7 @@
     int         startFuFlags;
   
     // Controls the speed of the fade in and out.
+    // This feature is deprecated and off by default.
     double      fadeTime;
     double      fadeReservationTime;
 }


### PR DESCRIPTION
Native full-screen:

Fix restoring window when we don't have smooth resize setting set. The NSWindow has a contentResizeIncrement set and macOS seems to have a bug/quirk where it would ignore it when entering full screen, but on exit, it will use it to determine the final window size. This means it would restore the window to a slightly different and wrong size. From testing, seems like Apple's own Terminal just works around that by always resizing the window after existing full screen and other apps just have this subtle bug. For MacVim, we just fix it by temporarily removing the contentResizeIncrement while exiting full screen, which is a small hack but it works.

Non-native full screen:

Fix restoring window when we have smooth resize setting set. Previously we remember the number of lines/columns and manually resize to that on exit, but it could result in the restored window size being wrong. Just do the more sensible thing and simply keep the old window size and rescale the Vim view inside it. It simplifies the code and make everything works more intuitively, and it makes sure the old window size is respected. Long term goal is to keep MMFullScreenWindow as simple as possible the window controller whould be the one doing the more complicated integration work.

Also fix manually dragging a non-native full screen window across multiple screen (e.g in Mission Control) to work properly, and make sure the restored window is in the new screen.

Other improvements:
- Make sure the non-native full screen window has "movable" set to NO, and configure the window so it cannot go full screen. These make sure macOS would properly gray out the Window menu item for window tiling/full screen/etc. Previously the user could use those accidentally which leads to bad results.
- Remove the previous code that tried to make sure we restore the window the current Space (i.e. virtual desktop). macOS has no explicit control for Mission Control Spaces and the old method does not work and relies on a hacky way of configuring the collection method. This is a niche situation anyway. See code comments for details.

Tests
- In order to get the tests for this to pass in CI, I had to add a somewhat hacky solution to manually inject a user click to pretend we have clicked on the window to resize it. There is an obscure macOS quirk/bug where it seems to restore a full screen window to an old location that the user has manually interacted with but this bug only seems to happen in a VM and not a real machine. The workaround allows our tests to pass consistently regardless of where it is run.
