### PR TITLE
Allow underscores in guifont PostScript names

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -1135,10 +1135,18 @@ That's all.  XLFDs are not used.  For Chinese this is reported to work well: >
 
 MacVim							*macvim-guifont*
 
-For MacVim you can use something like this: >
-    :set guifont=Menlo:h10
-Fonts with spaces are set like this: >
+In MacVim, you can specify fonts by either the full PostScript name or the
+family name (both can be found in the Font Book app), followed by an optional
+font size (which defaults to `h11`).  Font names can also be completed in the
+cmdline using |complete-set-option|.
+
+Basic example of setting the font to Menlo with default size: >
+    :set guifont=Menlo
+To set a font by its family name which contains spaces: >
     :set guifont=DejaVu\ Sans\ Mono:h13
+When specifying family names with spaces, you can also use underscores
+instead: >
+    :set guifont=DejaVu_Sans_Mono:h13
 To use bold/italic fonts, use the fully specified PostScript name of the
 font, like so: >
     :set guifont=Menlo-Bold:h13

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -1196,12 +1196,6 @@ gui_macvim_font_with_name(char_u *name)
         parseFailed = YES;
     }
 
-    if (!parseFailed) {
-        // Replace underscores with spaces.
-        fontName = [[fontName componentsSeparatedByString:@"_"]
-                                 componentsJoinedByString:@" "];
-    }
-
     const BOOL isSystemFont = [fontName hasPrefix:MMSystemFontAlias];
     if (isSystemFont) {
         if (fontName.length > MMSystemFontAlias.length) {
@@ -1228,6 +1222,16 @@ gui_macvim_font_with_name(char_u *name)
                 || isSystemFont
                 || [NSFont fontWithName:fontName size:size])
             return [[NSString alloc] initWithFormat:@"%@:h%d", fontName, size];
+
+        // If font loading failed, try to replace underscores with spaces for
+        // user convenience. This really only works if the name is a family
+        // name because PostScript names should not have spaces.
+        if ([fontName rangeOfString:@"_"].location != NSNotFound) {
+            fontName = [fontName stringByReplacingOccurrencesOfString:@"_" withString:@" "];
+            if ([NSFont fontWithName:fontName size:size]) {
+                return [[NSString alloc] initWithFormat:@"%@:h%d", fontName, size];
+            }
+        }
     }
 
     return NOFONT;


### PR DESCRIPTION
MacVim guifont's can be specified by either full PostScript names or family names. Since family names can contain spaces, MacVim allows using underscores to serve as substitute to make it easier for the user to type, and this is similar to how Win32 gVim works.

However, some fonts use underscores in their full PostScript name. For example, Cascadia Code has names like "CascadiaCode-Regular_Light". The previous substitution code always replaced underscores with spaces which caused them to fail to load. Fix the code to only do the underscore-space substitution if the font could not be loaded. Also, fix documentation to be clearer in what MacVim expects as guifont's input.

In retrospect, implicit substitution like this was probably a bad idea when the user could just escape with spaces, but given this has been the behavior for a long time we should just keep it to avoid breaking backwards compatibility.

Fix #1208