### PR TITLE
ci: Fix MacVim test breakage for testIPCSelectedText test

### DIFF
--- a/src/MacVim/MacVimTests/MacVimTests.m
+++ b/src/MacVim/MacVimTests/MacVimTests.m
@@ -1394,7 +1394,7 @@ do { \
 /// Test the selected text related IPC APIs
 - (void)testIPCSelectedText {
     [self createTestVimWindow];
-    [self sendStringToVim:@":put =['abcd', 'efgh', 'ijkl']\nggdd" withMods:0];
+    [self sendStringToVim:@":call setline(1,['abcd','efgh','ijkl'])\n" withMods:0];
     [self waitForEventHandlingAndVimProcess];
 
     MMAppController *app = MMAppController.sharedInstance;


### PR DESCRIPTION
It seems that the input system is a little flaky and can occasionally drop the full command. Switching to a regular Vim function seems to alleviate this for now. This would be looked at and revamped in more details when we drop Distributed Objects soon.