### PR TITLE
ci: Use Ruby 3.4 instead of the recently released 4.0 for now

### DIFF
--- a/.github/workflows/macvim-buildtest.yaml
+++ b/.github/workflows/macvim-buildtest.yaml
@@ -40,13 +40,13 @@ env:
   vi_cv_path_python: /Library/Frameworks/Python.framework/Versions/2.7/bin/python
   vi_cv_path_python3: "%s/bin/python3"
   vi_cv_path_plain_lua: "%s/bin/lua"
-  vi_cv_path_ruby: "%s/opt/ruby/bin/ruby"
+  vi_cv_path_ruby: "%s/opt/ruby@3.4/bin/ruby"
   vi_cv_dll_name_perl: /System/Library/Perl/%s/darwin-thread-multi-2level/CORE/libperl.dylib
   vi_cv_dll_name_python: /Library/Frameworks/Python.framework/Versions/2.7/Python
   vi_cv_dll_name_python3: /usr/local/Frameworks/Python.framework/Versions/Current/Python
   vi_cv_dll_name_python3_arm64: /opt/homebrew/Frameworks/Python.framework/Versions/Current/Python
   vi_cv_dll_name_ruby: /usr/local/opt/ruby/lib/libruby.dylib
-  vi_cv_dll_name_ruby_arm64: /opt/homebrew/opt/ruby/lib/libruby.dylib
+  vi_cv_dll_name_ruby_arm64: /opt/homebrew/opt/ruby@3.4/lib/libruby.dylib
   vi_cv_dll_name_lua: /usr/local/lib/liblua.dylib
   vi_cv_dll_name_lua_arm64: /opt/homebrew/lib/liblua.dylib
 
@@ -137,7 +137,7 @@ jobs:
           # be installed on runners. Since we use stable ABI, the exact version
           # on CI does not matter.
 
-          brew install --quiet ruby
+          brew install --quiet ruby@3.4 # Ruby 4.0 is broken in Vim. Use 3.4 until that's fixed upstream.
           brew install --quiet lua
 
           if [[ -d $(brew --prefix)/Cellar/perl ]]; then


### PR DESCRIPTION
Ruby 4.0 is broken upstream in Vim. Once that's fixed, we can remove this.