### PR TITLE
Fix What's New URL checking logic to compare port correctly

### DIFF
--- a/src/MacVim/MMWhatsNewController.m
+++ b/src/MacVim/MMWhatsNewController.m
@@ -171,7 +171,7 @@ static NSString *_latestVersion;
 
     if ([requestURL.scheme isEqual:_whatsNewURL.scheme] &&
         [requestURL.host isEqual:_whatsNewURL.host] &&
-        [requestURL.port isEqual:_whatsNewURL.port] &&
+        requestURL.port.integerValue == _whatsNewURL.port.integerValue &&
         [requestURL.path isEqual:_whatsNewURL.path] &&
         [requestURL.query isEqual:_whatsNewURL.query])
     {


### PR DESCRIPTION
In a normal HTTP URL the port will be nil, which doesn't equal itself.

This bug was introduced by #1561 when it tried to add more granular comparison to URL checking to allow for anchor links.