### PR TITLE
ci: Build MacVim test binaries separately from running tests

### DIFF
--- a/.github/workflows/macvim-buildtest.yaml
+++ b/.github/workflows/macvim-buildtest.yaml
@@ -348,6 +348,10 @@ jobs:
         id: test_macvim
         timeout-minutes: 10
         run: |
+          echo '::group::Build MacVim test binaries'
+          # Build test binaries in a separate step to allow grouping in the CI output to make the output more concise.
+          make ${MAKE_BUILD_ARGS} -C src macvim-tests-binaries
+          echo '::endgroup::'
           make ${MAKE_BUILD_ARGS} -C src macvim-tests
 
       - name: Upload failed MacVim test results

--- a/src/Makefile
+++ b/src/Makefile
@@ -3753,7 +3753,7 @@ Makefile:
 
 ##############################################################################
 ### MacVim GUI
-.PHONY: macvim macvim-dmg macvim-dmg-legacy macvimclean macvim-signed macvim-signed-adhoc macvim-dmg-release macvim-dmg-release-legacy macvim-install-runtime macvim-xcodeproj-compat
+.PHONY: macvim macvim-dmg macvim-dmg-legacy macvimclean macvim-tests-binaries macvim-tests macvim-signed macvim-signed-adhoc macvim-dmg-release macvim-dmg-release-legacy macvim-install-runtime macvim-xcodeproj-compat
 
 RUNTIME_FOLDER_LIST = MacVim/auto/runtime_folder_list.xcfilelist
 
@@ -3776,6 +3776,9 @@ $(RUNTIME_FOLDER_LIST):
 
 macvim: $(VIMTARGET) $(RUNTIME_FOLDER_LIST)
 	xcodebuild -project MacVim/MacVim.xcodeproj $(XCODEFLAGS)
+
+macvim-tests-binaries:
+	xcodebuild build-for-testing -project MacVim/MacVim.xcodeproj -scheme MacVim $(XCODEFLAGS)
 
 macvim-tests:
 	xcodebuild test -project MacVim/MacVim.xcodeproj -scheme MacVim $(XCODEFLAGS)


### PR DESCRIPTION
Separate out the building step into a separate group. This makes the tests output more concise to read when a test has failed and we want to look at the logs.