### PR TITLE
ci: Add macos-26, and swap out macos-13

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -40,6 +40,9 @@ jobs:
             publish: true
             optimized: true
 
+          - os: macos-26
+            testgui: true
+
     uses: ./.github/workflows/macvim-buildtest.yaml
     with:
       skip: ${{ matrix.skip && true || false }}


### PR DESCRIPTION
Don't use macos-26 / Xcode 26 for making release builds yet. Doing so will require updating the OS deployment target and move legacy builds to include 10.13-10.15, and MacVim also doesn't work perfectly when compiled under the macOS 26 SDK right now.