### PR TITLE
Fix non-native full screen menu sizing / make resize option updates immediate

### DIFF
--- a/src/MacVim/Base.lproj/Preferences.xib
+++ b/src/MacVim/Base.lproj/Preferences.xib
@@ -507,6 +507,7 @@
                                 </connections>
                             </buttonCell>
                             <connections>
+                                <action selector="nonNativeFullScreenShowMenuChanged:" target="-1" id="7gA-SN-OaM"/>
                                 <binding destination="58" name="value" keyPath="values.MMNonNativeFullScreenShowMenu" id="5wX-jg-QPo"/>
                             </connections>
                         </button>

--- a/src/MacVim/MMAppController.h
+++ b/src/MacVim/MMAppController.h
@@ -83,11 +83,13 @@
 - (NSArray *)filterOpenFiles:(NSArray *)filenames;
 - (BOOL)openFiles:(NSArray *)filenames withArguments:(NSDictionary *)args;
 
+// Refresh functions are used by preference pane to push through settings changes
 - (void)refreshAllAppearances;
 - (void)refreshAllTabProperties;
 - (void)refreshAllFonts;
 - (void)refreshAllResizeConstraints;
 - (void)refreshAllTextViews;
+- (void)refreshAllFullScreenPresentationOptions;
 
 - (void)openNewWindow:(enum NewWindowMode)mode activate:(BOOL)activate extraArgs:(NSArray *)args;
 - (void)openNewWindow:(enum NewWindowMode)mode activate:(BOOL)activate;

--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -38,6 +38,7 @@
  */
 
 #import "MMAppController.h"
+#import "MMFullScreenWindow.h"
 #import "MMPreferenceController.h"
 #import "MMVimController.h"
 #import "MMVimView.h"
@@ -1269,6 +1270,19 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
     for (MMVimController *vc in vimControllers) {
         [vc.windowController.vimView.textView updateCmdlineRow];
         vc.windowController.vimView.textView.needsDisplay = YES;
+    }
+}
+
+/// Refresh all non-native full screen windows to update their presentation
+/// options (show/hide menu and dock).
+- (void)refreshAllFullScreenPresentationOptions
+{
+    for (MMVimController *vc in vimControllers) {
+        MMFullScreenWindow *fullScreenWindow = vc.windowController.fullScreenWindow;
+        if (fullScreenWindow != nil) {
+            [fullScreenWindow updatePresentationOptions];
+            [vc.windowController resizeVimView];
+        }
     }
 }
 

--- a/src/MacVim/MMFullScreenWindow.h
+++ b/src/MacVim/MMFullScreenWindow.h
@@ -35,6 +35,7 @@
 - (MMFullScreenWindow *)initWithWindow:(NSWindow *)t view:(MMVimView *)v
                                backgroundColor:(NSColor *)back;
 - (void)setOptions:(int)opt;
+- (void)updatePresentationOptions;
 - (void)enterFullScreen;
 - (void)leaveFullScreen;
 - (NSRect)getDesiredFrame;

--- a/src/MacVim/MMPreferenceController.h
+++ b/src/MacVim/MMPreferenceController.h
@@ -40,5 +40,6 @@
 // Appearance pane
 - (IBAction)fontPropertiesChanged:(id)sender;
 - (IBAction)tabsPropertiesChanged:(id)sender;
+- (IBAction)nonNativeFullScreenShowMenuChanged:(id)sender;
 
 @end

--- a/src/MacVim/MMPreferenceController.m
+++ b/src/MacVim/MMPreferenceController.m
@@ -182,4 +182,9 @@
     [[MMAppController sharedInstance] refreshAllTextViews];
 }
 
+- (IBAction)nonNativeFullScreenShowMenuChanged:(id)sender
+{
+    [[MMAppController sharedInstance] refreshAllFullScreenPresentationOptions];
+}
+
 @end

--- a/src/MacVim/MMVimController.h
+++ b/src/MacVim/MMVimController.h
@@ -60,6 +60,8 @@
 /// E.g. ".AppleSystemUIFontMonospaced-Medium" -> "-monospace-Medium"
 @property (nonatomic, readonly) NSMutableDictionary<NSString*, NSString*>* systemFontNamesToAlias;
 
+@property (nonatomic, readonly) BOOL isHandlingInputQueue;
+
 - (id)initWithBackend:(id)backend pid:(int)processIdentifier;
 - (void)uninitialize;
 - (unsigned long)vimControllerId;

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -557,6 +557,8 @@ static BOOL isUnsafeMessage(int msgid);
 {
     if (!isInitialized) return;
 
+    _isHandlingInputQueue = YES;
+
     // NOTE: This method must not raise any exceptions (see comment in the
     // calling method).
     @try {
@@ -566,6 +568,7 @@ static BOOL isUnsafeMessage(int msgid);
     @catch (NSException *ex) {
         ASLogDebug(@"Exception: pid=%d id=%lu reason=%@", pid, identifier, ex);
     }
+    _isHandlingInputQueue = NO;
 }
 
 - (NSToolbarItem *)toolbar:(NSToolbar *)theToolbar

--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -62,6 +62,7 @@
 - (id)initWithVimController:(MMVimController *)controller;
 - (MMVimController *)vimController;
 - (MMVimView *)vimView;
+- (MMFullScreenWindow*)fullScreenWindow;
 - (NSString *)windowAutosaveKey;
 - (void)setWindowAutosaveKey:(NSString *)key;
 - (void)cleanup;

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -290,6 +290,11 @@
     return vimView;
 }
 
+- (MMFullScreenWindow *)fullScreenWindow
+{
+    return fullScreenWindow;
+}
+
 - (NSString *)windowAutosaveKey
 {
     return windowAutosaveKey;
@@ -468,6 +473,8 @@
     if (setupDone)
     {
         shouldResizeVimView = YES;
+        if (!vimController.isHandlingInputQueue)
+            [self processInputQueueDidFinish];
     }
 }
 
@@ -480,6 +487,8 @@
     {
         shouldResizeVimView = YES;
         shouldKeepGUISize = YES;
+        if (!vimController.isHandlingInputQueue)
+            [self processInputQueueDidFinish];
     }
 }
 
@@ -492,9 +501,13 @@
 /// or shows the tab bar.
 - (void)resizeVimViewBlockRender
 {
-    [self resizeVimView];
-    if (shouldResizeVimView) {
+    if (setupDone)
+    {
+        shouldResizeVimView = YES;
+        shouldKeepGUISize = YES;
         blockRenderUntilResize = YES;
+        if (!vimController.isHandlingInputQueue)
+            [self processInputQueueDidFinish];
     }
 }
 


### PR DESCRIPTION
Problem: Non-native full screen has an option to show the menu bar but it does not work properly in some multi-monitor scenarios. On a MacBook with a notch it would sometimes use the thicker notch menu bar height even when going full screen on a regular monitor, and when using a single Space for all displays it would also show a black bar on top on the screen that does not have the menu bar.

Solution: Use the NSScreen visibleFrame API exclusively instead of querying the menu bar height which seems to be inconsistent. There are some quirks with this API (e.g. a one-pixel gap) but we already handle it when handling non-native full screen on a laptop screen with notch so it's best to consolidate the code paths.

Also, make the "show menu bar" option immediate when changing it in preference pane. As a corollary, this also makes changing "smooth scrolling" option immediate, as well as liveResizeDidEnd's delayed pending resize.