### PR TITLE
Remove get-task-allow entitlement from signed builds

### DIFF
--- a/src/MacVim/MacVim.entitlements
+++ b/src/MacVim/MacVim.entitlements
@@ -6,7 +6,5 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
-    <key>com.apple.security.get-task-allow</key>
-    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
This entitlement allows debugger to hook in to the app and allow other apps to call `task_for_pid()` on MacVim, and Apple has discouraged its use. In fact, the only reason why MacVim passes app notarization is because it has also set the disable-library-validation entitlement which allows get-task-allow to be set. We don't actually need get-task-allow in release binary builds as we don't intentionally want to allow external debuggers and code injection, so we should just remove it.

This was previously added in #980 where we made a mistake in assuming that get-task-allow was what was needed to sign the app with hardened runtime while allowing scripting interface (e.g. Python) to work, but that was wrong. It was the disable-library-validation entitlment instead, as we need the ability to load in unsigned libraries as Python distributions from say Homebrew are not signed.

Credit: This was pointed out by Karol Mazurek