### PR TITLE
tests: Remove MacVim-specific flaky tests guard

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -457,15 +457,6 @@ endfunc
 
 func AfterTheTest(func_name)
   if len(v:errors) > 0
-    if has('gui_macvim') && g:test_is_flaky
-      " MacVim's currently doesn't always pass these tests. Make these
-      " tests pending for now before a more proper fix is implemented.
-      call add(s:messages, 'MacVim marked ' .. a:func_name .. 'as pending')
-      let s:pending += 1
-      call add(s:errors_pending, 'Found errors in ' . g:testfunc . ':')
-      call extend(s:errors_pending, v:errors)
-      call add(s:errors_pending, 'PENDING ' .. a:func_name)
-    else
     if match(s:may_fail_list, '^' .. a:func_name) >= 0
       let s:fail_expected += 1
       call add(s:errors_expected, 'Found errors in ' . g:testfunc . ':')
@@ -474,7 +465,6 @@ func AfterTheTest(func_name)
       let s:fail += 1
       call add(s:errors, 'Found errors in ' . g:testfunc . ':')
       call extend(s:errors, v:errors)
-    endif
     endif
     let v:errors = []
   endif
@@ -498,7 +488,7 @@ func FinishTesting()
   " Don't write viminfo on exit.
   set viminfo=
 
-  if s:fail == 0 && s:fail_expected == 0 && s:pending == 0
+  if s:fail == 0 && s:fail_expected == 0
     " Success, create the .res file so that make knows it's done.
     exe 'split ' . fnamemodify(g:testname, ':r') . '.res'
     write
@@ -548,12 +538,6 @@ func FinishTesting()
     call add(s:messages, message)
     call extend(s:messages, s:errors_expected)
   endif
-  if s:pending > 0
-    let message = s:pending . ' FAILED (pending):'
-    echo message
-    call add(s:messages, message)
-    call extend(s:messages, s:errors_pending)
-  endif
 
   " Add SKIPPED messages
   call extend(s:messages, s:skipped)
@@ -578,8 +562,6 @@ let s:errors = []
 let s:errors_expected = []
 let s:messages = []
 let s:skipped = []
-let s:pending = 0
-let s:errors_pending = []
 if expand('%') =~ 'test_vimscript.vim'
   " this test has intentional errors, don't use try/catch.
   source %


### PR DESCRIPTION
A while ago, flaky Vim tests would routinely fail in MacVim's repo and an intermediate hack was added to essentially pass all flaky tests and these failed tests would be added to a "pending" list for review. The issue is that this essentially gives a free pass for tests to fail and no one really has time to look at these "pending" tests when they see a green checkmark. It's much better to fail early and fast so we are forced to address them as they come up. Waiting till later tends to make these test failures harder to isolate and diagnose, leading to us just ignoring them. Even worse, flaky tests are retried multiple times, so they end up making MacVim CI run longer.

Simply revert the changes that added these flaky tests and we should fix broken tests as they come up just like any other non-flaky tests.