### PR TITLE
MMTabline: Add Vim colorscheme / window use tab fill color support

### DIFF
--- a/runtime/doc/gui_mac.txt
+++ b/runtime/doc/gui_mac.txt
@@ -310,11 +310,6 @@ KEY				VALUE ~
 *MMScrollOneDirectionOnly*	scroll along one axis only when using trackpad [bool]
 *MMSmoothResize*		allow smooth resizing of MacVim window [bool]
 *MMShareFindPboard*		share search text to Find Pasteboard [bool]
-*MMShowAddTabButton*		enable "add tab" button on tabline [bool]
-*MMShowTabScrollButtons*	enable tab scroll buttons on tabline [bool]
-*MMTabMinWidth*			minimum width of a tab [int]
-*MMTabOptimumWidth*		default width of a tab [int]
-*MMDefaultTablineColors*	use default colors instead of colorscheme for tabs [bool]
 *MMTextInsetBottom*		text area offset in pixels [int]
 *MMTextInsetLeft*		text area offset in pixels [int]
 *MMTextInsetRight*		text area offset in pixels [int]
@@ -326,6 +321,14 @@ KEY				VALUE ~
 *MMZoomBoth*			zoom button maximizes both directions [bool]
 *MMUpdaterPrereleaseChannel*	opt-in to pre-release software update [bool]
 *MMShowWhatsNewOnStartup*	show "What's New" after updating to new version [bool]
+
+Tabs ~
+*MMTabColorsMode*		use default/auto/colorscheme for tab colors [int]
+*MMWindowUseTabBackgroundColor*	use tabs background fill color as window color [bool]
+*MMShowAddTabButton*		enable "add tab" button on tabline [bool]
+*MMShowTabScrollButtons*	enable tab scroll buttons on tabline [bool]
+*MMTabMinWidth*			minimum width of a tab [int]
+*MMTabOptimumWidth*		default width of a tab [int]
 
 As an example, if you have more than one mouse button and would wish to free
 up Ctrl-click so you can bind it to something else, then the appropriate

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5645,7 +5645,6 @@ MMAllowForceClickLookUp	gui_mac.txt	/*MMAllowForceClickLookUp*
 MMAppearanceModeSelection	gui_mac.txt	/*MMAppearanceModeSelection*
 MMCellWidthMultiplier	gui_mac.txt	/*MMCellWidthMultiplier*
 MMCmdLineAlignBottom	gui_mac.txt	/*MMCmdLineAlignBottom*
-MMDefaultTablineColors	gui_mac.txt	/*MMDefaultTablineColors*
 MMDialogsTrackPwd	gui_mac.txt	/*MMDialogsTrackPwd*
 MMDisableLaunchAnimation	gui_mac.txt	/*MMDisableLaunchAnimation*
 MMDisableTablineAnimation	gui_mac.txt	/*MMDisableTablineAnimation*
@@ -5666,6 +5665,7 @@ MMShowAddTabButton	gui_mac.txt	/*MMShowAddTabButton*
 MMShowTabScrollButtons	gui_mac.txt	/*MMShowTabScrollButtons*
 MMShowWhatsNewOnStartup	gui_mac.txt	/*MMShowWhatsNewOnStartup*
 MMSmoothResize	gui_mac.txt	/*MMSmoothResize*
+MMTabColorsMode	gui_mac.txt	/*MMTabColorsMode*
 MMTabMinWidth	gui_mac.txt	/*MMTabMinWidth*
 MMTabOptimumWidth	gui_mac.txt	/*MMTabOptimumWidth*
 MMTextInsetBottom	gui_mac.txt	/*MMTextInsetBottom*
@@ -5678,6 +5678,7 @@ MMTranslateCtrlClick	gui_mac.txt	/*MMTranslateCtrlClick*
 MMUpdaterPrereleaseChannel	gui_mac.txt	/*MMUpdaterPrereleaseChannel*
 MMUseMouseTime	gui_mac.txt	/*MMUseMouseTime*
 MMVerticalSplit	gui_mac.txt	/*MMVerticalSplit*
+MMWindowUseTabBackgroundColor	gui_mac.txt	/*MMWindowUseTabBackgroundColor*
 MMZoomBoth	gui_mac.txt	/*MMZoomBoth*
 MS-DOS	os_msdos.txt	/*MS-DOS*
 MS-Windows	os_win32.txt	/*MS-Windows*

--- a/src/MacVim/Base.lproj/Preferences.xib
+++ b/src/MacVim/Base.lproj/Preferences.xib
@@ -280,11 +280,11 @@
             <point key="canvasLocation" x="137.5" y="-17"/>
         </customView>
         <customView id="hr4-G4-3ZG" userLabel="Appearance">
-            <rect key="frame" x="0.0" y="0.0" width="483" height="405"/>
+            <rect key="frame" x="0.0" y="0.0" width="483" height="447"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <customView id="fw0-VK-Nbz" userLabel="Dark mode selection">
-                    <rect key="frame" x="19" y="227" width="433" height="156"/>
+                    <rect key="frame" x="19" y="269" width="433" height="156"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="T40-Os-PUf" userLabel="Dark mode selection">
@@ -345,11 +345,11 @@
                     </subviews>
                 </customView>
                 <customView id="7af-iK-4r7" userLabel="Titlebar appearance">
-                    <rect key="frame" x="19" y="144" width="433" height="75"/>
+                    <rect key="frame" x="19" y="169" width="433" height="92"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="9Rk-gT-kVC" userLabel="Titlebar appearance">
-                            <rect key="frame" x="-2" y="57" width="187" height="17"/>
+                            <rect key="frame" x="-2" y="74" width="187" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Window appearance:" id="HEH-Lo-v4I" userLabel="Titlebar appearance:">
                                 <font key="font" metaFont="system"/>
@@ -358,7 +358,7 @@
                             </textFieldCell>
                         </textField>
                         <button id="7ie-0J-0Zr">
-                            <rect key="frame" x="189" y="56" width="244" height="18"/>
+                            <rect key="frame" x="189" y="73" width="244" height="18"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                             <buttonCell key="cell" type="check" title="Transparent title bar" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="hzd-hj-Pth">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -369,8 +369,21 @@
                                 <binding destination="58" name="value" keyPath="values.MMTitlebarAppearsTransparent" id="pQP-eb-JXS"/>
                             </connections>
                         </button>
+                        <button id="W5G-Qq-B7Z">
+                            <rect key="frame" x="189" y="55" width="190" height="18"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <string key="toolTip">Use tab bar's background color for the window title bar color as well. This creates a seamless pane when transparent title bar is also set.</string>
+                            <buttonCell key="cell" type="check" title="Use tabs background color" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="om2-70-baY">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="tabsPropertiesChanged:" target="-1" id="D9I-8s-GXi"/>
+                                <binding destination="58" name="value" keyPath="values.MMWindowUseTabBackgroundColor" id="8yg-KT-59b"/>
+                            </connections>
+                        </button>
                         <button id="Hqh-Ql-2od">
-                            <rect key="frame" x="189" y="38" width="244" height="18"/>
+                            <rect key="frame" x="189" y="37" width="244" height="18"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                             <buttonCell key="cell" type="check" title="Hidden title bar" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="W40-cB-m1U">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -394,7 +407,7 @@
                             </connections>
                         </button>
                         <button id="s2M-pj-U8e">
-                            <rect key="frame" x="189" y="-1" width="244" height="18"/>
+                            <rect key="frame" x="189" y="1" width="244" height="18"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                             <buttonCell key="cell" type="check" title="No drop shadows" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="VM8-tg-mVV">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -408,9 +421,39 @@
                     </subviews>
                 </customView>
                 <customView id="C3B-cu-RC2" userLabel="Tabs">
-                    <rect key="frame" x="20" y="118" width="432" height="18"/>
+                    <rect key="frame" x="20" y="118" width="432" height="43"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
+                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="qMc-Md-UwA" userLabel="Tabs">
+                            <rect key="frame" x="-2" y="25" width="187" height="17"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Tabs:" id="iUO-3c-iff" userLabel="Tabs:">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <popUpButton verticalHuggingPriority="750" id="Ncf-jw-6ZJ" userLabel="Tab colors">
+                            <rect key="frame" x="188" y="18" width="248" height="26"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <popUpButtonCell key="cell" type="push" title="Default colors" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="OhI-Q1-7PP" id="GVe-19-lXP" userLabel="Tab colors">
+                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="message"/>
+                                <menu key="menu" title="OtherViews" id="VE4-hh-it9">
+                                    <items>
+                                        <menuItem title="Default colors" state="on" toolTip="Use default tab colors based on macOS light / dark modes." id="OhI-Q1-7PP" userLabel="Default Colors"/>
+                                        <menuItem title="Automatic colors" toolTip="Automatically pick matching colors based on the current Vim foreground/background colors." id="CPh-w1-24K"/>
+                                        <menuItem title="Use Vim colorscheme" id="Nqs-aD-DWs" userLabel="Use Vim colorscheme">
+                                            <string key="toolTip">Use tab colors from Vim's colorscheme, using TabLine/TabLineSel/TabLineFill highlight groups. Some colorschemes will work better than others under this setting.</string>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </popUpButtonCell>
+                            <connections>
+                                <action selector="tabsPropertiesChanged:" target="-1" id="zcR-FW-4Ui"/>
+                                <binding destination="58" name="selectedIndex" keyPath="values.MMTabColorsMode" id="LCa-Uo-szO"/>
+                            </connections>
+                        </popUpButton>
                         <button id="rCZ-9B-5RL">
                             <rect key="frame" x="189" y="-1" width="244" height="18"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
@@ -423,15 +466,6 @@
                                 <binding destination="58" name="value" keyPath="values.MMShowTabScrollButtons" id="KHi-zu-Jz2"/>
                             </connections>
                         </button>
-                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="qMc-Md-UwA" userLabel="Tabs">
-                            <rect key="frame" x="-2" y="0.0" width="187" height="17"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Tabs:" id="iUO-3c-iff" userLabel="Tabs:">
-                                <font key="font" metaFont="system"/>
-                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
                     </subviews>
                 </customView>
                 <customView id="BpJ-rH-ona" userLabel="Full Screen">
@@ -535,7 +569,7 @@
                     </subviews>
                 </customView>
             </subviews>
-            <point key="canvasLocation" x="137.5" y="457.5"/>
+            <point key="canvasLocation" x="137.5" y="478.5"/>
         </customView>
         <customView id="Bnq-Nx-GJH" userLabel="Input">
             <rect key="frame" x="0.0" y="0.0" width="483" height="110"/>
@@ -622,7 +656,7 @@
                     </subviews>
                 </customView>
             </subviews>
-            <point key="canvasLocation" x="138" y="775"/>
+            <point key="canvasLocation" x="138" y="913"/>
         </customView>
         <customView id="620" userLabel="Advanced">
             <rect key="frame" x="0.0" y="0.0" width="483" height="367"/>

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -178,6 +178,9 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
         [NSNumber numberWithInt:210],     MMTabOptimumWidthKey,
         [NSNumber numberWithBool:YES],    MMShowAddTabButtonKey,
         [NSNumber numberWithBool:NO],     MMShowTabScrollButtonsKey,
+        [NSNumber numberWithInt:MMTabColorsModeAutomatic],
+                                          MMTabColorsModeKey,
+        [NSNumber numberWithBool:NO],     MMWindowUseTabBackgroundColorKey,
         [NSNumber numberWithInt:2],       MMTextInsetLeftKey,
         [NSNumber numberWithInt:1],       MMTextInsetRightKey,
         [NSNumber numberWithInt:1],       MMTextInsetTopKey,
@@ -1238,7 +1241,7 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 - (void)refreshAllTabProperties
 {
     for (MMVimController *vc in vimControllers) {
-        [vc.windowController.vimView refreshTabProperties];
+        [vc.windowController refreshTabProperties];
     }
 }
 

--- a/src/MacVim/MMBackend.h
+++ b/src/MacVim/MMBackend.h
@@ -62,6 +62,7 @@
 - (void)setBackgroundColor:(int)color;
 - (void)setForegroundColor:(int)color;
 - (void)setSpecialColor:(int)color;
+- (void)setTablineColors:(int[6])colors;
 - (void)setDefaultColorsBackground:(int)bg foreground:(int)fg;
 - (NSConnection *)connection;
 - (NSDictionary *)actionDict;

--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -293,6 +293,17 @@ static struct specialkey
     specialColor = MM_COLOR(color);
 }
 
+- (void)setTablineColors:(int[6])colors
+{
+    unsigned tabColors[6];
+    for (int i = 0; i < 6; i++) {
+        tabColors[i] = MM_COLOR(colors[i]);
+    }
+    NSMutableData *data = [NSMutableData data];
+    [data appendBytes:&tabColors length:sizeof(tabColors)];
+    [self queueMessage:SetTablineColorsMsgID data:data];
+}
+
 - (void)setDefaultColorsBackground:(int)bg foreground:(int)fg
 {
     defaultBackgroundColor = MM_COLOR_WITH_TRANSP(bg,p_transp);

--- a/src/MacVim/MMTabline/MMTab.m
+++ b/src/MacVim/MMTabline/MMTab.m
@@ -3,9 +3,10 @@
 #import "MMTabline.h"
 #import "MMHoverButton.h"
 
-#import "MacVim.h" // for availability macros
+// Only imported for AVAILABLE_MAC_OS
+#import "MacVim.h"
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_13
+#if !defined(MAC_OS_X_VERSION_10_13) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_13
 typedef NSString * NSAnimatablePropertyKey;
 #endif
 
@@ -46,7 +47,7 @@ typedef NSString * NSAnimatablePropertyKey;
         [self addSubview:_closeButton];
 
         _titleLabel = [NSTextField new];
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11
+#if defined(MAC_OS_X_VERSION_10_11) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11
         if (AVAILABLE_MAC_OS(10,11)) {
             _titleLabel.font = [NSFont systemFontOfSize:NSFont.smallSystemFontSize weight:NSFontWeightSemibold];
         } else
@@ -109,27 +110,29 @@ typedef NSString * NSAnimatablePropertyKey;
 
 - (void)setState:(MMTabState)state
 {
+    const BOOL hasFocus = (self.window == nil) || [self.window isKeyWindow];
+
     // Transitions to and from MMTabStateSelected
     // DO NOT animate so that UX feels snappier.
     if (state == MMTabStateSelected) {
         _closeButton.fgColor = _tabline.tablineSelFgColor;
-        _titleLabel.textColor = _tabline.tablineSelFgColor;
+        _titleLabel.textColor = hasFocus ? _tabline.tablineSelFgColor : _tabline.tablineUnfocusedSelFgColor;
         self.fillColor = _tabline.tablineSelBgColor;
     }
     else if (state == MMTabStateUnselected) {
         if (_state == MMTabStateSelected) {
             _closeButton.fgColor = _tabline.tablineFgColor;
-            _titleLabel.textColor = _tabline.tablineFgColor;
+            _titleLabel.textColor = hasFocus ? _tabline.tablineFgColor : _tabline.tablineUnfocusedFgColor;
             self.fillColor = _tabline.tablineBgColor;
         } else {
             _closeButton.animator.fgColor = _tabline.tablineFgColor;
-            _titleLabel.animator.textColor = _tabline.tablineFgColor;
+            _titleLabel.animator.textColor = hasFocus ? _tabline.tablineFgColor : _tabline.tablineUnfocusedFgColor;
             self.animator.fillColor = _tabline.tablineBgColor;
         }
     }
     else { // state == MMTabStateUnselectedHover
         _closeButton.animator.fgColor = _tabline.tablineSelFgColor;
-        _titleLabel.animator.textColor = _tabline.tablineSelFgColor;
+        _titleLabel.animator.textColor = hasFocus ? _tabline.tablineSelFgColor : _tabline.tablineUnfocusedSelFgColor;
         self.animator.fillColor = self.unselectedHoverColor;
     }
     _state = state;
@@ -164,6 +167,11 @@ typedef NSString * NSAnimatablePropertyKey;
         [p transformUsingAffineTransform:transform];
     }
     [p fill];
+    NSColor *strokeColor = _tabline.tablineStrokeColor;
+    if (strokeColor != nil) {
+        [strokeColor set];
+        [p stroke];
+    }
 }
 
 @end

--- a/src/MacVim/MMTabline/MMTabline.h
+++ b/src/MacVim/MMTabline/MMTabline.h
@@ -19,11 +19,18 @@
 @property (nonatomic) BOOL useAnimation;
 @property (nonatomic, readonly) NSInteger numberOfTabs;
 @property (nonatomic, retain, readonly) MMHoverButton *addTabButton;
+
 @property (nonatomic, retain) NSColor *tablineBgColor;
 @property (nonatomic, retain) NSColor *tablineFgColor;
 @property (nonatomic, retain) NSColor *tablineSelBgColor;
 @property (nonatomic, retain) NSColor *tablineSelFgColor;
 @property (nonatomic, retain) NSColor *tablineFillFgColor;
+
+// Derived colors that cannot be set directly
+@property (nonatomic, readonly) NSColor *tablineUnfocusedFgColor;
+@property (nonatomic, readonly) NSColor *tablineUnfocusedSelFgColor;
+@property (nonatomic, readonly) NSColor *tablineStrokeColor;
+
 @property (nonatomic, weak) id <MMTablineDelegate> delegate;
 
 /// Add a tab at the end. It's not selected automatically.
@@ -57,7 +64,16 @@
 - (void)scrollTabToVisibleAtIndex:(NSInteger)index;
 - (void)scrollBackwardOneTab;
 - (void)scrollForwardOneTab;
-- (void)setTablineSelBackground:(NSColor *)back foreground:(NSColor *)fore;
+
+/// Sets the colors used by this tab bar explicitly. Pass nil to use default
+/// colors based on the system light/dark modes.
+- (void)setColorsTabBg:(NSColor *)tabBg tabFg:(NSColor *)tabFg
+                 selBg:(NSColor *)selBg selFg:(NSColor *)selFg
+                  fill:(NSColor *)fill;
+
+/// Lets the tabline calculate best colors to use based on background and
+/// foreground colors of the selected tab. The colors cannot be nil.
+- (void)setAutoColorsSelBg:(NSColor *)back fg:(NSColor *)fore;
 
 @end
 

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -968,6 +968,26 @@ static BOOL isUnsafeMessage(int msgid);
             }
         }
         break;
+        case SetTablineColorsMsgID:
+        {
+            const void *bytes = [data bytes];
+            unsigned argbTabBg = *((unsigned*)bytes);  bytes += sizeof(unsigned);
+            unsigned argbTabFg = *((unsigned*)bytes);  bytes += sizeof(unsigned);
+            unsigned argbFillBg = *((unsigned*)bytes);  bytes += sizeof(unsigned);
+            unsigned argbFillFg = *((unsigned*)bytes);  bytes += sizeof(unsigned);
+            unsigned argbSelBg = *((unsigned*)bytes);  bytes += sizeof(unsigned);
+            unsigned argbSelFg = *((unsigned*)bytes);  bytes += sizeof(unsigned);
+
+            NSColor *tabBg = [NSColor colorWithRgbInt:argbTabBg];
+            NSColor *tabFg = [NSColor colorWithRgbInt:argbTabFg];
+            NSColor *fillBg = [NSColor colorWithRgbInt:argbFillBg];
+            NSColor *fillFg = [NSColor colorWithRgbInt:argbFillFg];
+            NSColor *selBg = [NSColor colorWithRgbInt:argbSelBg];
+            NSColor *selFg = [NSColor colorWithRgbInt:argbSelFg];
+
+            [windowController setTablineColorsTabBg:tabBg tabFg:tabFg fillBg:fillBg fillFg:fillFg selBg:selBg selFg:selFg];
+        }
+        break;
         case SetDefaultColorsMsgID:
         {
             const void *bytes = [data bytes];

--- a/src/MacVim/MMVimView.h
+++ b/src/MacVim/MMVimView.h
@@ -60,6 +60,9 @@
 - (void)finishPlaceScrollbars;
 
 - (void)setDefaultColorsBackground:(NSColor *)back foreground:(NSColor *)fore;
+- (void)setTablineColorsTabBg:(NSColor *)tabBg tabFg:(NSColor *)tabFg
+                       fillBg:(NSColor *)fillBg fillFg:(NSColor *)fillFg
+                        selBg:(NSColor *)selBg selFg:(NSColor *)selFg;
 
 - (void)viewWillStartLiveResize;
 - (void)viewDidEndLiveResize;

--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -84,7 +84,10 @@
 - (void)setBackgroundOption:(int)dark;
 - (void)refreshApperanceMode;
 - (void)updateResizeConstraints:(BOOL)resizeWindow;
-
+- (void)setTablineColorsTabBg:(NSColor *)tabBg tabFg:(NSColor *)tabFg
+                       fillBg:(NSColor *)fillBg fillFg:(NSColor *)fillFg
+                        selBg:(NSColor *)selBg selFg:(NSColor *)selFg;
+- (void)refreshTabProperties;
 - (void)setDefaultColorsBackground:(NSColor *)back foreground:(NSColor *)fore;
 - (void)setFont:(NSFont *)font;
 - (void)setWideFont:(NSFont *)font;

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -301,6 +301,7 @@ extern const char * const MMVimMsgIDStrings[];
     MSG(SetWideFontMsgID) \
     MSG(VimShouldCloseMsgID) \
     MSG(SetDefaultColorsMsgID) \
+    MSG(SetTablineColorsMsgID) \
     MSG(ExecuteActionMsgID) \
     MSG(DropFilesMsgID) \
     MSG(DropStringMsgID) \

--- a/src/MacVim/Miscellaneous.h
+++ b/src/MacVim/Miscellaneous.h
@@ -23,6 +23,8 @@ extern NSString *MMTabMaxWidthKey;
 extern NSString *MMTabOptimumWidthKey;
 extern NSString *MMShowAddTabButtonKey;
 extern NSString *MMShowTabScrollButtonsKey;
+extern NSString *MMTabColorsModeKey;
+extern NSString *MMWindowUseTabBackgroundColorKey;
 extern NSString *MMTextInsetLeftKey;
 extern NSString *MMTextInsetRightKey;
 extern NSString *MMTextInsetTopKey;
@@ -104,6 +106,11 @@ enum MMAppearanceModeSelectionEnum {
     MMAppearanceModeSelectionBackgroundOption = 3,
 };
 
+typedef enum : NSInteger {
+    MMTabColorsModeDefaultColors = 0,   ///< Use default colors based on macOS light/dark modes
+    MMTabColorsModeAutomatic,           ///< Automatically derive tab colors based on foreground/background colors
+    MMTabColorsModeVimColorscheme,      ///< Use Vim colorscheme TabLine/TabLineSel/TabLineFill colors
+} MMTabColorsMode;
 
 enum {
     // These values are chosen so that the min text view size is not too small
@@ -174,7 +181,13 @@ NSView *showHiddenFilesView(void);
 NSString *normalizeFilename(NSString *filename);
 NSArray *normalizeFilenames(NSArray *filenames);
 
-int getCurrentAppearance(NSAppearance *appearance);
+typedef enum : int {
+    AppearanceLight = 0,
+    AppearanceDark,
+    AppearanceLightHighContrast,
+    AppearanceDarkHighContrast,
+} AppearanceType;
+AppearanceType getCurrentAppearance(NSAppearance *appearance);
 
 // Pasteboard helpers
 NSPasteboardType getPasteboardFilenamesType(void);

--- a/src/MacVim/Miscellaneous.m
+++ b/src/MacVim/Miscellaneous.m
@@ -19,6 +19,8 @@ NSString *MMTabMaxWidthKey                = @"MMTabMaxWidth";
 NSString *MMTabOptimumWidthKey            = @"MMTabOptimumWidth";
 NSString *MMShowAddTabButtonKey           = @"MMShowAddTabButton";
 NSString *MMShowTabScrollButtonsKey       = @"MMShowTabScrollButtons";
+NSString *MMTabColorsModeKey              = @"MMTabColorsMode";
+NSString *MMWindowUseTabBackgroundColorKey      = @"MMWindowUseTabBackgroundColor";
 NSString *MMTextInsetLeftKey              = @"MMTextInsetLeft";
 NSString *MMTextInsetRightKey             = @"MMTextInsetRight";
 NSString *MMTextInsetTopKey               = @"MMTextInsetTop";
@@ -305,9 +307,9 @@ normalizeFilenames(NSArray *filenames)
 
 
 
-int
+AppearanceType
 getCurrentAppearance(NSAppearance *appearance){
-    int flag = 0; // for macOS 10.13 or earlier always return 0;
+    int flag = AppearanceLight; // for macOS 10.13 or earlier always return 0;
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
     if (@available(macOS 10.14, *)) {
         NSAppearanceName appearanceName = [appearance bestMatchFromAppearancesWithNames:
@@ -316,11 +318,11 @@ getCurrentAppearance(NSAppearance *appearance){
                 , NSAppearanceNameAccessibilityHighContrastAqua
                 , NSAppearanceNameAccessibilityHighContrastDarkAqua]];
         if ([appearanceName isEqualToString:NSAppearanceNameDarkAqua]) {
-            flag = 1;
+            flag = AppearanceDark;
         } else if ([appearanceName isEqualToString:NSAppearanceNameAccessibilityHighContrastAqua]) {
-            flag = 2;
+            flag = AppearanceLightHighContrast;
         } else if ([appearanceName isEqualToString:NSAppearanceNameAccessibilityHighContrastDarkAqua]) {
-            flag = 3;
+            flag = AppearanceDarkHighContrast;
         }
     }
 #endif

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -4069,6 +4069,12 @@ highlight_changed(void)
 
 #endif // USER_HIGHLIGHT
 
+#if defined(FEAT_GUI) && defined(FEAT_GUI_MACVIM)
+    // MacVim needs to know about the other highlight colors other than just
+    // the default fg/bg colors.
+    if (gui.in_use)
+	gui_mch_update_highlight();
+#endif
     return OK;
 }
 

--- a/src/proto/gui_macvim.pro
+++ b/src/proto/gui_macvim.pro
@@ -63,6 +63,7 @@ int gui_mch_haskey(char_u *name);
 void gui_mch_iconify(void);
 void gui_mch_invert_rectangle(int r, int c, int nr, int nc, int invert);
 void gui_mch_new_colors(void);
+void gui_mch_update_highlight(void);
 void gui_mch_set_bg_color(guicolor_T color);
 int gui_mch_is_blinking(void);
 int gui_mch_is_blink_off(void);


### PR DESCRIPTION
Tabs can now use colors defined by the Vim colorscheme under the TabLine/TabLineFill/TabLineSel highlight groups. There are now 3 coloring modes available: default, automatic (the default mode that generates matching colors using foreground/background colors), and Vim colorscheme. The new mode looks quite nice in some colorschemes and allows user customization, but for some existing ones it doesn't quite look right as they were designed for non-GUI tabs, which is why it's not the default.

MacVim window can now also use the tabline's fill color as the window background color, which allows the title bar to show as a cohesive whole when transparent title bar is set. This creates a nice look especially when the colorscheme is designed for this.

Other tab coloring changes:
- Tabs now support high contrast mode (macOS accessibility setting) now. The default colors will use higher contrast colors, and in all modes, the tabs will be drawn with an outline similar to other system native UI to aid visual differentiation.
- Tabs will also show a dimmed text color when the window has lost focus, similar to other native title bar / tool bar UI elements.
- Fixed default colors to look a little better. Previously the fill color and unselected tab background colors were the same.