### PR TITLE
Open Find / Replace dialog in the current space.

### DIFF
--- a/src/MacVim/MMFindReplaceController.m
+++ b/src/MacVim/MMFindReplaceController.m
@@ -33,9 +33,11 @@
 
     // Set collection behavior to ensure the dialog appears in the current
     // space rather than jumping to another space.
-    NSWindowCollectionBehavior wcb = window.collectionBehavior;
-    wcb |= NSWindowCollectionBehaviorMoveToActiveSpace;
-    [window setCollectionBehavior:wcb];
+    if (AVAILABLE_MAC_OS(10, 7)) {
+        NSWindowCollectionBehavior wcb = window.collectionBehavior;
+        wcb |= NSWindowCollectionBehaviorMoveToActiveSpace;
+        [window setCollectionBehavior:wcb];
+    }
 
     if (text && [text length] > 0)
         [findBox setStringValue:text];


### PR DESCRIPTION
Set the window's collection behavior to include NSWindowCollectionBehaviorMoveToActiveSpace.

This tells macOS to always show the Find dialog in the current active space (the one where you press Command+F) rather than following the application to another space.

Resolves macvim-dev/macvim#1629

This solution was provided by Copilot and verified locally.