### PR TITLE
ci: Minor fix so that if gettext/libsodium is cached, don't warn

### DIFF
--- a/.github/actions/universal-package/action.yml
+++ b/.github/actions/universal-package/action.yml
@@ -72,8 +72,9 @@ runs:
         # which cause brew install to return non-zero and fail the build.
         export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
 
-        # This will be a no-op if formula was cached
-        brew install --quiet --formula -s ./${formula}.rb
+        # This will be a no-op if formula was cached. We check if the package
+        # exists first just to avoid an "already installed" warning.
+        brew list ${formula} &>/dev/null || brew install --quiet --formula -s ./${formula}.rb
 
         # If formula was cached, this step is necessary to relink it to brew prefix (e.g. /usr/local)
         brew unlink ${formula} && brew link ${formula}


### PR DESCRIPTION
Previously when we try to set up a cached package, Homebrew generates an annoying "already installed, it's just not linked" warning which is distracting when parsing CI logs. Just make sure to run `brew install` if we don't have the package cached.

Note that when a package is not cached and we have to rebuild it, Homebrew will still warn needlessly because we have HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK set. This is mostly ok because most of the time our packages should be cached in CI.