### PR TITLE
MMTabline: Localize button strings

### DIFF
--- a/src/MacVim/MMTabline/MMTabline.m
+++ b/src/MacVim/MMTabline/MMTabline.m
@@ -21,7 +21,7 @@ static MMHoverButton* MakeHoverButton(MMTabline *tabline, MMHoverButtonImage ima
     button.action = action;
     button.continuous = continuous;
     [button sizeToFit];
-    [button setToolTip:NSLocalizedString(tooltip, @"Tabline button")];
+    [button setToolTip:tooltip];
     [tabline addSubview:button];
     return button;
 }
@@ -82,9 +82,9 @@ static BOOL isDarkMode(NSAppearance *appearance) {
         _scrollView.documentView = _tabsContainer;
         [self addSubview:_scrollView];
 
-        _addTabButton = MakeHoverButton(self, MMHoverButtonImageAddTab, @"New Tab (⌘T)", @selector(addTabAtEnd), NO);
-        _leftScrollButton = MakeHoverButton(self, MMHoverButtonImageScrollLeft, @"Scroll Tabs", @selector(scrollLeftOneTab), YES);
-        _rightScrollButton = MakeHoverButton(self, MMHoverButtonImageScrollRight, @"Scroll Tabs", @selector(scrollRightOneTab), YES);
+        _addTabButton = MakeHoverButton(self, MMHoverButtonImageAddTab, NSLocalizedString(@"create-new-tab-button", @"Create a new tab button"), @selector(addTabAtEnd), NO);
+        _leftScrollButton = MakeHoverButton(self, MMHoverButtonImageScrollLeft, NSLocalizedString(@"scroll-tabs-backward", @"Scroll backward button in tabs line"), @selector(scrollLeftOneTab), YES);
+        _rightScrollButton = MakeHoverButton(self, MMHoverButtonImageScrollRight, NSLocalizedString(@"scroll-tabs-forward", @"Scroll forward button in tabs line"), @selector(scrollRightOneTab), YES);
 
         [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[_leftScrollButton][_rightScrollButton]-5-[_scrollView]-5-[_addTabButton]" options:NSLayoutFormatAlignAllCenterY metrics:nil views:NSDictionaryOfVariableBindings(_scrollView, _leftScrollButton, _rightScrollButton, _addTabButton)]];
         [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_scrollView]|" options:0 metrics:nil views:@{@"_scrollView":_scrollView}]];

--- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
+++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		90290BB02D48649B00AA7489 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 90290BAE2D48649B00AA7489 /* Localizable.strings */; };
 		907FF7512521BCE200BADACB /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 907FF74F2521BCE200BADACB /* MainMenu.xib */; };
 		907FF7542521BDA600BADACB /* Preferences.xib in Resources */ = {isa = PBXBuildFile; fileRef = 907FF7522521BDA600BADACB /* Preferences.xib */; };
 		907FF7572521BDC300BADACB /* FindAndReplace.xib in Resources */ = {isa = PBXBuildFile; fileRef = 907FF7552521BDC200BADACB /* FindAndReplace.xib */; };
@@ -283,6 +284,28 @@
 		901C07182430C8CD00797C2A /* viminfo.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = viminfo.c; path = ../viminfo.c; sourceTree = "<group>"; };
 		901C07192430C8CD00797C2A /* filepath.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = filepath.c; path = ../filepath.c; sourceTree = "<group>"; };
 		901C071A2430C8CD00797C2A /* session.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = session.c; path = ../session.c; sourceTree = "<group>"; };
+		90290BAF2D48649B00AA7489 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB12D4864C200AA7489 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		90290BB22D486AC600AA7489 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB32D486AC600AA7489 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB42D486AC600AA7489 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		90290BB52D48743A00AA7489 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB62D48743A00AA7489 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB72D48743A00AA7489 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB82D48743A00AA7489 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB92D48743A00AA7489 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BBA2D48743A00AA7489 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BBB2D48743A00AA7489 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BBC2D48743A00AA7489 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		90290BBD2D48764E00AA7489 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BBE2D48764E00AA7489 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BBF2D48764E00AA7489 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BC02D48764E00AA7489 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BC12D48764E00AA7489 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		90290BC22D4878BF00AA7489 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BC32D4878BF00AA7489 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BC42D4878BF00AA7489 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BC52D4878BF00AA7489 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		907FF75A2521C09F00BADACB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/FindAndReplace.xib; sourceTree = "<group>"; };
 		907FF75B2521C09F00BADACB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/Preferences.xib; sourceTree = "<group>"; };
 		907FF75C2521C0A000BADACB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -441,6 +464,13 @@
 		90F84F312521F8760000268B /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		90F84F322521F87F0000268B /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		90F84F332521F8880000268B /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		925B55CD254B604A006B047E /* MMHoverButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMHoverButton.h; sourceTree = "<group>"; };
+		925B55D1254B604A006B047E /* MMHoverButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMHoverButton.m; sourceTree = "<group>"; };
+		925B55D6254B61AB006B047E /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		92C6F6E325587E1C007AE21E /* MMTab.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMTab.m; sourceTree = "<group>"; };
+		92C6F6E525587E1C007AE21E /* MMTabline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMTabline.m; sourceTree = "<group>"; };
+		92C6F6E625587E1C007AE21E /* MMTabline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMTabline.h; sourceTree = "<group>"; };
+		92C6F6E725587E1C007AE21E /* MMTab.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMTab.h; sourceTree = "<group>"; };
 		95241CE12573D587001E3711 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		95241CF025749CC6001E3711 /* vim9type.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = vim9type.c; path = ../vim9type.c; sourceTree = "<group>"; };
 		95241CF125749CC6001E3711 /* help.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = help.c; path = ../help.c; sourceTree = "<group>"; };
@@ -454,13 +484,6 @@
 		95241CF925749CC7001E3711 /* errors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = errors.h; path = ../errors.h; sourceTree = "<group>"; };
 		95241CFA25749CC7001E3711 /* textobject.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = textobject.c; path = ../textobject.c; sourceTree = "<group>"; };
 		95241CFB25749D4A001E3711 /* os_macosx.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = os_macosx.m; path = ../os_macosx.m; sourceTree = "<group>"; };
-		925B55CD254B604A006B047E /* MMHoverButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMHoverButton.h; sourceTree = "<group>"; };
-		925B55D1254B604A006B047E /* MMHoverButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMHoverButton.m; sourceTree = "<group>"; };
-		925B55D6254B61AB006B047E /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
-		92C6F6E325587E1C007AE21E /* MMTab.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMTab.m; sourceTree = "<group>"; };
-		92C6F6E525587E1C007AE21E /* MMTabline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMTabline.m; sourceTree = "<group>"; };
-		92C6F6E625587E1C007AE21E /* MMTabline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMTabline.h; sourceTree = "<group>"; };
-		92C6F6E725587E1C007AE21E /* MMTab.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMTab.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -635,6 +658,7 @@
 		29B97317FDCFA39411CA2CEA /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				90290BAE2D48649B00AA7489 /* Localizable.strings */,
 				1D384A0D100D671700D3C22F /* KeyBinding.plist */,
 				1D9C602E0EF79C0C0034AD44 /* MacVim.icns */,
 				0395A8A90D72D88B00881434 /* General.png */,
@@ -1036,6 +1060,7 @@
 				1DCD00C10E50B2B700460166 /* Cut.png in Resources */,
 				1DCD00C20E50B2B700460166 /* FindHelp.png in Resources */,
 				1DCD00C30E50B2B700460166 /* FindNext.png in Resources */,
+				90290BB02D48649B00AA7489 /* Localizable.strings in Resources */,
 				1DCD00C40E50B2B700460166 /* FindPrev.png in Resources */,
 				1DCD00C50E50B2B700460166 /* Help.png in Resources */,
 				1DCD00C60E50B2B700460166 /* LoadSesn.png in Resources */,
@@ -1257,6 +1282,35 @@
 				95241CE12573D587001E3711 /* en */,
 			);
 			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		90290BAE2D48649B00AA7489 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				90290BAF2D48649B00AA7489 /* en */,
+				90290BB12D4864C200AA7489 /* zh-Hant */,
+				90290BB22D486AC600AA7489 /* ja */,
+				90290BB32D486AC600AA7489 /* ko */,
+				90290BB42D486AC600AA7489 /* zh-Hans */,
+				90290BB52D48743A00AA7489 /* ca */,
+				90290BB62D48743A00AA7489 /* cs */,
+				90290BB72D48743A00AA7489 /* da */,
+				90290BB82D48743A00AA7489 /* de */,
+				90290BB92D48743A00AA7489 /* fi */,
+				90290BBA2D48743A00AA7489 /* fr */,
+				90290BBB2D48743A00AA7489 /* nl */,
+				90290BBC2D48743A00AA7489 /* pt-BR */,
+				90290BBD2D48764E00AA7489 /* hu */,
+				90290BBE2D48764E00AA7489 /* it */,
+				90290BBF2D48764E00AA7489 /* nb */,
+				90290BC02D48764E00AA7489 /* pl */,
+				90290BC12D48764E00AA7489 /* pt-PT */,
+				90290BC22D4878BF00AA7489 /* es */,
+				90290BC32D4878BF00AA7489 /* ru */,
+				90290BC42D4878BF00AA7489 /* sv */,
+				90290BC52D4878BF00AA7489 /* tr */,
+			);
+			name = Localizable.strings;
 			sourceTree = "<group>";
 		};
 		907FF74F2521BCE200BADACB /* MainMenu.xib */ = {

--- a/src/MacVim/MacVim_xcode8.xcodeproj/project.pbxproj
+++ b/src/MacVim/MacVim_xcode8.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		90290BB02D48649B00AA7489 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 90290BAE2D48649B00AA7489 /* Localizable.strings */; };
 		907FF7512521BCE200BADACB /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 907FF74F2521BCE200BADACB /* MainMenu.xib */; };
 		907FF7542521BDA600BADACB /* Preferences.xib in Resources */ = {isa = PBXBuildFile; fileRef = 907FF7522521BDA600BADACB /* Preferences.xib */; };
 		907FF7572521BDC300BADACB /* FindAndReplace.xib in Resources */ = {isa = PBXBuildFile; fileRef = 907FF7552521BDC200BADACB /* FindAndReplace.xib */; };
@@ -284,6 +285,28 @@
 		901C07182430C8CD00797C2A /* viminfo.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = viminfo.c; path = ../viminfo.c; sourceTree = "<group>"; };
 		901C07192430C8CD00797C2A /* filepath.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = filepath.c; path = ../filepath.c; sourceTree = "<group>"; };
 		901C071A2430C8CD00797C2A /* session.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = session.c; path = ../session.c; sourceTree = "<group>"; };
+		90290BAF2D48649B00AA7489 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB12D4864C200AA7489 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		90290BB22D486AC600AA7489 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB32D486AC600AA7489 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB42D486AC600AA7489 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		90290BB52D48743A00AA7489 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB62D48743A00AA7489 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB72D48743A00AA7489 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB82D48743A00AA7489 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BB92D48743A00AA7489 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BBA2D48743A00AA7489 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BBB2D48743A00AA7489 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BBC2D48743A00AA7489 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		90290BBD2D48764E00AA7489 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BBE2D48764E00AA7489 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BBF2D48764E00AA7489 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BC02D48764E00AA7489 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BC12D48764E00AA7489 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		90290BC22D4878BF00AA7489 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BC32D4878BF00AA7489 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BC42D4878BF00AA7489 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90290BC52D4878BF00AA7489 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		907FF75A2521C09F00BADACB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/FindAndReplace.xib; sourceTree = "<group>"; };
 		907FF75B2521C09F00BADACB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/Preferences.xib; sourceTree = "<group>"; };
 		907FF75C2521C0A000BADACB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -442,6 +465,13 @@
 		90F84F312521F8760000268B /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		90F84F322521F87F0000268B /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		90F84F332521F8880000268B /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		925B55CD254B604A006B047E /* MMHoverButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMHoverButton.h; sourceTree = "<group>"; };
+		925B55D1254B604A006B047E /* MMHoverButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMHoverButton.m; sourceTree = "<group>"; };
+		925B55D6254B61AB006B047E /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		92C6F6E325587E1C007AE21E /* MMTab.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMTab.m; sourceTree = "<group>"; };
+		92C6F6E525587E1C007AE21E /* MMTabline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMTabline.m; sourceTree = "<group>"; };
+		92C6F6E625587E1C007AE21E /* MMTabline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMTabline.h; sourceTree = "<group>"; };
+		92C6F6E725587E1C007AE21E /* MMTab.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMTab.h; sourceTree = "<group>"; };
 		95241CE12573D587001E3711 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		95241CF025749CC6001E3711 /* vim9type.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = vim9type.c; path = ../vim9type.c; sourceTree = "<group>"; };
 		95241CF125749CC6001E3711 /* help.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = help.c; path = ../help.c; sourceTree = "<group>"; };
@@ -455,13 +485,6 @@
 		95241CF925749CC7001E3711 /* errors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = errors.h; path = ../errors.h; sourceTree = "<group>"; };
 		95241CFA25749CC7001E3711 /* textobject.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = textobject.c; path = ../textobject.c; sourceTree = "<group>"; };
 		95241CFB25749D4A001E3711 /* os_macosx.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = os_macosx.m; path = ../os_macosx.m; sourceTree = "<group>"; };
-		925B55CD254B604A006B047E /* MMHoverButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMHoverButton.h; sourceTree = "<group>"; };
-		925B55D1254B604A006B047E /* MMHoverButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMHoverButton.m; sourceTree = "<group>"; };
-		925B55D6254B61AB006B047E /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
-		92C6F6E325587E1C007AE21E /* MMTab.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMTab.m; sourceTree = "<group>"; };
-		92C6F6E525587E1C007AE21E /* MMTabline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMTabline.m; sourceTree = "<group>"; };
-		92C6F6E625587E1C007AE21E /* MMTabline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMTabline.h; sourceTree = "<group>"; };
-		92C6F6E725587E1C007AE21E /* MMTab.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMTab.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -636,6 +659,7 @@
 		29B97317FDCFA39411CA2CEA /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				90290BAE2D48649B00AA7489 /* Localizable.strings */,
 				1D384A0D100D671700D3C22F /* KeyBinding.plist */,
 				1D9C602E0EF79C0C0034AD44 /* MacVim.icns */,
 				0395A8A90D72D88B00881434 /* General.png */,
@@ -1037,6 +1061,7 @@
 				1DCD00C10E50B2B700460166 /* Cut.png in Resources */,
 				1DCD00C20E50B2B700460166 /* FindHelp.png in Resources */,
 				1DCD00C30E50B2B700460166 /* FindNext.png in Resources */,
+				90290BB02D48649B00AA7489 /* Localizable.strings in Resources */,
 				1DCD00C40E50B2B700460166 /* FindPrev.png in Resources */,
 				1DCD00C50E50B2B700460166 /* Help.png in Resources */,
 				1DCD00C60E50B2B700460166 /* LoadSesn.png in Resources */,
@@ -1258,6 +1283,35 @@
 				95241CE12573D587001E3711 /* en */,
 			);
 			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		90290BAE2D48649B00AA7489 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				90290BAF2D48649B00AA7489 /* en */,
+				90290BB12D4864C200AA7489 /* zh-Hant */,
+				90290BB22D486AC600AA7489 /* ja */,
+				90290BB32D486AC600AA7489 /* ko */,
+				90290BB42D486AC600AA7489 /* zh-Hans */,
+				90290BB52D48743A00AA7489 /* ca */,
+				90290BB62D48743A00AA7489 /* cs */,
+				90290BB72D48743A00AA7489 /* da */,
+				90290BB82D48743A00AA7489 /* de */,
+				90290BB92D48743A00AA7489 /* fi */,
+				90290BBA2D48743A00AA7489 /* fr */,
+				90290BBB2D48743A00AA7489 /* nl */,
+				90290BBC2D48743A00AA7489 /* pt-BR */,
+				90290BBD2D48764E00AA7489 /* hu */,
+				90290BBE2D48764E00AA7489 /* it */,
+				90290BBF2D48764E00AA7489 /* nb */,
+				90290BC02D48764E00AA7489 /* pl */,
+				90290BC12D48764E00AA7489 /* pt-PT */,
+				90290BC22D4878BF00AA7489 /* es */,
+				90290BC32D4878BF00AA7489 /* ru */,
+				90290BC42D4878BF00AA7489 /* sv */,
+				90290BC52D4878BF00AA7489 /* tr */,
+			);
+			name = Localizable.strings;
 			sourceTree = "<group>";
 		};
 		907FF74F2521BCE200BADACB /* MainMenu.xib */ = {

--- a/src/MacVim/ca.lproj/Localizable.strings
+++ b/src/MacVim/ca.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Desplaça cap enrere";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Desplaça cap endavant";
+
+// The strings below were generated from Apple localization glossaries (Catalan).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Crear una pestanya nova";

--- a/src/MacVim/cs.lproj/Localizable.strings
+++ b/src/MacVim/cs.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Posunout dozadu";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Posunout dopředu";
+
+// The strings below were generated from Apple localization glossaries (Czech).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Vytvoří nový panel";

--- a/src/MacVim/da.lproj/Localizable.strings
+++ b/src/MacVim/da.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Scroll baglæns";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Scroll forlæns";
+
+// The strings below were generated from Apple localization glossaries (Danish).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Opret en ny fane";

--- a/src/MacVim/de.lproj/Localizable.strings
+++ b/src/MacVim/de.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Zurück scrollen";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Nach vorn scrollen";
+
+// The strings below were generated from Apple localization glossaries (German).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Neuen Tab erstellen";

--- a/src/MacVim/en.lproj/Localizable.strings
+++ b/src/MacVim/en.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+﻿/* Create a new tab button */
+"create-new-tab-button" = "Create a new tab";
+
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Scroll backwards";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Scroll forwards";
+

--- a/src/MacVim/es.lproj/Localizable.strings
+++ b/src/MacVim/es.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Desplazarse hacia atrás";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Desplazarse hacia adelante";
+
+// The strings below were generated from Apple localization glossaries (Spanish).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Crear una pestaña nueva";

--- a/src/MacVim/fi.lproj/Localizable.strings
+++ b/src/MacVim/fi.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Vieritä taaksepäin";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Vieritä eteenpäin";
+
+// The strings below were generated from Apple localization glossaries (Finnish).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Luo uusi välilehti";

--- a/src/MacVim/fr.lproj/Localizable.strings
+++ b/src/MacVim/fr.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Faire défiler vers l’arrière";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Faire défiler vers l’avant";
+
+// The strings below were generated from Apple localization glossaries (Universal French).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Créer un nouvel onglet";

--- a/src/MacVim/hu.lproj/Localizable.strings
+++ b/src/MacVim/hu.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Görgetés visszafelé";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Görgetés előrefelé";
+
+// The strings below were generated from Apple localization glossaries (Hungarian).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Új lap létrehozása";

--- a/src/MacVim/it.lproj/Localizable.strings
+++ b/src/MacVim/it.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Scorri indietro";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Scorri avanti";
+
+// The strings below were generated from Apple localization glossaries (Italian).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Crea un nuovo pannello";

--- a/src/MacVim/ja.lproj/Localizable.strings
+++ b/src/MacVim/ja.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "スクロールして戻ります";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "スクロールして進みます";
+
+// The strings below were generated from Apple localization glossaries (Japanese).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "新しいタブを開きます";

--- a/src/MacVim/ko.lproj/Localizable.strings
+++ b/src/MacVim/ko.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "뒤로 스크롤";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "앞으로 스크롤";
+
+// The strings below were generated from Apple localization glossaries (Korean).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "새로운 탭을 생성합니다";

--- a/src/MacVim/nb.lproj/Localizable.strings
+++ b/src/MacVim/nb.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Rull bakover";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Rull fremover";
+
+// The strings below were generated from Apple localization glossaries (Norwegian).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Opprett ny fane";

--- a/src/MacVim/nl.lproj/Localizable.strings
+++ b/src/MacVim/nl.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Terug scrollen";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Vooruit scrollen";
+
+// The strings below were generated from Apple localization glossaries (Dutch).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Maak een nieuw tabblad aan";

--- a/src/MacVim/pl.lproj/Localizable.strings
+++ b/src/MacVim/pl.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Przewiń do tyłu";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Przewiń do przodu";
+
+// The strings below were generated from Apple localization glossaries (Polish).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Pozwala utworzyć nową kartę.";

--- a/src/MacVim/pt-BR.lproj/Localizable.strings
+++ b/src/MacVim/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Deslizar para trás";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Deslizar para frente";
+
+// The strings below were generated from Apple localization glossaries (Brazilian).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Cria uma nova aba";

--- a/src/MacVim/pt-PT.lproj/Localizable.strings
+++ b/src/MacVim/pt-PT.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Deslocar para trás";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Deslocar para a frente";
+
+// The strings below were generated from Apple localization glossaries (Portuguese).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Criar um novo separador.";

--- a/src/MacVim/ru.lproj/Localizable.strings
+++ b/src/MacVim/ru.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Прокрутить назад";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Прокрутить вперёд";
+
+// The strings below were generated from Apple localization glossaries (Russian).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Создать новую вкладку";

--- a/src/MacVim/sv.lproj/Localizable.strings
+++ b/src/MacVim/sv.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Bläddra bakåt";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "Bläddra framåt";
+
+// The strings below were generated from Apple localization glossaries (Swedish).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Skapa en ny flik";

--- a/src/MacVim/tr.lproj/Localizable.strings
+++ b/src/MacVim/tr.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "Geri kaydır";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "İleri kaydır";
+
+// The strings below were generated from Apple localization glossaries (Turkish).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "Yeni bir sekme yarat";

--- a/src/MacVim/zh-Hans.lproj/Localizable.strings
+++ b/src/MacVim/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "往回滚动";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "向前滚动";
+
+// The strings below were generated from Apple localization glossaries (Simplified Chinese).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "创建新标签页";

--- a/src/MacVim/zh-Hant.lproj/Localizable.strings
+++ b/src/MacVim/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,13 @@
+
+
+/* Scroll backward button in tabs line */
+"scroll-tabs-backward" = "向後捲動";
+
+/* Scroll forward button in tabs line */
+"scroll-tabs-forward" = "向前捲動";
+
+// The strings below were generated from Apple localization glossaries (Traditional Chinese).
+// See extract-specific-localised-strings.swift for details.
+// Do no modify directly!
+
+"create-new-tab-button" = "新增標籤頁";


### PR DESCRIPTION
Use Apple Glossary for the new tab button translations. For the scroll backward/forward buttons I took it from Firefox
(https://pontoon.mozilla.org/) under the arrowscrollbox strings.