### PR TITLE
Fix macOS services no longer able to insert texts in non-Visual modes

### DIFF
--- a/src/MacVim/MMTextViewHelper.m
+++ b/src/MacVim/MMTextViewHelper.m
@@ -251,7 +251,7 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
         // Only known way of this being called is Apple Intelligence Writing
         // Tools.
         MMVimController *vc = [self vimController];
-        [vc replaceSelectedText:string];
+        [vc insertOrReplaceSelectedText:string];
         return;
     }
 

--- a/src/MacVim/MMVimController.h
+++ b/src/MacVim/MMVimController.h
@@ -94,7 +94,7 @@
                      errorString:(NSString **)errstr;
 - (BOOL)hasSelectedText;
 - (NSString *)selectedText;
-- (void)replaceSelectedText:(NSString *)text;
+- (void)insertOrReplaceSelectedText:(NSString *)text;
 - (void)processInputQueue:(NSArray *)queue;
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12_2
 - (NSTouchBar *)makeTouchBar;

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -563,14 +563,14 @@ static BOOL isUnsafeMessage(int msgid);
     return selectedText;
 }
 
-- (void)replaceSelectedText:(NSString *)text
+- (void)insertOrReplaceSelectedText:(NSString *)text
 {
     if (backendProxy) {
         @try {
-            [backendProxy replaceSelectedText:text];
+            [backendProxy insertOrReplaceSelectedText:text];
         }
         @catch (NSException *ex) {
-            ASLogDebug(@"replaceSelectedText: failed: pid=%d reason=%@",
+            ASLogDebug(@"insertOrReplaceSelectedText: failed: pid=%d reason=%@",
                     pid, ex);
         }
     }

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -1679,7 +1679,7 @@
     NSArray *types = [pboard types];
     if ([types containsObject:NSPasteboardTypeString]) {
         NSString *input = [pboard stringForType:NSPasteboardTypeString];
-        [vimController replaceSelectedText:input];
+        [vimController insertOrReplaceSelectedText:input];
         return YES;
     }
 

--- a/src/MacVim/MacVim.h
+++ b/src/MacVim/MacVim.h
@@ -194,7 +194,7 @@ typedef NSString* NSAttributedStringKey;
                   errorString:(out bycopy NSString **)errstr;
 - (BOOL)hasSelectedText;
 - (NSString *)selectedText;
-- (oneway void)replaceSelectedText:(in bycopy NSString *)text;
+- (oneway void)insertOrReplaceSelectedText:(in bycopy NSString *)text;
 - (BOOL)mouseScreenposIsSelection:(int)row column:(int)column selRow:(byref int *)startRow selCol:(byref int *)startCol;
 - (oneway void)acknowledgeConnection;
 @end


### PR DESCRIPTION
Interactions with OS services that insert texts were improved in #1552 to make it work in a more integrated fashion instead of a hacky injection of 's' followed by the text. However, it only accounted for services that replaces selected texts in visual mode. In other modes, MacVim would simply ignore the service. This was a regression as previously it would work everywhere (albeit often times in a non-intuitive manner since if used in insert mode the user would see an 's' in the beginning). This also affects Shortcuts that a user may have made that could be invoked from the Services menu or bound to a hotkey.

Fix this properly by allowing this to be used in Normal / Insert / Cmdline modes in addition to Visual mode.

Even with this fix, there is still a slight difference between the new behavior and the old hacky solution - the old method would leave the user in Insert mode, whereas the new method would stay in Normal  mode. I think this is an improvement so no need to fix.

Fix #1569