### PR TITLE
ci: Fix Homebrew not able to build custom formula due to trust issues

### DIFF
--- a/.github/actions/universal-package/action.yml
+++ b/.github/actions/universal-package/action.yml
@@ -60,6 +60,7 @@ runs:
         FORMULA_DIR="$(brew --repository)/Library/Taps/macvim-dev/homebrew-deps/Formula/"
         mkdir -p "$FORMULA_DIR"
         cp ${formula}.rb "$FORMULA_DIR"
+        brew trust macvim-dev/deps
 
         # Uninstall the already installed formula because we want to build our own
         brew uninstall --ignore-dependencies ${formula} || true


### PR DESCRIPTION
New Homebrew versions seems to require a manual `brew trust` step now.