### PR TITLE
Fix fontSizeUp/Down actions to preserve -monospace- font alias

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -1333,6 +1333,15 @@ static void grid_free(Grid *grid) {
 
     if (newFont) {
         NSString *name = [newFont fontName];
+
+        // If this is a system monospace font, retrieve the user-friendly
+        // name before we send it to Vim. We don't want to expose the OS-
+        // specific system font name which is confusing to the user.
+        NSString *userMonospaceFontName = [[self vimController] systemFontNamesToAlias][name];
+        if (userMonospaceFontName != nil) {
+            name = userMonospaceFontName;
+        }
+
         unsigned len = (unsigned)[name lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
         if (len > 0) {
             NSMutableData *data = [NSMutableData data];

--- a/src/MacVim/MMVimController.h
+++ b/src/MacVim/MMVimController.h
@@ -56,6 +56,10 @@
     BOOL                hasModifiedBuffer;
 }
 
+/// Mapping from internal names for system monospace font to user-visible one.
+/// E.g. ".AppleSystemUIFontMonospaced-Medium" -> "-monospace-Medium"
+@property (nonatomic, readonly) NSMutableDictionary<NSString*, NSString*>* systemFontNamesToAlias;
+
 - (id)initWithBackend:(id)backend pid:(int)processIdentifier;
 - (void)uninitialize;
 - (unsigned long)vimControllerId;

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -250,6 +250,8 @@ static BOOL isUnsafeMessage(int msgid);
     [mainMenu release];  mainMenu = nil;
     [creationDate release];  creationDate = nil;
 
+    [_systemFontNamesToAlias release];  _systemFontNamesToAlias = nil;
+
     [super dealloc];
 }
 
@@ -927,6 +929,14 @@ static BOOL isUnsafeMessage(int msgid);
                             fontWeight = NSFontWeightBlack;
                     }
                     font = [NSFont monospacedSystemFontOfSize:size weight:fontWeight];
+
+                    // We cache the internal name -> user-facing alias mapping
+                    // to allow fontSizeUp/Down actions to be able to retain
+                    // the user-facing font name in 'guifont'.
+                    if (_systemFontNamesToAlias == nil) {
+                        _systemFontNamesToAlias = [[NSMutableDictionary alloc] initWithCapacity:9];
+                    }
+                    _systemFontNamesToAlias[font.fontName] = name;
                 }
                 else
 #endif

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1239,12 +1239,14 @@
 
 - (IBAction)fontSizeUp:(id)sender
 {
+    // This creates a new font and triggers text view's changeFont: callback
     [[NSFontManager sharedFontManager] modifyFont:
             [NSNumber numberWithInt:NSSizeUpFontAction]];
 }
 
 - (IBAction)fontSizeDown:(id)sender
 {
+    // This creates a new font and triggers text view's changeFont: callback
     [[NSFontManager sharedFontManager] modifyFont:
             [NSNumber numberWithInt:NSSizeDownFontAction]];
 }

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -446,7 +446,7 @@ enum {
 
 extern NSString *VimFindPboardType;
 
-// Alias for system monospace font name
+/// Alias for system monospace font name
 extern NSString *MMSystemFontAlias;
 
 

--- a/src/MacVim/MacVimTests/MacVimTests.m
+++ b/src/MacVim/MacVimTests/MacVimTests.m
@@ -536,10 +536,12 @@ do { \
     [[[app keyVimController] windowController] fontSizeUp:nil];
     [self waitForEventHandlingAndVimProcess];
     XCTAssertEqualObjects([textView font], [NSFont monospacedSystemFontOfSize:13 weight:NSFontWeightHeavy]);
+    XCTAssertEqualObjects([[app keyVimController] evaluateVimExpression:@"&guifont"], @"-monospace-Heavy:h13");
 
     [[[app keyVimController] windowController] fontSizeDown:nil];
     [self waitForEventHandlingAndVimProcess];
     XCTAssertEqualObjects([textView font], [NSFont monospacedSystemFontOfSize:12 weight:NSFontWeightHeavy]);
+    XCTAssertEqualObjects([[app keyVimController] evaluateVimExpression:@"&guifont"], @"-monospace-Heavy:h12");
 }
 
 /// Test that dark mode settings work and the corresponding Vim bindings are functional.


### PR DESCRIPTION
This prevents using Cmd +/- to adjust font size resulting in guifont being set from "-monospace-" to a non-user-friendly internal name like ".AppleSystemUIFontMonospaced-Regular".