### PR TITLE
ci: Don't run both non-GUI/GUI Vim tests most of the time

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -68,16 +68,19 @@ jobs:
 
           - os: macos-13
             xcode: '15.2'
+            testgui: true
             extra: [vimtags, check-xcodeproj-compat]
 
           # Below runners use Apple Silicon.
           - os: macos-14
             xcode: '15.4'
+            testgui: false
             optimized: true
 
           # Most up to date OS and Xcode. Used to publish release for the main build.
           - os: macos-15
             xcode: '16.2'
+            testgui: true
             publish: true
             optimized: true
 
@@ -351,12 +354,13 @@ jobs:
           fi
 
       - name: Test MacVim
+        id: test_macvim
         timeout-minutes: 10
         run: |
           make ${MAKE_BUILD_ARGS} -C src macvim-tests
 
       - name: Upload failed MacVim test results
-        if: ${{ !cancelled() && failure() }}
+        if: ${{ !cancelled() && failure() && steps.test_macvim.conclusion == 'failure' }}
         uses: ./.github/actions/test_macvim_artifacts
 
       - name: Build Vim test binaries
@@ -370,19 +374,23 @@ jobs:
           make ${MAKE_BUILD_ARGS} -j${NPROC} -C src unittesttargets
 
       - name: Test Vim
+        if: startsWith(github.ref, 'refs/tags/') || !matrix.testgui
         timeout-minutes: 25
-        run: make ${MAKE_BUILD_ARGS} test
+        run: |
+          defaults delete org.vim.MacVim  # Clean up stale states
+          make ${MAKE_BUILD_ARGS} test
+
+      - name: Test Vim (GUI)
+        if: startsWith(github.ref, 'refs/tags/') || matrix.testgui
+        timeout-minutes: 25
+        run: |
+          defaults delete org.vim.MacVim  # Clean up stale states
+          make ${MAKE_BUILD_ARGS} -C src/testdir clean
+          make ${MAKE_BUILD_ARGS} -C src testgui
 
       - name: Upload failed test files
         if: ${{ !cancelled() && failure() }}
         uses: ./.github/actions/test_artifacts
-
-      - name: Test Vim (GUI)
-        timeout-minutes: 25
-        run: |
-          defaults delete org.vim.MacVim  # Clean up stale states left from MacVim tests
-          make ${MAKE_BUILD_ARGS} -C src/testdir clean
-          make ${MAKE_BUILD_ARGS} -C src testgui
 
       - name: Build MacVim dmg image
         if: matrix.publish && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')


### PR DESCRIPTION
Only run the full suite of Vim tests when doing a tagged release. Otherwise just either run GUI or non-GUI test on each platform. This should catch most regressions in Vim upstream functionality, as even a bad upstream merge should still exhibit the same issue in one of the other (and most MacVim pull requests do not touch Vim to begin with). This helps speeds up CI as currently it's quite time consuming to run Vim tests twice.

We still run the whole thing for a release for now just to catch any potential issues.