### PR TITLE
Reduce flicker when entering non-native full screen

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -1499,6 +1499,8 @@ static void grid_free(Grid *grid) {
     if (col + nc == grid.cols) {
         const NSInteger insetRight = [[NSUserDefaults standardUserDefaults] integerForKey:MMTextInsetRightKey];
         CGFloat extraWidth = frame.size.width - insetRight - (rect.size.width + rect.origin.x);
+        if (extraWidth > cellSize.width * 4) // just a sane cap so Vim doesn't look really stretched when resized before Vim could catch up
+            extraWidth = cellSize.width * 4;
         rect.size.width += extraWidth;
     }
 

--- a/src/MacVim/MMWindow.m
+++ b/src/MacVim/MMWindow.m
@@ -213,11 +213,12 @@ static CGSSetWindowBackgroundBlurRadiusFunction* GetCGSSetWindowBackgroundBlurRa
 
 - (IBAction)toggleFullScreen:(id)sender
 {
-    // HACK! This is an NSWindow method used to enter full-screen on OS X 10.7.
-    // We override it so that we can interrupt and pass this on to Vim first.
-    // An alternative hack would be to reroute the action message sent by the
-    // full-screen button in the top right corner of a window, but there could
-    // be other places where this action message is sent from.
+    // This is an NSWindow method used to enter full-screen since OS X 10.7
+    // Lion. We override it so that we can interrupt and pass this on to Vim
+    // first, as it is full-screen aware (":set fullscreen") and it's better to
+    // only have one path to enter full screen. For non-native full screen this
+    // does mean this button will now enter non-native full screen instead of
+    // native one.
     // To get to the original method (and enter Lion full-screen) we need to
     // call realToggleFullScreen: defined below.
 
@@ -227,11 +228,8 @@ static CGSSetWindowBackgroundBlurRadiusFunction* GetCGSSetWindowBackgroundBlurRa
 
 - (IBAction)realToggleFullScreen:(id)sender
 {
-#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
-    // HACK! See toggleFullScreen: comment above.
-    if ([NSWindow instancesRespondToSelector:@selector(toggleFullScreen:)])
-        [super toggleFullScreen:sender];
-#endif
+    // See toggleFullScreen: comment above.
+    [super toggleFullScreen:sender];
 }
 
 - (void)setToolbar:(NSToolbar *)toolbar

--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -31,7 +31,9 @@
 
     BOOL                shouldResizeVimView; ///< Indicates there is a pending command to resize the Vim view
     BOOL                shouldKeepGUISize; ///< If on, the Vim view resize will try to fit in the existing window. If off, the window resizes to fit Vim view.
+
     BOOL                blockRenderUntilResize; ///< Indicates that there should be no text rendering until a Vim view resize is completed to avoid flicker.
+    NSRect              blockedRenderTextViewFrame; ///< The old screen-based coords for the text view when render was blocked.
 
     BOOL                shouldRestoreUserTopLeft;
     int                 updateToolbarFlag;

--- a/src/MacVim/MacVimTests/MacVimTests.m
+++ b/src/MacVim/MacVimTests/MacVimTests.m
@@ -17,6 +17,7 @@
 #import "MMApplication.h"
 #import "MMFullScreenWindow.h"
 #import "MMWindow.h"
+#import "MMTabline.h"
 #import "MMTextView.h"
 #import "MMWindowController.h"
 #import "MMVimController.h"
@@ -887,6 +888,8 @@ do { \
     XCTAssertLessThan(textView.pendingMaxRows, 30); // confirms that we have an outstanding resize request to make it smaller
     XCTAssertLessThan(textView.pendingMaxColumns, 80);
     XCTAssertTrue(win.isRenderBlocked);
+    XCTAssertEqual(textView.drawRectOffset.width, 0);
+    XCTAssertEqual(textView.drawRectOffset.height, 0);
     // Vim has responded to the size change. We should now have unblocked rendering.
     [self waitForVimMessage:SetTextDimensionsNoResizeWindowMsgID blockFutureMessages:YES];
     XCTAssertLessThan(textView.maxRows, 30);
@@ -910,7 +913,7 @@ do { \
     [self waitForVimMessage:ShowTabBarMsgID blockFutureMessages:YES];
     XCTAssertEqual(textView.maxRows, 30);
     XCTAssertLessThan(textView.pendingMaxRows, 30);
-    XCTAssertGreaterThan(textView.drawRectOffset.height, 0);
+    XCTAssertEqual(textView.drawRectOffset.height, MMTablineHeight);
     XCTAssertTrue(win.isRenderBlocked);
     [self waitForVimMessage:SetTextDimensionsNoResizeWindowMsgID blockFutureMessages:YES];
     XCTAssertLessThan(textView.maxRows, 30);
@@ -923,7 +926,11 @@ do { \
     // was not explicitly set.
     [self setDefault:MMNativeFullScreenKey toValue:@NO]; // non-native is faster so use that
     [self sendStringToVim:@":set guioptions-=k fullscreen\n" withMods:0];
+    [self waitForVimMessage:EnterFullScreenMsgID blockFutureMessages:YES];
+    XCTAssertTrue(win.isRenderBlocked);
+    [self blockVimProcessInput:NO];
     [self waitForFullscreenTransitionIsEnter:YES isNative:NO];
+    XCTAssertFalse(win.isRenderBlocked);
     int fuRows = textView.maxRows;
     int fuCols = textView.maxColumns;
     [self sendStringToVim:@":set guifont=Menlo:h13\n" withMods:0];


### PR DESCRIPTION
In #1547, flicker during font size change and showing tab/scrollbar were reduced. Here, we do something similar for the flicker that happens when entering non-native full screen, where the temporarily moved text view shows a brief temporary draw before the updated Vim redraws over it, leading to a flicker. Use the same mechanism here to block rendering and offset the text view draw while we wait for Vim to preserve visual stability as much as possible.

No need to do this for native full screen as the smooth but slow transition means there isn't a sharp flicker anyway.

Also, reduce the "fill right" behavior of Core Text renderer (#1276).  It's designed to make smooth resizing more seamless but it fills all the way to the right which makes situations like this or maximizing the window jarrying as Vim looks stretched horizontally but not vertically during the resize before Vim catches up and resizes/redraws. Just put a sane cap of 4 cell widths. This way even if Vim is a little slow to respond, smooth resize still looks good, but it won't stretch across the whole screen.