### PR TITLE
Fix Writing Tools integration and fix up Services integration with texts

### DIFF
--- a/src/MacVim/MMCoreTextView.m
+++ b/src/MacVim/MMCoreTextView.m
@@ -648,8 +648,7 @@ static void grid_free(Grid *grid) {
 
 - (void)insertText:(id)string replacementRange:(NSRange)replacementRange
 {
-    // We are not currently replacementRange right now.
-    [helper insertText:string];
+    [helper insertText:string replacementRange:replacementRange];
 }
 
 - (void)doCommandBySelector:(SEL)selector
@@ -1992,7 +1991,7 @@ static void rowColFromUtfRange(const Grid* grid, NSRange range,
         // top of said selection and if so, show definition of that instead.
         MMVimController *vc = [self vimController];
         id<MMBackendProtocol> backendProxy = [vc backendProxy];
-        if ([backendProxy selectedTextToPasteboard:nil]) {
+        if ([backendProxy hasSelectedText]) {
             int selRow = 0, selCol = 0;
             const BOOL isMouseInSelection = [backendProxy mouseScreenposIsSelection:row column:col selRow:&selRow selCol:&selCol];
 

--- a/src/MacVim/MMTextView.m
+++ b/src/MacVim/MMTextView.m
@@ -724,7 +724,7 @@
 
 - (void)insertText:(id)string
 {
-    [helper insertText:string];
+    [helper insertText:string replacementRange:NSMakeRange(0, 0)];
 }
 
 - (void)doCommandBySelector:(SEL)selector

--- a/src/MacVim/MMTextViewHelper.h
+++ b/src/MacVim/MMTextViewHelper.h
@@ -65,7 +65,7 @@
 - (NSColor *)insertionPointColor;
 
 - (void)keyDown:(NSEvent *)event;
-- (void)insertText:(id)string;
+- (void)insertText:(id)string replacementRange:(NSRange)replacementRange;
 - (void)doCommandBySelector:(SEL)selector;
 - (void)scrollWheel:(NSEvent *)event;
 - (void)mouseDown:(NSEvent *)event;

--- a/src/MacVim/MMTextViewHelper.m
+++ b/src/MacVim/MMTextViewHelper.m
@@ -221,7 +221,7 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
     currentEvent = nil;
 }
 
-- (void)insertText:(id)string
+- (void)insertText:(id)string replacementRange:(NSRange)replacementRange
 {
     if ([self hasMarkedText]) {
         [self sendMarkedText:nil position:0];
@@ -240,6 +240,20 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
     // latter case.
     if ([string isKindOfClass:[NSAttributedString class]])
         string = [string string];
+
+    if (replacementRange.length > 0)
+    {
+        // Replacement range is a concept we don't really have a way to fulfill
+        // as we don't have proper access to the underlying text storage. This
+        // should usually be triggered when we have selected text though, and
+        // so we simply ask Vim to replace the current selection with the new
+        // text, and it should hopefully work.
+        // Only known way of this being called is Apple Intelligence Writing
+        // Tools.
+        MMVimController *vc = [self vimController];
+        [vc replaceSelectedText:string];
+        return;
+    }
 
     //int len = [string length];
     //ASLogDebug(@"len=%d char[0]=%#x char[1]=%#x string='%@'", [string length],

--- a/src/MacVim/MMVimController.h
+++ b/src/MacVim/MMVimController.h
@@ -92,6 +92,9 @@
 - (NSString *)evaluateVimExpression:(NSString *)expr;
 - (id)evaluateVimExpressionCocoa:(NSString *)expr
                      errorString:(NSString **)errstr;
+- (BOOL)hasSelectedText;
+- (NSString *)selectedText;
+- (void)replaceSelectedText:(NSString *)text;
 - (void)processInputQueue:(NSArray *)queue;
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
 - (NSTouchBar *)makeTouchBar;

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -533,6 +533,49 @@ static BOOL isUnsafeMessage(int msgid);
     return eval;
 }
 
+- (BOOL)hasSelectedText
+{
+    BOOL hasSelectedText = NO;
+    if (backendProxy) {
+        @try {
+            hasSelectedText = [backendProxy hasSelectedText];
+        }
+        @catch (NSException *ex) {
+            ASLogDebug(@"hasSelectedText: failed: pid=%d reason=%@",
+                    pid, ex);
+        }
+    }
+    return hasSelectedText;
+}
+
+- (NSString *)selectedText
+{
+    NSString *selectedText = nil;
+    if (backendProxy) {
+        @try {
+            selectedText = [backendProxy selectedText];
+        }
+        @catch (NSException *ex) {
+            ASLogDebug(@"selectedText: failed: pid=%d reason=%@",
+                    pid, ex);
+        }
+    }
+    return selectedText;
+}
+
+- (void)replaceSelectedText:(NSString *)text
+{
+    if (backendProxy) {
+        @try {
+            [backendProxy replaceSelectedText:text];
+        }
+        @catch (NSException *ex) {
+            ASLogDebug(@"replaceSelectedText: failed: pid=%d reason=%@",
+                    pid, ex);
+        }
+    }
+}
+
 - (id)backendProxy
 {
     return backendProxy;

--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -18,7 +18,7 @@
 @class MMVimView;
 
 @interface MMWindowController : NSWindowController<
-    NSWindowDelegate
+    NSWindowDelegate, NSServicesMenuRequestor
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
     , NSMenuItemValidation
 #endif

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -192,8 +192,9 @@ typedef NSString* NSAttributedStringKey;
 - (NSString *)evaluateExpression:(in bycopy NSString *)expr;
 - (id)evaluateExpressionCocoa:(in bycopy NSString *)expr
                   errorString:(out bycopy NSString **)errstr;
-- (BOOL)selectedTextToPasteboard:(byref NSPasteboard *)pboard;
+- (BOOL)hasSelectedText;
 - (NSString *)selectedText;
+- (oneway void)replaceSelectedText:(in bycopy NSString *)text;
 - (BOOL)mouseScreenposIsSelection:(int)row column:(int)column selRow:(byref int *)startRow selCol:(byref int *)startCol;
 - (oneway void)acknowledgeConnection;
 @end

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -72,10 +72,8 @@ static void f_getenv(typval_T *argvars, typval_T *rettv);
 static void f_getfontname(typval_T *argvars, typval_T *rettv);
 static void f_getjumplist(typval_T *argvars, typval_T *rettv);
 static void f_getpid(typval_T *argvars, typval_T *rettv);
-static void f_getpos(typval_T *argvars, typval_T *rettv);
 static void f_getreg(typval_T *argvars, typval_T *rettv);
 static void f_getreginfo(typval_T *argvars, typval_T *rettv);
-static void f_getregion(typval_T *argvars, typval_T *rettv);
 static void f_getregionpos(typval_T *argvars, typval_T *rettv);
 static void f_getregtype(typval_T *argvars, typval_T *rettv);
 static void f_gettagstack(typval_T *argvars, typval_T *rettv);
@@ -5758,7 +5756,7 @@ f_getcursorcharpos(typval_T *argvars, typval_T *rettv)
 /*
  * "getpos(string)" function
  */
-    static void
+    void
 f_getpos(typval_T *argvars, typval_T *rettv)
 {
     if (in_vim9script() && check_for_string_arg(argvars, 0) == FAIL)
@@ -5949,7 +5947,7 @@ getregionpos(
 /*
  * "getregion()" function
  */
-    static void
+    void
 f_getregion(typval_T *argvars, typval_T *rettv)
 {
     pos_T		p1, p2;

--- a/src/normal.c
+++ b/src/normal.c
@@ -112,7 +112,6 @@ static void	nv_record(cmdarg_T *cap);
 static void	nv_at(cmdarg_T *cap);
 static void	nv_halfpage(cmdarg_T *cap);
 static void	nv_join(cmdarg_T *cap);
-static void	nv_put(cmdarg_T *cap);
 static void	nv_put_opt(cmdarg_T *cap, int fix_indent);
 static void	nv_open(cmdarg_T *cap);
 #ifdef FEAT_NETBEANS_INTG
@@ -7339,7 +7338,7 @@ nv_join(cmdarg_T *cap)
 /*
  * "P", "gP", "p" and "gp" commands.
  */
-    static void
+    void
 nv_put(cmdarg_T *cap)
 {
     nv_put_opt(cap, FALSE);

--- a/src/proto/evalfunc.pro
+++ b/src/proto/evalfunc.pro
@@ -30,5 +30,7 @@ long do_searchpair(char_u *spat, char_u *mpat, char_u *epat, int dir, typval_T *
 
 // MacVim only
 void f_getcurpos(typval_T *argvars, typval_T *rettv);
+void f_getpos(typval_T *argvars, typval_T *rettv);
+void f_getregion(typval_T *argvars, typval_T *rettv);
 
 /* vim: set ft=c : */

--- a/src/proto/normal.pro
+++ b/src/proto/normal.pro
@@ -33,4 +33,8 @@ void may_start_select(int c);
 int unadjust_for_sel(void);
 int unadjust_for_sel_inner(pos_T *pp);
 void set_cursor_for_append_to_line(void);
+
+// MacVim only
+void nv_put(cmdarg_T *cap);
+
 /* vim: set ft=c : */


### PR DESCRIPTION
Apple "Intelligence" Writing Tools was previously not working correctly with MacVim. When the user chooses to replace the original selection with the updated texts, MacVim mistreats the input and treat them as commands instead of raw texts. The reason was that even though this service uses the NSServicesMenuRequestor API to obtain the selected texts, it does not use it to send over the replacement. Instead, it uses NSTextInput's `insertText:replacementRange` to do so instead, which we never implemented properly. The reason behind this choice was probably because Writing Tools first shows a UI with user interaction and has a delay between obtaining the texts and replacing them, like a regular Services menu. This means the selection may already be invalid by the time it requests a replacement.

To fix this, add a new IPC API `replaceSelectedText` to replace the selected texts and redirect `insertText:replacementRange` to use it if the replacement range is non-empty. This isn't the most correct implementation of the protocol but should work in most cases. We don't have a way to implement it "correctly" as MacVim does not have easy access to Vim's internal text storage. Also make sure the Service menu uses this API (for things like "convert to full width" and Traditional/Simplified Chinese conversions). The old method of simple injecting a normal mode command `s` before the text was horribly buggy. It also works with visual block selection properly now.

The implementation uses Vim's register put functionality because Vim doesn't have an API to simply replace a block of text, and everything has to go through registers. At the same time, replace the implementation for the old `selectedText` IPC API to not do this, because Vim *did* end an API to do so for obtaining texts (via `getregion()`) and it's more stable to use this than to manually cache/restore registers.

Related: vim/vim#16596 (fixes `setreg()` which this uses)

Fix #1512