### PR TITLE
Tabs: Fix MMHoverButton poor usage of images and potential stack overflow

### DIFF
--- a/src/MacVim/MMTabline/MMHoverButton.h
+++ b/src/MacVim/MMTabline/MMHoverButton.h
@@ -5,6 +5,7 @@
 @interface MMHoverButton : NSButton
 
 @property (nonatomic, retain) NSColor *fgColor;
+@property (nonatomic, retain) NSImage *imageTemplate;
 
 typedef enum : NSUInteger {
     MMHoverButtonImageAddTab = 0,

--- a/src/MacVim/MMTabline/MMHoverButton.m
+++ b/src/MacVim/MMTabline/MMHoverButton.m
@@ -90,11 +90,12 @@
 - (void)setFgColor:(NSColor *)color
 {
     _fgColor = color;
-    self.image = super.image;
+    [self setImageTemplate:_imageTemplate];
 }
 
-- (void)setImage:(NSImage *)imageTemplate
+- (void)setImageTemplate:(NSImage *)imageTemplate
 {
+    _imageTemplate = imageTemplate;
     _circle.cornerRadius = imageTemplate.size.width / 2.0;
     NSColor *fillColor = self.fgColor ?: NSColor.controlTextColor;
     NSImage *image = [NSImage imageWithSize:imageTemplate.size
@@ -105,16 +106,7 @@
         NSRectFillUsingOperation(dstRect, NSCompositingOperationSourceAtop);
         return YES;
     }];
-    NSImage *alternateImage = [NSImage imageWithSize:imageTemplate.size
-                                             flipped:NO
-                                      drawingHandler:^BOOL(NSRect dstRect) {
-        [[fillColor colorWithAlphaComponent:0.2] set];
-        [[NSBezierPath bezierPathWithOvalInRect:dstRect] fill];
-        [image drawInRect:dstRect];
-        return YES;
-    }];
-    super.image = image;
-    self.alternateImage = alternateImage;
+    self.image = image;
 }
 
 - (void)setEnabled:(BOOL)enabled

--- a/src/MacVim/MMTabline/MMTab.m
+++ b/src/MacVim/MMTabline/MMTab.m
@@ -40,7 +40,7 @@ typedef NSString * NSAnimatablePropertyKey;
         _tabline = tabline;
         
         _closeButton = [MMHoverButton new];
-        _closeButton.image = [MMHoverButton imageFromType:MMHoverButtonImageCloseTab];
+        _closeButton.imageTemplate = [MMHoverButton imageFromType:MMHoverButtonImageCloseTab];
         _closeButton.target = self;
         _closeButton.action = @selector(closeTab:);
         _closeButton.translatesAutoresizingMaskIntoConstraints = NO;

--- a/src/MacVim/MMTabline/MMTabline.m
+++ b/src/MacVim/MMTabline/MMTabline.m
@@ -17,7 +17,7 @@ static const CGFloat ScrollOneTabAllowance = 0.25; // If we are showing 75+% of 
 
 static MMHoverButton* MakeHoverButton(MMTabline *tabline, MMHoverButtonImage imageType, NSString *tooltip, SEL action, BOOL continuous) {
     MMHoverButton *button = [MMHoverButton new];
-    button.image = [MMHoverButton imageFromType:imageType];
+    button.imageTemplate = [MMHoverButton imageFromType:imageType];
     button.translatesAutoresizingMaskIntoConstraints = NO;
     button.target = tabline;
     button.action = action;


### PR DESCRIPTION
Fix hover buttons to not keep setting image on itself everytime a fg color is changed, leading to each image referring to the last one. If a display changed happens and macOS triggers a redraw, this could sometimes lead to a stack overflow crash.

Just simplify the code and properly separate out the image template and the derived images. This also makes sure we properly free the old images when we change fg color where we discard the last image and make a new one.