### PR TITLE
ci: Fix matrix to use testgui flag properly

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -52,6 +52,7 @@ jobs:
       os: ${{ matrix.os }}
       legacy: ${{ matrix.legacy && true || false }}
       xcode: ${{ matrix.xcode }}
+      testgui: ${{ matrix.testgui && true || false }}
       publish: ${{ matrix.publish && true || false }}
       publish_postfix: ${{ matrix.publish_postfix }}
       optimized: ${{ matrix.optimized && true || false }}

--- a/.github/workflows/macvim-buildtest.yaml
+++ b/.github/workflows/macvim-buildtest.yaml
@@ -13,6 +13,8 @@ on:
         type: boolean
       xcode:
         type: string
+      testgui:
+        type: boolean
       publish:
         type: boolean
       publish_postfix:
@@ -363,7 +365,7 @@ jobs:
           make ${MAKE_BUILD_ARGS} -j${NPROC} -C src unittesttargets
 
       - name: Test Vim
-        if: startsWith(github.ref, 'refs/tags/') || !matrix.testgui
+        if: startsWith(github.ref, 'refs/tags/') || !inputs.testgui
         timeout-minutes: 30
         run: |
           defaults delete org.vim.MacVim  # Clean up stale states
@@ -373,7 +375,7 @@ jobs:
           make ${MAKE_BUILD_ARGS} -C src test
 
       - name: Test Vim (GUI)
-        if: startsWith(github.ref, 'refs/tags/') || matrix.testgui
+        if: startsWith(github.ref, 'refs/tags/') || inputs.testgui
         timeout-minutes: 30
         run: |
           defaults delete org.vim.MacVim  # Clean up stale states


### PR DESCRIPTION
This flag is there to get CI to only run either GUI or CLI tests, unless we are publishing a release, in order to cut down on interation time. When the YAML file was split into two in #1559, there was a mistake where this matrix flag wasn't ported over properly to an input, causing it to always evaluate to false.