### PR TITLE
Support extra side mouse buttons in MacVim (X1 and X2)

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -1166,7 +1166,7 @@ Mouse clicks can be mapped.  The codes for mouse clicks are:
 
 The X1 and X2 buttons refer to the extra buttons found on some mice.  The
 'Microsoft Explorer' mouse has these buttons available to the right thumb.
-Currently X1 and X2 only work on Win32 and X11 environments.
+Currently X1 and X2 only work on MacVim, Win32, and X11 environments.
 
 Examples: >
 	:noremap <MiddleMouse> <LeftMouse><MiddleMouse>

--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -3793,9 +3793,9 @@ static unsigned eventModifierFlagsToVimMouseModMask(unsigned modifierFlags)
 
 static int eventButtonNumberToVimMouseButton(int buttonNumber)
 {
-    static int mouseButton[] = { MOUSE_LEFT, MOUSE_RIGHT, MOUSE_MIDDLE };
+    static int mouseButton[] = { MOUSE_LEFT, MOUSE_RIGHT, MOUSE_MIDDLE, MOUSE_X1, MOUSE_X2 };
 
-    return (buttonNumber >= 0 && buttonNumber < 3)
+    return (buttonNumber >= 0 && buttonNumber < 5)
             ? mouseButton[buttonNumber] : -1;
 }
 


### PR DESCRIPTION
This seems like a simple oversight. Adding this allows the user to map the extra side buttons on a mouse useful for navigation commands.