### PR TITLE
ci: Don't use guioptions-k in Vim tests, clean up defaults for gui tests

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -380,6 +380,7 @@ jobs:
       - name: Test Vim (GUI)
         timeout-minutes: 25
         run: |
+          defaults delete org.vim.MacVim  # Clean up stale states left from MacVim tests
           make ${MAKE_BUILD_ARGS} -C src/testdir clean
           make ${MAKE_BUILD_ARGS} -C src testgui
 

--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -58,6 +58,9 @@ if has('gui_running')
   if has('gui_gtk')
     " to keep screendump size unchanged
     set guifont=Monospace\ 10
+  elseif has('gui_macvim')
+    " keep defaults consistent with other GUIs
+    set guioptions-=k
   endif
   set columns=80 lines=25
 endif


### PR DESCRIPTION
This keeps it consistent with other Vim GUIs and prevent unintentional breakages, since we have enabled guioptions-k as default now in MacVim which isn't the case for other platforms.

Also, since MacVim tests are run before Vim GUI tests, there's a possibility that there are stale auto-saved states leftover that interferes with them. Usually they should not matter, but we clean them up anyway to make sure we have a consistent state to run tests from.