### PR TITLE
macvim crashes on startup

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1112,6 +1112,7 @@ INSTALL_DATA_R	= cp -r
 ### Program to run on installed binary.  Use the second one to disable strip.
 #STRIP = strip
 #STRIP = /bin/true
+STRIP = /usr/bin/strip
 
 ### Permissions for binaries  {{{1
 BINMOD = 755


### PR DESCRIPTION
https://github.com/macvim-dev/macvim/issues/1692

Use macOS's default strip command.
binutils's strip command is malfunctioning.