### PR TITLE
ci: Don't run Vim non-src tests (indent/syntax etc)

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -375,14 +375,17 @@ jobs:
 
       - name: Test Vim
         if: startsWith(github.ref, 'refs/tags/') || !matrix.testgui
-        timeout-minutes: 25
+        timeout-minutes: 30
         run: |
           defaults delete org.vim.MacVim  # Clean up stale states
-          make ${MAKE_BUILD_ARGS} test
+          # Currently we don't run any non-src tests, as syntax tests are fragile and prone to spamming escape codes.
+          # This needs to be investigated and fixed upstream.
+          # MacVim is unlikely to introduce breaking changes in runtime files anyway.
+          make ${MAKE_BUILD_ARGS} -C src test
 
       - name: Test Vim (GUI)
         if: startsWith(github.ref, 'refs/tags/') || matrix.testgui
-        timeout-minutes: 25
+        timeout-minutes: 30
         run: |
           defaults delete org.vim.MacVim  # Clean up stale states
           make ${MAKE_BUILD_ARGS} -C src/testdir clean


### PR DESCRIPTION
Currently Vim syntax tests are quite broken and keep failing in MacVim CI. There seems to be some Unicode / emoji handling bug causing tests to fail sporadically, and the syntax tests also spam the console output as they aren't redirecting output to /dev/null like normal Vim script tests. Just disable them for now until this is fixed.

This should not cause much issues anyway. It's unlike MacVim will have any downstream syntax/indent bugs as those files are mostly merged from upstream as-is.