### PR TITLE
ci: Fix test_popup failing on macos-13 due to lack of italics support

### DIFF
--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -2396,6 +2396,15 @@ endfunc
 func Test_popup_shadow_hiddenchar()
   CheckScreendump
 
+  if has('osx')
+    " On older macOS versions, the default Terminal app does not properly
+    " advertise italics support, which this test requires. When that happens,
+    " Vim just uses t_mr (reverse) as a substitute, which we detect here.
+    if &t_ZH == &t_mr
+      throw 'Skipped: italics not supported'
+    endif
+  endif
+
   let lines =<< trim END
     bold italic underline reverse normal
     italic underline reverse normal bold


### PR DESCRIPTION
Up till macOS 13, the default terminal does not properly advertise it supports italics, and Vim just silently replaces it with the "reverse" effect. Revently, a test in test_popup (Test_popup_shadow_hiddenchar) was added and the test dumps assume italics support. Add checks to skip this test if we detect that italics is not supported to avoid failing the screen dump tests.

Note that macos-13 is being sunset by GitHub Actions, but we still use a self-hosted version of it to make legacy builds.

Note that due to MacVim silently passing all flaky tests currently, this test wasn't breaking CI anyway, but it did slow it down due to test retries, and we do want to go back to not silently passing flaky tests in near future.
