### PR TITLE
Make GUI tabs track Vim tabs in updates and animate correctly

### DIFF
--- a/src/MacVim/MMTabline/MMTab.h
+++ b/src/MacVim/MMTabline/MMTab.h
@@ -14,6 +14,7 @@ typedef enum : NSInteger {
 
 @interface MMTab : NSView
 
+@property (nonatomic, readwrite) NSInteger tag; ///< Unique identifier that caller can set for the tab
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, getter=isCloseButtonHidden) BOOL closeButtonHidden;
 @property (nonatomic) MMTabState state;

--- a/src/MacVim/MMTabline/MMTab.m
+++ b/src/MacVim/MMTabline/MMTab.m
@@ -20,6 +20,8 @@ typedef NSString * NSAnimatablePropertyKey;
     NSTextField *_titleLabel;
 }
 
+@synthesize tag = _tag;
+
 + (id)defaultAnimationForKey:(NSAnimatablePropertyKey)key
 {
     if ([key isEqualToString:@"fillColor"]) {

--- a/src/MacVim/MMTabline/MMTabline.h
+++ b/src/MacVim/MMTabline/MMTabline.h
@@ -10,7 +10,8 @@
 
 @interface MMTabline : NSView
 
-@property (nonatomic) NSInteger selectedTabIndex;
+/// The index of the selected tab. Can be -1 if nothing is selected.
+@property (nonatomic, readonly) NSInteger selectedTabIndex;
 @property (nonatomic) NSInteger optimumTabWidth;
 @property (nonatomic) NSInteger minimumTabWidth;
 @property (nonatomic) BOOL showsAddTabButton;
@@ -24,10 +25,31 @@
 @property (nonatomic, retain) NSColor *tablineFillFgColor;
 @property (nonatomic, weak) id <MMTablineDelegate> delegate;
 
+/// Add a tab at the end. It's not selected automatically.
 - (NSInteger)addTabAtEnd;
+/// Add a tab after the selected one. It's not selected automatically.
 - (NSInteger)addTabAfterSelectedTab;
+/// Add a tab at specified index. It's not selected automatically.
 - (NSInteger)addTabAtIndex:(NSInteger)index;
+
 - (void)closeTab:(MMTab *)tab force:(BOOL)force layoutImmediately:(BOOL)layoutImmediately;
+
+/// Batch update all the tabs using tab tags as unique IDs. Tab line will handle
+/// creating / removing tabs as necessary, and moving tabs to their new
+/// positions.
+///
+/// The tags array has to have unique items only, and each existing MMTab also
+/// has to have unique tags.
+///
+/// @param tags The list of unique tags that are cross-referenced with each
+///        MMTab's tag. Order within the array indicates the desired tab order.
+/// @param len The length of the tags array.
+/// @param delayTabResize If true, do not resize tab widths until the the tab
+///        line loses focus. This helps preserve the relative tab positions and
+///        lines up the close buttons to the previous tab. This will also
+///        prevent scrolling to the new selected tab.
+- (void)updateTabsByTags:(NSInteger *)tags len:(NSUInteger)len delayTabResize:(BOOL)delayTabResize;
+
 - (void)selectTabAtIndex:(NSInteger)index;
 - (MMTab *)tabAtIndex:(NSInteger)index;
 - (void)scrollTabToVisibleAtIndex:(NSInteger)index;

--- a/src/MacVim/MMVimView.h
+++ b/src/MacVim/MMVimView.h
@@ -20,8 +20,9 @@
 
 
 @interface MMVimView : NSView {
+    /// The tab that has been requested to be closed and waiting on Vim to respond
+    NSInteger           pendingCloseTabID;
     MMTabline           *tabline;
-    MMTab               *tabToClose;
     MMVimController     *vimController;
     MMTextView          *textView;
     NSMutableArray      *scrollbars;
@@ -44,8 +45,6 @@
 - (MMTabline *)tabline;
 - (IBAction)addNewTab:(id)sender;
 - (void)updateTabsWithData:(NSData *)data;
-- (void)selectTabWithIndex:(int)idx;
-- (MMTab *)addNewTab;
 
 - (void)createScrollbarWithIdentifier:(int32_t)ident type:(int)type;
 - (BOOL)destroyScrollbarWithIdentifier:(int32_t)ident;

--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -65,7 +65,6 @@
 - (BOOL)presentWindow:(id)unused;
 - (void)moveWindowAcrossScreens:(NSPoint)origin;
 - (void)updateTabsWithData:(NSData *)data;
-- (void)selectTabWithIndex:(int)idx;
 - (void)setTextDimensionsWithRows:(int)rows columns:(int)cols isLive:(BOOL)live
                       keepGUISize:(BOOL)keepGUISize
                      keepOnScreen:(BOOL)onScreen;

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -331,9 +331,6 @@
     // TODO: Remove this method?  Everything can probably be done in
     // presentWindow: but must carefully check dependencies on 'setupDone'
     // flag.
-
-    [vimView addNewTab];
-
     setupDone = YES;
 }
 
@@ -390,11 +387,6 @@
 - (void)updateTabsWithData:(NSData *)data
 {
     [vimView updateTabsWithData:data];
-}
-
-- (void)selectTabWithIndex:(int)idx
-{
-    [vimView selectTabWithIndex:idx];
 }
 
 - (void)setTextDimensionsWithRows:(int)rows columns:(int)cols isLive:(BOOL)live


### PR DESCRIPTION
MMTabline was introduced in #1120, which replaced the ancient PSMTabBarControl for representing Vim tabs. It uses animation to handle tab layouts, but it only worked in some situations, due to the Vim IPC API only sending a tabline update with all the tab labels with no way to track individual tabs. Update the API so that Vim now sends individual unique IDs in the update message as well to allow the GUI to track tabs over time and animate them. Vim does not interally have a concept of unique tab IDs, but we can use the pointer to the structure as such because they are allocated as a linked list and will never change.

Extend MMTabline to have a new `updateTabsByTags` API to batch update all tabs in one go, which will diff the new tags with existing tabs and create/remove/move tabs as necessary. The scrolling logic has also been moved inside it and it now only scrolls to selected tab when it has changed or moved. When deleting tabs we won't scroll as usually the user doesn't expect it. Dragging tabs also now work correctly when it is removed during a drag, or another tab has been selected.

This does mean the add/close tab APIs are currently unused, as the only entrypoint for modifying tabs from MacVim is currently only via `updateTabsByTags`.

After this, different Vim operations will now animate correctly, including `:tabmove`, `:bdelete` (which could remove multiple tabs at once), `:tabnew`, `:tabclose`.