### PR TITLE
Update getcellpixels() docs to point out the delay in MacVim GUI

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3885,6 +3885,8 @@ getcellpixels()						*getcellpixels()*
 		On macOS, system Terminal.app returns sizes in points (before
 		Retina scaling), whereas third-party terminals return raw pixel
 		sizes (post Retina scaling).
+		In MacVim, there is a small delay after startup or changing
+		'guifont' before this will return the updated values.
 
 		Return type: list<any>
 


### PR DESCRIPTION
#1554 added support for `getcellpixels()`, but it has a quirk in MacVim in that it has a slight delay due to MacVim's asynchronous nature. Make sure the documentation reflects that to avoid surprises.