### PR TITLE
ci: Remove macos-13 runner

### DIFF
--- a/.github/workflows/ci-macvim.yaml
+++ b/.github/workflows/ci-macvim.yaml
@@ -29,20 +29,14 @@ jobs:
             skip: ${{ ! startswith(github.ref, 'refs/tags/release') }}
             legacy: true
 
-          - os: macos-13
-            xcode: '15.2'
+          - os: macos-14
+            xcode: '15.4'
             testgui: true
             extra: [vimtags, check-xcodeproj-compat]
 
-          # Below runners use Apple Silicon.
-          - os: macos-14
-            xcode: '15.4'
-            testgui: false
-
-          # Most up to date OS and Xcode. Used to publish release for the main build.
           - os: macos-15
             xcode: '16.4'
-            testgui: true
+            testgui: false
             publish: true
             optimized: true
 


### PR DESCRIPTION
macOS-13 is retired from GitHub hosted runners, so we need to remove it.

With this change we also no longer have any x86 runners in the mix. While GitHub Actions provides a macos-15-intel runner, it will be deprecate in near future as well, so it's not really worth setting it up. If we care to test MacVim on x86 machines we may have to find alternative solutions, but for now it should be ok as we haven't seen any issues with universal builds for a long time.