### PR TITLE
ci: Fix test artifact upload not working

### DIFF
--- a/.github/actions/test_artifacts/action.yml
+++ b/.github/actions/test_artifacts/action.yml
@@ -1,31 +1,41 @@
 name: 'test_artifacts'
 description: "Upload failed test artifacts"
+inputs:
+  artifact-name:
+    description: Name of the artifact
+    required: true
+
 runs:
   using: "composite"
   steps:
-    - name: Collect matrix properties for naming
-      uses: actions/github-script@v8
-      id: matrix-props
-      env:
-        MATRIX_PROPS: ${{ toJSON(matrix) }}
-      with:
-        # An array-flattening-to-string JavaScript function.
-        script: |
-          const f = function (x) { return x.toString().length > 0; }
-          const g = function (x) {
-            return (Array.isArray(x))
-              ? x.filter(f)
-                .map((function (h) { return function (y) { return h(y); }; })(g))
-                .join('-')
-              : x;
-          }
-          return Object.values(JSON.parse(process.env.MATRIX_PROPS))
-            .filter(f)
-            .map(g)
-            .join('-');
-        # By default, the JSON-encoded return value of the function is
-        # set as the "result".
-        result-encoding: string
+# MacVim: We don't use a matrix within the reused
+# workflow, and so would prefer to manually pass
+# in the name of the artifact rather than deriving
+# it from the matrix automatically like in Vim
+# upstream.
+#    - name: Collect matrix properties for naming
+#      uses: actions/github-script@v8
+#      id: matrix-props
+#      env:
+#        MATRIX_PROPS: ${{ toJSON(inputs) }}
+#      with:
+#        # An array-flattening-to-string JavaScript function.
+#        script: |
+#          const f = function (x) { return x.toString().length > 0; }
+#          const g = function (x) {
+#            return (Array.isArray(x))
+#              ? x.filter(f)
+#                .map((function (h) { return function (y) { return h(y); }; })(g))
+#                .join('-')
+#              : x;
+#          }
+#          return Object.values(JSON.parse(process.env.MATRIX_PROPS))
+#            .filter(f)
+#            .map(g)
+#            .join('-');
+#        # By default, the JSON-encoded return value of the function is
+#        # set as the "result".
+#        result-encoding: string
     - name: Upload failed tests
       uses: actions/upload-artifact@v4
       with:
@@ -35,7 +45,7 @@ runs:
           github.run_attempt,
           github.job,
           strategy.job-index,
-          steps.matrix-props.outputs.result) }}
+          inputs.artifact-name) }}
 
         # A file, directory or wildcard pattern that describes what
         # to upload.

--- a/.github/actions/test_macvim_artifacts/action.yml
+++ b/.github/actions/test_macvim_artifacts/action.yml
@@ -1,6 +1,14 @@
 # This is a clone of test_artifacts for MacVim-specific files
+# This should be almost identical to test_artifacts, other than the artifact
+# name/path. In the future we could potentially combine the two, but for now
+# it's simpler to keep them separate to ease upstream merging.
 name: 'test_macvim_artifacts'
 description: "Upload failed MacVim test artifacts"
+inputs:
+  artifact-name:
+    description: Name of the artifact
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -8,7 +16,12 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         # Name of the artifact to upload.
-        name: ${{ github.workflow }}-${{ github.job }}-${{ join(matrix.*, '-') }}-failed-macvim-tests
+        name: ${{ format('GH-{0}-{1}-{2}-{3}-{4}-failed-macvim-tests',
+          github.run_id,
+          github.run_attempt,
+          github.job,
+          strategy.job-index,
+          inputs.artifact-name) }}
 
         # A file, directory or wildcard pattern that describes what
         # to upload.

--- a/.github/workflows/macvim-buildtest.yaml
+++ b/.github/workflows/macvim-buildtest.yaml
@@ -353,6 +353,8 @@ jobs:
       - name: Upload failed MacVim test results
         if: ${{ !cancelled() && failure() && steps.test_macvim.conclusion == 'failure' }}
         uses: ./.github/actions/test_macvim_artifacts
+        with:
+          artifact-name: ${{ format('{0}-{1}', inputs.os, inputs.xcode) }}
 
       - name: Build Vim test binaries
         run: |
@@ -385,6 +387,8 @@ jobs:
       - name: Upload failed test files
         if: ${{ !cancelled() && failure() }}
         uses: ./.github/actions/test_artifacts
+        with:
+          artifact-name: ${{ format('{0}-{1}', inputs.os, inputs.xcode) }}
 
       - name: Build MacVim dmg image
         if: inputs.publish && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')


### PR DESCRIPTION
The test_artifacts action (which we use to upload artifacts when a test has failed) relies on parsing the CI matrix values to generate a unique artifact name. However, in #1559 we switched to using a reusable workflow instead, which no longer uses a matrix inside the composable workflow. We could simply make a matrix with only one item in it to satisfy the test_artifact action but that seems a bit overkill. Instead, just modify it so we manually pass in the preferred artifact name instead which also gives us more flexibility in the naming. It does mean future upstream merges may cause conflicts.