### PR TITLE
Fix code to be buildable on Xcode 8 again

### DIFF
--- a/src/MacVim/MMCoreTextView.h
+++ b/src/MacVim/MMCoreTextView.h
@@ -88,7 +88,9 @@ NS_ASSUME_NONNULL_BEGIN
 // NSFontChanging methods
 //
 - (void)changeFont:(nullable id)sender;
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
 - (NSFontPanelModeMask)validModesForFontPanel:(NSFontPanel *)fontPanel;
+#endif
 
 //
 // NSMenuItemValidation

--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -1355,6 +1355,7 @@ static void grid_free(Grid *grid) {
     }
 }
 
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
 - (NSFontPanelModeMask)validModesForFontPanel:(NSFontPanel *)fontPanel
 {
     // Lets the user pick only the font face / size, as other properties as not
@@ -1362,6 +1363,7 @@ static void grid_free(Grid *grid) {
     // Otherwise it could just be white text on white background in the preview.
     return NSFontPanelModesMaskStandardModes & (~NSFontPanelModeMaskAllEffects | NSFontPanelModeMaskTextColorEffect | NSFontPanelModeMaskDocumentColorEffect);
 }
+#endif
 
 /// Specifies whether the menu item should be enabled/disabled.
 - (BOOL)validateMenuItem:(NSMenuItem *)item

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -43,6 +43,9 @@
 #ifndef MAC_OS_X_VERSION_10_14
 # define MAC_OS_X_VERSION_10_14 101400
 #endif
+#ifndef MAC_OS_X_VERSION_10_15
+# define MAC_OS_X_VERSION_10_15 101500
+#endif
 #ifndef MAC_OS_VERSION_11_0
 # define MAC_OS_VERSION_11_0 110000
 #endif
@@ -55,12 +58,18 @@
 #ifndef MAC_OS_VERSION_14_0
 # define MAC_OS_VERSION_14_0 140000
 #endif
+#ifndef MAC_OS_VERSION_15_0
+# define MAC_OS_VERSION_15_0 150000
+#endif
 
 #ifndef NSAppKitVersionNumber10_10
 # define NSAppKitVersionNumber10_10 1343
 #endif
 #ifndef NSAppKitVersionNumber10_10_Max
 # define NSAppKitVersionNumber10_10_Max 1349
+#endif
+#ifndef NSAppKitVersionNumber10_11
+# define NSAppKitVersionNumber10_11 1404
 #endif
 #ifndef NSAppKitVersionNumber10_12
 # define NSAppKitVersionNumber10_12 1504
@@ -73,6 +82,9 @@
 #endif
 #ifndef NSAppKitVersionNumber10_14
 # define NSAppKitVersionNumber10_14 1671
+#endif
+#ifndef NSAppKitVersionNumber10_15
+# define NSAppKitVersionNumber10_15 1894
 #endif
 #ifndef NSAppKitVersionNumber11_0
 # define NSAppKitVersionNumber11_0 2022


### PR DESCRIPTION
We added code to rely on MAC_OS_X_VERSION_10_15, and therefore need to add stub for that to make it buildable on older Xcode versions. Use this opportunity to add the other missing ones to prevent future mistakes.